### PR TITLE
Makes ServicesFrame default in all exports, refactor NetexReferenceRemovingIterator to remove TariffZone ref version if it is farezone , refactor PublicationDeliveryCreator, to support diffrent types of publication deliveries, Refactor StreamingPublicationDelivery

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/exporter/PublicationDeliveryCreator.java
+++ b/src/main/java/org/rutebanken/tiamat/exporter/PublicationDeliveryCreator.java
@@ -50,18 +50,6 @@ public class PublicationDeliveryCreator {
         return publicationDeliveryStructure;
     }
 
-    public PublicationDeliveryStructure createPublicationDelivery(org.rutebanken.netex.model.SiteFrame siteFrame, ResourceFrame netexResourceFrame) {
-        PublicationDeliveryStructure publicationDeliveryStructure = createPublicationDelivery();
-        publicationDeliveryStructure.withDataObjects(
-                new PublicationDeliveryStructure.DataObjects()
-                        .withCompositeFrameOrCommonFrame(new ObjectFactory().createSiteFrame(siteFrame))
-                        .withCompositeFrameOrCommonFrame(new ObjectFactory().createResourceFrame(netexResourceFrame))
-        );
-
-        logger.info("Returning publication delivery {} with site frame", publicationDeliveryStructure);
-        return publicationDeliveryStructure;
-    }
-
     public PublicationDeliveryStructure createPublicationDelivery(org.rutebanken.netex.model.SiteFrame siteFrame,
                                                                   org.rutebanken.netex.model.ServiceFrame serviceFrame,
                                                                   org.rutebanken.netex.model.FareFrame fareFrame,
@@ -82,6 +70,58 @@ public class PublicationDeliveryCreator {
         return publicationDeliveryStructure;
     }
 
+    public PublicationDeliveryStructure createPublicationDelivery(org.rutebanken.netex.model.SiteFrame siteFrame,
+                                                                  org.rutebanken.netex.model.ServiceFrame serviceFrame,
+                                                                  org.rutebanken.netex.model.FareFrame fareFrame
+    ) {
+        PublicationDeliveryStructure publicationDeliveryStructure = createPublicationDelivery();
+
+        publicationDeliveryStructure.withDataObjects
+                (
+                        new PublicationDeliveryStructure.DataObjects()
+                                .withCompositeFrameOrCommonFrame(new ObjectFactory().createServiceFrame(serviceFrame))
+                                .withCompositeFrameOrCommonFrame(new ObjectFactory().createSiteFrame(siteFrame))
+                                .withCompositeFrameOrCommonFrame(new ObjectFactory().createFareFrame(fareFrame))
+                );
+
+        logger.info("Returning publication delivery {} with site frame and  service frame", publicationDeliveryStructure);
+        return publicationDeliveryStructure;
+    }
+
+    public PublicationDeliveryStructure createPublicationDelivery(org.rutebanken.netex.model.SiteFrame siteFrame,
+                                                                  org.rutebanken.netex.model.ServiceFrame serviceFrame,
+                                                                  ResourceFrame netexResourceFrame
+    ) {
+        PublicationDeliveryStructure publicationDeliveryStructure = createPublicationDelivery();
+
+        publicationDeliveryStructure.withDataObjects
+                (
+                        new PublicationDeliveryStructure.DataObjects()
+                                .withCompositeFrameOrCommonFrame(new ObjectFactory().createServiceFrame(serviceFrame))
+                                .withCompositeFrameOrCommonFrame(new ObjectFactory().createSiteFrame(siteFrame))
+                                .withCompositeFrameOrCommonFrame(new ObjectFactory().createResourceFrame(netexResourceFrame))
+                );
+
+        logger.info("Returning publication delivery {} with site frame and  service frame", publicationDeliveryStructure);
+        return publicationDeliveryStructure;
+    }
+
+    public PublicationDeliveryStructure createPublicationDelivery(org.rutebanken.netex.model.SiteFrame siteFrame,
+                                                                  org.rutebanken.netex.model.ServiceFrame serviceFrame
+    ) {
+        PublicationDeliveryStructure publicationDeliveryStructure = createPublicationDelivery();
+
+        publicationDeliveryStructure.withDataObjects
+                (
+                        new PublicationDeliveryStructure.DataObjects()
+                                .withCompositeFrameOrCommonFrame(new ObjectFactory().createServiceFrame(serviceFrame))
+                                .withCompositeFrameOrCommonFrame(new ObjectFactory().createSiteFrame(siteFrame))
+                );
+
+        logger.info("Returning publication delivery {} with site frame and  service frame", publicationDeliveryStructure);
+        return publicationDeliveryStructure;
+    }
+
 
 
     private ResourceFrame createResourceFrame() {
@@ -93,7 +133,7 @@ public class PublicationDeliveryCreator {
 
         return new ResourceFrame().withId("NSR:RescourceFrame:1").withVersion("1")
                 .withTypesOfValue(new ObjectFactory()
-                        .createTypesOfValueInFrame_RelStructure().withValueSetOrTypeOfValue(purposeOfGroupingList ));
+                        .createTypesOfValueInFrame_RelStructure().withValueSetOrTypeOfValue(purposeOfGroupingList));
     }
 
 

--- a/src/main/java/org/rutebanken/tiamat/exporter/async/NetexReferenceRemovingIterator.java
+++ b/src/main/java/org/rutebanken/tiamat/exporter/async/NetexReferenceRemovingIterator.java
@@ -15,16 +15,10 @@
 
 package org.rutebanken.tiamat.exporter.async;
 
-import org.rutebanken.netex.model.ObjectFactory;
 import org.rutebanken.netex.model.StopPlace;
-import org.rutebanken.netex.model.TariffZoneRef;
-import org.rutebanken.netex.model.TariffZoneRefs_RelStructure;
 import org.rutebanken.tiamat.exporter.params.ExportParams;
-
 import java.util.Iterator;
-import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 public class NetexReferenceRemovingIterator implements Iterator<StopPlace> {
 
@@ -36,16 +30,20 @@ public class NetexReferenceRemovingIterator implements Iterator<StopPlace> {
 
     private final Consumer<StopPlace> fareZoneRefRemover;
 
-    private final Consumer<StopPlace> doNothingConsumer = s -> {
-    };
-
     public NetexReferenceRemovingIterator(Iterator<StopPlace> iterator, ExportParams exportParams) {
         this.iterator = iterator;
+        Consumer<StopPlace> doNothingConsumer = s -> {};
 
         if (exportParams.getTariffZoneExportMode().equals(ExportParams.ExportMode.NONE)) {
-            tariffZoneVersionRemover = this::removeTariffZoneRefsVersion;
+            tariffZoneVersionRemover = stopPlace -> removeTariffZoneRefsVersion(stopPlace,"TariffZone");
         } else {
             tariffZoneVersionRemover = doNothingConsumer;
+        }
+
+        if(exportParams.getFareZoneExportMode().equals(ExportParams.ExportMode.NONE)) {
+            fareZoneRefRemover = stopPlace -> removeTariffZoneRefsVersion(stopPlace,"FareZone");
+        } else {
+            fareZoneRefRemover = doNothingConsumer;
         }
 
 
@@ -53,12 +51,6 @@ public class NetexReferenceRemovingIterator implements Iterator<StopPlace> {
             topographicPlaceVersionRemover = this::removeTopographicPlaceRef;
         } else {
             topographicPlaceVersionRemover = doNothingConsumer;
-        }
-
-        if (!exportParams.getServiceFrameExportMode().equals(ExportParams.ExportMode.ALL)) {
-            fareZoneRefRemover = this::removeFareZoneRef;
-        } else {
-            fareZoneRefRemover = doNothingConsumer;
         }
     }
 
@@ -72,32 +64,25 @@ public class NetexReferenceRemovingIterator implements Iterator<StopPlace> {
         StopPlace next = iterator.next();
         if(next != null) {
             tariffZoneVersionRemover.accept(next);
-            topographicPlaceVersionRemover.accept(next);
             fareZoneRefRemover.accept(next);
+            topographicPlaceVersionRemover.accept(next);
         }
         return next;
     }
 
-    private void removeTariffZoneRefsVersion(StopPlace stopPlace) {
+    private void removeTariffZoneRefsVersion(StopPlace stopPlace, String type) {
         if(stopPlace.getTariffZones() != null && stopPlace.getTariffZones().getTariffZoneRef() != null) {
-            stopPlace.getTariffZones().getTariffZoneRef().forEach(tariffZoneRef -> tariffZoneRef.setVersion(null));
+            stopPlace.getTariffZones().getTariffZoneRef().forEach(tariffZoneRef -> {
+                if(tariffZoneRef.getRef().contains(type)) {
+                    tariffZoneRef.setVersion(null);
+                }
+            });
         }
     }
 
     private void removeTopographicPlaceRef(StopPlace stopPlace) {
         if(stopPlace.getTopographicPlaceRef() != null) {
             stopPlace.getTopographicPlaceRef().setVersion(null);
-        }
-    }
-
-    private void removeFareZoneRef(StopPlace stopPlace) {
-        if (stopPlace.getTariffZones() != null && !stopPlace.getTariffZones().getTariffZoneRef().isEmpty()) {
-                final List<TariffZoneRef> tariffZoneRefs = stopPlace.getTariffZones().getTariffZoneRef().stream()
-                        .filter(tariffZoneRef -> !tariffZoneRef.getRef().contains("FareZone"))
-                        .map(tariffZoneRef -> new ObjectFactory().createTariffZoneRef().withRef(tariffZoneRef.getRef()).withVersion(tariffZoneRef.getVersion()))
-                        .collect(Collectors.toList());
-                stopPlace.withTariffZones(new TariffZoneRefs_RelStructure().withTariffZoneRef(tariffZoneRefs));
-
         }
     }
 }

--- a/src/main/java/org/rutebanken/tiamat/exporter/params/ExportParams.java
+++ b/src/main/java/org/rutebanken/tiamat/exporter/params/ExportParams.java
@@ -83,12 +83,6 @@ public class ExportParams {
     @Schema(description = "Group of tariff zones export mode")
     private ExportMode groupOfTariffZonesExportMode = DEFAULT_GROUP_OF_TARIFF_ZONES_EXPORT_MODE;
 
-    @QueryParam(value = "serviceFrameExportMode")
-    @DefaultValue(value = "NONE")
-    @Parameter(description = "Controls exported service frame, if set to all, netex export will be exported with service frame with Scheduled Stop Points and Passenger Stop Assignments")
-    @Schema(description = "Service Frame export mode")
-    private ExportMode serviceFrameExportMode = DEFAULT_SERVICE_FRAME_EXPORT_MODE;
-
     @QueryParam(value = "municipalityReference")
     @Parameter(description = MUNICIPALITY_REF_ARG_DESCRIPTION)
     @Schema(description = "municipalityReference")
@@ -118,7 +112,6 @@ public class ExportParams {
                          ExportMode fareZoneExportMode,
                          ExportMode groupOfStopPlacesExportMode,
                          ExportMode groupOfTariffZonesExportMode,
-                         ExportMode serviceFrameExportMode,
                          List<String> municipalityReferences,
                          List<String> countyReferences,
                          List<String> countryReferences,
@@ -129,7 +122,6 @@ public class ExportParams {
         this.fareZoneExportMode = fareZoneExportMode;
         this.groupOfStopPlacesExportMode = groupOfStopPlacesExportMode;
         this.groupOfTariffZonesExportMode = groupOfTariffZonesExportMode;
-        this.serviceFrameExportMode = serviceFrameExportMode;
         this.municipalityReferences = municipalityReferences;
         this.countyReferences = countyReferences;
         this.countryReferences = countryReferences;
@@ -162,10 +154,6 @@ public class ExportParams {
 
     public ExportMode getGroupOfTariffZonesExportMode() {
         return groupOfTariffZonesExportMode;
-    }
-
-    public ExportMode getServiceFrameExportMode() {
-        return serviceFrameExportMode;
     }
 
     public List<String> getMunicipalityReferences() {
@@ -201,7 +189,6 @@ public class ExportParams {
                 .add("stopPlaceSearch", stopPlaceSearch)
                 .add("tariffZoneExportMode", tariffZoneExportMode)
                 .add("fareZoneExportMode", fareZoneExportMode)
-                .add("serviceFrameExportMode",serviceFrameExportMode)
                 .add("codeSpace", codeSpace)
                 .toString();
     }
@@ -212,7 +199,6 @@ public class ExportParams {
         private ExportMode topographicPlaceExportMode = DEFAULT_TOPOGRAPHIC_PLACE_EXPORT_MODE;
         private ExportMode groupOfStopPlacesExportMode = DEFAULT_GROUP_OF_STOP_PLACES_EXPORT_MODE;
         private ExportMode groupOfTariffZonesExportMode = DEFAULT_GROUP_OF_TARIFF_ZONES_EXPORT_MODE;
-        private ExportMode serviceFrameExportMode = DEFAULT_SERVICE_FRAME_EXPORT_MODE;
         private List<String> municipalityReferences;
         private List<String> countyReferences;
         private List<String> countryReferences;
@@ -224,11 +210,6 @@ public class ExportParams {
 
         public Builder setTopographicPlaceExportMode(ExportMode topographicPlaceExportMode) {
             this.topographicPlaceExportMode = topographicPlaceExportMode;
-            return this;
-        }
-
-        public Builder setServiceFrameExportMode(ExportMode serviceFrameExportMode) {
-            this.serviceFrameExportMode = serviceFrameExportMode;
             return this;
         }
 
@@ -297,7 +278,6 @@ public class ExportParams {
                     tariffZoneExportMode,fareZoneExportMode,
                     groupOfStopPlacesExportMode,
                     groupOfTariffZonesExportMode,
-                    serviceFrameExportMode,
                     municipalityReferences,
                     countyReferences,
                     countryReferences,

--- a/src/test/java/org/rutebanken/tiamat/exporter/async/NetexReferenceRemovingIteratorTest.java
+++ b/src/test/java/org/rutebanken/tiamat/exporter/async/NetexReferenceRemovingIteratorTest.java
@@ -23,6 +23,7 @@ import org.rutebanken.netex.model.TopographicPlaceRefStructure;
 import org.rutebanken.tiamat.exporter.params.ExportParams;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,20 +40,27 @@ public class NetexReferenceRemovingIteratorTest {
                         new TariffZoneRefs_RelStructure()
                                 .withTariffZoneRef(
                                         new TariffZoneRef()
-                                                .withRef("ref")
-                                                .withVersion("version")))
+                                                .withRef("RUT:TariffZone:1")
+                                                .withVersion("1"))
+                                .withTariffZoneRef(
+                                        new TariffZoneRef()
+                                                .withRef("RUT:FareZone:2")
+                                                .withVersion("2")
+                                )
+                )
                 .withTopographicPlaceRef(
                         new TopographicPlaceRefStructure()
                             .withValue("KVE:TopographicPlace:XXX")
                             .withVersion("version"));
 
 
-        List<StopPlace> stopPlaces = Arrays.asList(stopPlace);
+        List<StopPlace> stopPlaces = Collections.singletonList(stopPlace);
 
 
         ExportParams exportParams = ExportParams.newExportParamsBuilder()
                 .setTopographicPlaceExportMode(ExportParams.ExportMode.NONE)
                 .setTariffZoneExportMode(ExportParams.ExportMode.NONE)
+                .setFareZoneExportMode(ExportParams.ExportMode.NONE)
                 .build();
 
         NetexReferenceRemovingIterator netexReferenceRemovingIterator = new NetexReferenceRemovingIterator(stopPlaces.iterator(), exportParams);
@@ -61,6 +69,7 @@ public class NetexReferenceRemovingIteratorTest {
         StopPlace actual = netexReferenceRemovingIterator.next();
 
         assertThat(actual.getTariffZones().getTariffZoneRef().getFirst().getVersion()).as("TariffZoneref version").isNull();
+        assertThat(actual.getTariffZones().getTariffZoneRef().getLast().getVersion()).as("TariffZoneref version").isNull();
         assertThat(actual.getTopographicPlaceRef().getVersion()).as("topographic place ref version").isNull();
     }
 


### PR DESCRIPTION
Makes ServicesFrame default in all exports, refactor NetexReferenceRemovingIterator to remove TariffZone ref version if it is farezone , refactor PublicationDeliveryCreator, to support diffrent types of publication deliveries, Refactor StreamingPublicationDelivery