### PR TITLE
Add support for permission store proxy

### DIFF
--- a/helm/tiamat/env/values-kub-ent-dev.yaml
+++ b/helm/tiamat/env/values-kub-ent-dev.yaml
@@ -19,6 +19,15 @@ auth0:
       url: https://internal.dev.entur.org/
     partner:
       url: https://partner.dev.entur.org/
+  client:
+      id: Yd0qVrMoFE9qXT4zJvsTCOw6UT4Wi2WF
+      url: https://internal.dev.entur.org/oauth/token
+      audience: https://ror.api.dev.entur.io
+
+organisation:
+  service: http://baba.dev.entur.internal
+
+roleAssignmentExtractor: baba
 
 rbac:
   enabled: true

--- a/helm/tiamat/env/values-kub-ent-prd.yaml
+++ b/helm/tiamat/env/values-kub-ent-prd.yaml
@@ -19,6 +19,15 @@ auth0:
       url: https://internal.entur.org/
     partner:
       url: https://partner.entur.org/
+  client:
+    id: ga01hAU7XrM8cPOSuYXOocFoM8c1wB42
+    url: https://internal.entur.org/oauth/token
+    audience: https://ror.api.entur.io
+
+organisation:
+  service: http://baba.prd.entur.internal
+
+roleAssignmentExtractor: jwt
 
 rbac:
   enabled: true

--- a/helm/tiamat/env/values-kub-ent-tst.yaml
+++ b/helm/tiamat/env/values-kub-ent-tst.yaml
@@ -19,6 +19,15 @@ auth0:
       url: https://internal.staging.entur.org/
     partner:
       url: https://partner.staging.entur.org/
+  client:
+    id: 9x7HiPyzNWLZuHIaeTzI5QgGBv5hI9w7
+    url: https://internal.staging.entur.org/oauth/token
+    audience: https://ror.api.staging.entur.io
+
+organisation:
+  service: http://baba.tst.entur.internal
+
+roleAssignmentExtractor: jwt
 
 rbac:
   enabled: true

--- a/helm/tiamat/templates/configmap.yaml
+++ b/helm/tiamat/templates/configmap.yaml
@@ -54,8 +54,10 @@ data:
 
 
     # Security config with auth0
-
     authorization.enabled=true
+    tiamat.security.role.assignment.extractor={{ .Values.roleAssignmentExtractor }}
+    tiamat.user.permission.rest.service.url={{ .Values.organisation.service }}/services/organisations/users
+
 
     # OAuth2 Resource Server for Entur Partner tenant
     tiamat.oauth2.resourceserver.auth0.entur.partner.jwt.issuer-uri={{ .Values.auth0.entur.partner.url }}
@@ -70,6 +72,11 @@ data:
     tiamat.oauth2.resourceserver.auth0.ror.jwt.audience={{ .Values.auth0.ror.audience }}
     tiamat.oauth2.resourceserver.auth0.ror.claim.namespace=https://ror.entur.io/
 
+    # OAuth Entur Internal client
+    spring.security.oauth2.client.registration.internal.authorization-grant-type=client_credentials
+    spring.security.oauth2.client.registration.internal.client-id={{ .Values.auth0.client.id }}
+    spring.security.oauth2.client.provider.internal.token-uri={{ .Values.auth0.client.url }}
+    tiamat.oauth2.client.audience={{ .Values.auth0.client.audience }}
 
     # Logging Properties
     logging.level.org.rutebanken.tiamat=INFO

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.entur.ror.helpers</groupId>
+            <artifactId>permission-store-proxy</artifactId>
+            <version>${entur.helpers.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
         </dependency>

--- a/src/main/java/org/rutebanken/tiamat/auth/OAuth2Config.java
+++ b/src/main/java/org/rutebanken/tiamat/auth/OAuth2Config.java
@@ -1,31 +1,77 @@
 package org.rutebanken.tiamat.auth;
 
+import org.entur.oauth2.AuthorizedWebClientBuilder;
 import org.entur.oauth2.JwtRoleAssignmentExtractor;
 import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolver;
 import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolverBuilder;
 import org.entur.oauth2.user.JwtUserInfoExtractor;
+import org.entur.ror.permission.RemoteBabaRoleAssignmentExtractor;
+import org.entur.ror.permission.RemoteBabaUserInfoExtractor;
 import org.rutebanken.helper.organisation.RoleAssignmentExtractor;
 import org.rutebanken.helper.organisation.user.UserInfoExtractor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class OAuth2Config {
 
+    @ConditionalOnProperty(
+            value = "tiamat.security.role.assignment.extractor",
+            havingValue = "jwt",
+            matchIfMissing = true
+    )
     @Bean
-    public UserInfoExtractor userInfoExtractor() {
+    public UserInfoExtractor jwtUserInfoExtractor() {
         return new JwtUserInfoExtractor();
+    }
+
+    /**
+     * Extract user info from the Baba user repository.
+     *
+     */
+    @ConditionalOnProperty(
+            value = "tiamat.security.role.assignment.extractor",
+            havingValue = "baba"
+    )
+    @Bean
+    public UserInfoExtractor babaUserInfoExtractor(
+            WebClient webClient,
+            @Value("${tiamat.user.permission.rest.service.url}") String url
+    ) {
+        return new RemoteBabaUserInfoExtractor(webClient, url);
     }
 
     /**
      * Extract role assignments from a JWT token.
      *
      */
+    @ConditionalOnProperty(
+            value = "tiamat.security.role.assignment.extractor",
+            havingValue = "jwt",
+            matchIfMissing = true
+    )
     @Bean
-    public RoleAssignmentExtractor roleAssignmentExtractor() {
+    public RoleAssignmentExtractor jwtRoleAssignmentExtractor() {
         return new JwtRoleAssignmentExtractor();
+    }
+
+    /**
+     * Extract role assignments from the Baba user repository.
+     *
+     */
+    @ConditionalOnProperty(
+            value = "tiamat.security.role.assignment.extractor",
+            havingValue = "baba"
+    )
+    @Bean
+    public RoleAssignmentExtractor babaRoleAssignmentExtractor(WebClient webClient ,
+                                                               @Value("${tiamat.user.permission.rest.service.url}") String url) {
+        return new RemoteBabaRoleAssignmentExtractor(webClient, url);
     }
 
     @Bean
@@ -54,6 +100,36 @@ public class OAuth2Config {
                 .withRorAuth0Issuer(rorAuth0Issuer)
                 .withRorAuth0Audience(rorAuth0Audience)
                 .withRorAuth0ClaimNamespace(rorAuth0ClaimNamespace)
+                .build();
+    }
+
+    /**
+     * Return a WebClient for authorized API calls.
+     * The WebClient inserts a JWT bearer token in the Authorization HTTP header.
+     * The JWT token is obtained from the configured Authorization Server.
+     *
+     * @param properties The spring.security.oauth2.client.registration.* properties
+     * @param audience   The API audience, required for obtaining a token from Auth0
+     * @return a WebClient for authorized API calls.
+     */
+    @Profile("!test")
+    @Bean
+    @ConditionalOnProperty(
+            value = "tiamat.security.role.assignment.extractor",
+            havingValue = "baba"
+    )
+    WebClient webClient(
+            WebClient.Builder webClientBuilder,
+            OAuth2ClientProperties properties,
+            @Value("${tiamat.oauth2.client.audience}") String audience
+    ) {
+        return new AuthorizedWebClientBuilder(webClientBuilder)
+                .withOAuth2ClientProperties(properties)
+                .withAudience(audience)
+                .withClientRegistrationId("internal")
+                .build()
+                .mutate()
+                .defaultHeader("Et-Client-Name", "entur-tiamat")
                 .build();
     }
 


### PR DESCRIPTION
Add support for permission store proxy.
The default role assignment extractor and user info extractor are still the JWT-based implementations.