### PR TITLE
Add support for UserInfoExtractor

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/auth/OAuth2Config.java
+++ b/src/main/java/org/rutebanken/tiamat/auth/OAuth2Config.java
@@ -3,7 +3,9 @@ package org.rutebanken.tiamat.auth;
 import org.entur.oauth2.JwtRoleAssignmentExtractor;
 import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolver;
 import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolverBuilder;
+import org.entur.oauth2.user.JwtUserInfoExtractor;
 import org.rutebanken.helper.organisation.RoleAssignmentExtractor;
+import org.rutebanken.helper.organisation.user.UserInfoExtractor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +13,12 @@ import org.springframework.context.annotation.Profile;
 
 @Configuration
 public class OAuth2Config {
+
+    @Bean
+    public UserInfoExtractor userInfoExtractor() {
+        return new JwtUserInfoExtractor();
+    }
+
     /**
      * Extract role assignments from a JWT token.
      *

--- a/src/main/java/org/rutebanken/tiamat/auth/UsernameFetcher.java
+++ b/src/main/java/org/rutebanken/tiamat/auth/UsernameFetcher.java
@@ -16,25 +16,29 @@
 package org.rutebanken.tiamat.auth;
 
 
-import org.springframework.security.core.Authentication;
+import org.rutebanken.helper.organisation.user.UserInfoExtractor;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
+
+import javax.annotation.Nullable;
 
 @Service
 public class UsernameFetcher {
 
+    private final UserInfoExtractor userInfoExtractor;
+
+    public UsernameFetcher(UserInfoExtractor userInfoExtractor) {
+        this.userInfoExtractor = userInfoExtractor;
+    }
+
     /**
-     * Gets username from Spring Security
-     * <p>
-     * Expects property keycloak.principal-attribute=preferred_username
+     * Return the preferred username or null if the user is not authenticated.
      */
+    @Nullable
     public String getUserNameForAuthenticatedUser() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-            if (authentication != null && authentication.getPrincipal() != null &&
-                    authentication.getPrincipal() instanceof Jwt) {
-                return ((Jwt) authentication.getPrincipal()).getClaimAsString("preferred_username");
+        if(SecurityContextHolder.getContext().getAuthentication() == null) {
+            return null;
         }
-        return null;
+        return userInfoExtractor.getPreferredName();
     }
 }


### PR DESCRIPTION
Query the preferred username OAuth2 claim through the UserInfoExtractor interface, to be able to use alternative implementations.
The default implementation retrieves the  preferred username from the Oauth2 token.