### PR TITLE
TIS-884/AWS S3 support through `rutebanken-helpers/storage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,26 @@ See [Docker Compose reference](https://docs.docker.com/compose/reference/) for m
 
 ##### Storage
 
-| profile           | description                                      |
-|:------------------|--------------------------------------------------|
-| `gcs-blobstore`   | GCP GCS implementation of tiamat's blob storage  |
-| `local-blobstore` | Use local directory as backing storage location. |
+| profile                | description                                                                                                                                                                                                                                                                             |
+|:-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `gcs-blobstore`        | GCP GCS implementation of tiamat's blob storage                                                                                                                                                                                                                                         |
+| `local-blobstore`      | Use local directory as backing storage location.                                                                                                                                                                                                                                        |
+| `rutebanken-blobstore` | Use [`rutebanken-helpers/storage`](https://github.<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>com/entur/rutebanken-helpers/tree/master/storage) based implementation for storage. Must be combined with one of the supported extra profiles (see below). |
+
+###### Supported `rutebanken-blobstore` extra profiles
+
+If this profile is chosen, an additional implementation must be chosen to activate the underlying actual implementation.
+Supported extra profiles are
+
+| extra profile          | description                              |
+|:-----------------------|------------------------------------------|
+| `local-disk-blobstore` | Similar to `local-blobstore`.            |
+| `in-memory-blobstore`  | Entirely in-memory based implementation. |
+
+**Example: Activating `in-memory-blobstore` for local development**
+```properties
+spring.profiles.active=local,rutebanken-blobstore,in-memory-blobstore,local-changelog
+```
 
 ##### Changelog
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,31 @@ docker compose down
 docker compose --profile aws down
 ```
 
+#### Supported Docker Compose profiles
+
+Docker Compose has its own profiles which start up additional supporting services to e.g. make specific feature 
+development easier. You may include any number of additional profiles when working with Docker Compose by listing 
+them in the commands with the `--profile {profile name}` argument. Multiple profiles are activated by providing the 
+same attribute multiple times, for example starting Compose environment with profiles a and b would be
+```shell
+docker compose --profile a --profile b up
+```
+
+The provided profiles for Tiamat development are
+
+
+| profile | description                                                                                       |
+|:--------|---------------------------------------------------------------------------------------------------|
+| `aws`   | Starts up [LocalStack](https://www.localstack.cloud/) meant for developing AWS specific features. |
+
+
 See [Docker Compose reference](https://docs.docker.com/compose/reference/) for more details.
+
+See [Supported Docker Compose Profiles](#supported-docker-compose-profiles) for more information on provided profiles.
 
 ### 2. Run the Service
 
-#### Available Profiles
+#### Available Spring Boot Profiles
 
 > **Note!** You must choose at least one of the options from each category below!
 
@@ -118,11 +138,13 @@ See [Docker Compose reference](https://docs.docker.com/compose/reference/) for m
 
 ##### Storage
 
-| profile                | description                                                                                                                                                                                                                                                                             |
-|:-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `gcs-blobstore`        | GCP GCS implementation of tiamat's blob storage                                                                                                                                                                                                                                         |
-| `local-blobstore`      | Use local directory as backing storage location.                                                                                                                                                                                                                                        |
-| `rutebanken-blobstore` | Use [`rutebanken-helpers/storage`](https://github.<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>com/entur/rutebanken-helpers/tree/master/storage) based implementation for storage. Must be combined with one of the supported extra profiles (see below). |
+| profile                | description                                                                                                                                                     |
+|:-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `gcs-blobstore`        | GCP GCS implementation of tiamat's blob storage                                                                                                                 |
+| `local-blobstore`      | Use local directory as backing storage location.                                                                                                                |
+| `rutebanken-blobstore` | Use [`rutebanken-helpers/storage`][rutebanken-storage] based implementation for storage. Must be combined with one of the supported extra profiles (see below). |
+
+[rutebanken-storage]: https://github.com/entur/rutebanken-helpers/tree/master/storage
 
 ###### Supported `rutebanken-blobstore` extra profiles
 
@@ -133,11 +155,15 @@ Supported extra profiles are
 |:-----------------------|------------------------------------------|
 | `local-disk-blobstore` | Similar to `local-blobstore`.            |
 | `in-memory-blobstore`  | Entirely in-memory based implementation. |
+| `s3-blobstore`         | AWS S3 implementation.                   |
 
 **Example: Activating `in-memory-blobstore` for local development**
 ```properties
 spring.profiles.active=local,rutebanken-blobstore,in-memory-blobstore,local-changelog
 ```
+
+See the [`RutebankenBlobStoreServiceConfiguration`](./src/main/java/org/rutebanken/tiamat/config/RutebankenBlobStoreConfiguration.java)
+class for configuration keys and additional information.
 
 ##### Changelog
 
@@ -146,6 +172,28 @@ spring.profiles.active=local,rutebanken-blobstore,in-memory-blobstore,local-chan
 | `local-changelog` | Simple local implementation which logs the sent events to `stdout` |
 | `activemq`        | JMS based ActiveMQ implementation.                                 |
 | `google-pubsub`   | GCP PubSub implementation for publishing tiamat entity changes.    |
+
+#### Supported Docker Compose Profiles
+
+Tiamat's [`docker-compose.yml`](./docker-compose.yml) comes with built-in profiles for various use cases. The profiles 
+are mostly optional, default profile contains all mandatory configuration while the named profiles add features on 
+top of that. You can always activate zero or more profiles at the same time, e.g.
+
+```shell
+docker compose --profile first --profile second up
+# or
+COMPOSE_PROFILES=first,second docker compose up
+```
+
+### Default profile (no activation key)
+
+Starts up PostGIS server with settings matching the ones in [`application-local.properties`](./src/main/resources/application-local.properties).
+
+### `aws` profile
+
+Starts up [LocalStack](https://www.localstack.cloud/) meant for developing AWS specific features.
+
+See also [Disable AWS S3 Autoconfiguration](#disable-aws-s3-autoconfiguration), [NeTEx Export](#netex-export).
 
 #### Run It!
 
@@ -482,5 +530,4 @@ https://github.com/entur/tiamat-scripts
 
 ## CircleCI
 Tiamat is built using CircleCI. See the .circleci folder.
-
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,28 @@ services:
     networks:
       - tiamat-net
 
+  localstack:
+    container_name: "${COMPOSE_PROJECT_NAME}_localstack"
+    profiles: ["aws"]
+    image: localstack/localstack:4.0
+    ports:
+      - "37566:4566"             # LocalStack Gateway
+      - "37510-37559:4510-4559"  # external services port range
+    environment:
+      - DEBUG=${DEBUG-}
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - DISABLE_EVENTS=1
+      - SERVICES=s3
+      - AWS_ACCESS_KEY_ID=localstack
+      - AWS_SECRET_ACCESS_KEY=localstack
+      - AWS_DEFAULT_REGION=eu-north-1
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "./scripts/init-localstack.sh:/etc/localstack/init/ready.d/init-localstack.sh"
+    networks:
+      - tiamat-net
+
 volumes:
   postgres-data:
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,11 @@
             <artifactId>storage</artifactId>
             <version>${rutebanken-storage.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.entur.ror.helpers</groupId>
+            <artifactId>storage-aws-s3</artifactId>
+            <version>${rutebanken-storage.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <xercesImpl.version>2.12.2</xercesImpl.version>
         <maven.compiler.args>--add-opens java.base/java.lang=ALL-UNNAMED</maven.compiler.args>
         <testcontainers.version>1.19.2</testcontainers.version>
+        <rutebanken-storage.version>4.7</rutebanken-storage.version>
     </properties>
 
     <dependencies>
@@ -127,6 +128,12 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-graphite</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.entur.ror.helpers</groupId>
+            <artifactId>storage</artifactId>
+            <version>${rutebanken-storage.version}</version>
         </dependency>
 
         <dependency>

--- a/scripts/init-localstack.sh
+++ b/scripts/init-localstack.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# -- > Create S3 bucket for blob storage
+awslocal s3api create-bucket --bucket 'tiamat-test' --create-bucket-configuration LocationConstraint=eu-north-1

--- a/src/main/java/org/rutebanken/tiamat/config/RutebankenBlobStoreConfiguration.java
+++ b/src/main/java/org/rutebanken/tiamat/config/RutebankenBlobStoreConfiguration.java
@@ -1,0 +1,65 @@
+package org.rutebanken.tiamat.config;
+
+import org.rutebanken.helper.storage.repository.BlobStoreRepository;
+import org.rutebanken.helper.storage.repository.InMemoryBlobStoreRepository;
+import org.rutebanken.helper.storage.repository.LocalDiskBlobStoreRepository;
+import org.rutebanken.tiamat.service.BlobStoreService;
+import org.rutebanken.tiamat.service.RutebankenBlobStoreService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * <a href="https://github.com/entur/rutebanken-helpers">rutebanken-helpers</a> based repository configuration for blob
+ * storing. Support is enabled by activating <code>rutebanken-blobstore</code> profile and then one of the following:
+ * <ul>
+ *     <li><code>local-disk-blobstore</code></li>
+ *     <li><code>in-memory-blobstore</code></li>
+ * </ul>
+ * <p>
+ * Tiamat also has its own storage abstraction, {@link org.rutebanken.tiamat.service.BlobStoreService}. An adapter is
+ * provided ({@link org.rutebanken.tiamat.service.RutebankenBlobStoreService}) which will be used if the
+ * <code>rutebanken-blobstore</code> profile is active. The adapted blob stores complement Tiamat's own implementation
+ * in non-conflicting manner, meaning that of Tiamat's blobstore profiles (<code>gcs-blobstore</code>, <code>local-blobstore</code>)
+ * neither will clash with what this configuration class provides.
+ * <p>
+ * The names of the supported profiles and configuration keys match with the ones in <a href="https://github.com/entur/uttu">entur/uttu</a>.
+ * There is a legacy naming problem with the <code>gcs-blobstore</code> profile and its configuration injection, but as
+ * this <code>rutebanken-helpers adaptation</code> is not needed for GCS support within Tiamat but for the other
+ * implementations it provides, in practice these do not clash. If the GCS implementation is ever to be taken into use,
+ * {@link org.rutebanken.tiamat.service.GcsBlobStoreService} first needs to be adapted directly, and additional feature
+ * gap fixing will probably need to be done in <code>rutebanken-helpers</code> as well.
+ */
+@Configuration
+@Profile("rutebanken-blobstore")
+public class RutebankenBlobStoreConfiguration {
+
+    @Bean
+    BlobStoreService blobStoreService(BlobStoreRepository blobStoreRepository) {
+        return new RutebankenBlobStoreService(blobStoreRepository);
+    }
+
+    @Profile("local-disk-blobstore")
+    @Bean
+    BlobStoreRepository localDiskBlobStoreRepository(
+            @Value("${blobstore.local.folder:files/blob}") String baseFolder,
+            @Value("${blobstore.local.container.name}") String containerName
+    ) {
+        LocalDiskBlobStoreRepository localDiskBlobStoreRepository = new LocalDiskBlobStoreRepository(baseFolder);
+        localDiskBlobStoreRepository.setContainerName(containerName);
+        return localDiskBlobStoreRepository;
+    }
+
+    @Profile("in-memory-blobstore")
+    @Bean
+    BlobStoreRepository inMemoryBlobStoreRepository(
+            @Value("${blobstore.local.container.name}") String containerName
+    ) {
+        InMemoryBlobStoreRepository inMemoryBlobStoreRepository = new InMemoryBlobStoreRepository(new ConcurrentHashMap<>());
+        inMemoryBlobStoreRepository.setContainerName(containerName);
+        return inMemoryBlobStoreRepository;
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/service/BlobStoreService.java
+++ b/src/main/java/org/rutebanken/tiamat/service/BlobStoreService.java
@@ -1,15 +1,9 @@
 package org.rutebanken.tiamat.service;
 
-import com.google.cloud.storage.Storage;
-
 import java.io.InputStream;
 
 public interface BlobStoreService {
     void upload(String fileName, InputStream inputStream);
 
-    Storage getStorage();
-
     InputStream download(String fileName);
-
-    String createBlobIdName(String blobPath, String fileName);
 }

--- a/src/main/java/org/rutebanken/tiamat/service/GcsBlobStoreService.java
+++ b/src/main/java/org/rutebanken/tiamat/service/GcsBlobStoreService.java
@@ -40,9 +40,9 @@ public class GcsBlobStoreService implements BlobStoreService {
 
 
     public GcsBlobStoreService(@Value("${blobstore.gcs.credential.path:#{null}") String credentialPath,
-                            @Value("${blobstore.gcs.bucket.name}") String bucketName,
-                            @Value("${blobstore.gcs.blob.path}") String blobPath,
-                            @Value("${blobstore.gcs.project.id}") String projectId) {
+                               @Value("${blobstore.gcs.bucket.name}") String bucketName,
+                               @Value("${blobstore.gcs.blob.path}") String blobPath,
+                               @Value("${blobstore.gcs.project.id}") String projectId) {
 
         this.bucketName = bucketName;
         this.blobPath = blobPath;
@@ -61,7 +61,7 @@ public class GcsBlobStoreService implements BlobStoreService {
         }
     }
 
-    public Storage getStorage() {
+    private Storage getStorage() {
         try {
             logger.info("Get storage for project {}", projectId);
             if (credentialPath == null || credentialPath.isEmpty()) {

--- a/src/main/java/org/rutebanken/tiamat/service/LocalBlobStoreService.java
+++ b/src/main/java/org/rutebanken/tiamat/service/LocalBlobStoreService.java
@@ -1,6 +1,5 @@
 package org.rutebanken.tiamat.service;
 
-import com.google.cloud.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -58,15 +57,5 @@ public class LocalBlobStoreService implements BlobStoreService {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    @Override
-    public String createBlobIdName(String blobPath, String fileName) {
-        return blobPath + '/' + fileName;
-    }
-
-    @Override
-    public Storage getStorage() {
-        return null;
     }
 }

--- a/src/main/java/org/rutebanken/tiamat/service/RutebankenBlobStoreService.java
+++ b/src/main/java/org/rutebanken/tiamat/service/RutebankenBlobStoreService.java
@@ -1,0 +1,34 @@
+package org.rutebanken.tiamat.service;
+
+import org.rutebanken.helper.storage.model.BlobDescriptor;
+import org.rutebanken.helper.storage.repository.BlobStoreRepository;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+
+/**
+ * Shim for adapting {@link BlobStoreService} to use <code>rutebanken-helpers</code>
+ * {@link org.rutebanken.helper.storage.repository.BlobStoreRepository} which enables reuse of additional storage
+ * implementations. See also {@link org.rutebanken.tiamat.config.RutebankenBlobStoreConfiguration}
+ */
+@Service
+@Profile("rutebanken-blobstore")
+public class RutebankenBlobStoreService implements BlobStoreService {
+
+    private final BlobStoreRepository blobStoreRepository;
+
+    public RutebankenBlobStoreService(BlobStoreRepository blobStoreRepository) {
+        this.blobStoreRepository = blobStoreRepository;
+    }
+
+    @Override
+    public void upload(String fileName, InputStream inputStream) {
+        blobStoreRepository.uploadBlob(new BlobDescriptor(fileName, inputStream));
+    }
+
+    @Override
+    public InputStream download(String fileName) {
+        return blobStoreRepository.getBlob(fileName);
+    }
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -83,6 +83,9 @@ blobstore.gcs.bucket.name=tiamat-test
 blobstore.gcs.credential.path=gcloud-storage.json
 blobstore.gcs.project.id=carbon-1287
 
+# rutebanken-storage configurations
+blobstore.local.container.name=${blobstore.gcs.bucket.name}
+
 security.basic.enabled=false
 management.security.enabled=false
 authorization.enabled = true

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -83,8 +83,14 @@ blobstore.gcs.bucket.name=tiamat-test
 blobstore.gcs.credential.path=gcloud-storage.json
 blobstore.gcs.project.id=carbon-1287
 
-# rutebanken-storage configurations
+### rutebanken-storage configurations
+# local-disk-blobstore
 blobstore.local.container.name=${blobstore.gcs.bucket.name}
+# s3-blobstore, for local development with Localstack (see docker-compose.yml)
+blobstore.s3.region=eu-north-1
+blobstore.s3.access-key-id=dev-access-key-id
+blobstore.s3.secret-key=dev-secret-key
+blobstore.s3.endpoint-override=http://localhost:37566
 
 security.basic.enabled=false
 management.security.enabled=false


### PR DESCRIPTION
 - some cleanup for the `BlobStoreService` interface to make it actually consern only abstractable storage related operations
 - include shim for utilizing [rutebanken-helpers/storage](https://github.com/entur/rutebanken-helpers/tree/master/storage) as `BlobStoreService`
 - add AWS S3 support through [rutebanken-helpers/storage-aws-s3](https://github.com/entur/rutebanken-helpers/tree/master/storage-aws-s3)

AWS S3 support is needed by Fintraffic's deployment of NSR. There will possibly be further similar adaptation in the future as well. Generally the same assumptions as we made with uttu apply here as well, so including multi-cloud support into one build is assumed to be OK.

All documentation has been updated accordingly. GCS support still uses the old `BlobStoreService` implementation and has been excluded from the shim on purpose as I personally have never worked on GCS, so verifying it would do the right thing is really hard. Otherwise the AWS bits are quite similar to what's in uttu, including Localstack based local dev environment.