### PR TITLE
Add support for entity-specific permission into ext/Fintraffic Authorization model

### DIFF
--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficAuthorizationServiceTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficAuthorizationServiceTest.java
@@ -1,7 +1,5 @@
 package org.rutebanken.tiamat.ext.fintraffic.auth;
 
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -9,6 +7,8 @@ import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.rutebanken.tiamat.exporter.params.TopographicPlaceSearch;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.Quay;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.TopographicPlace;
 import org.rutebanken.tiamat.model.TopographicPlaceTypeEnumeration;
@@ -16,30 +16,24 @@ import org.rutebanken.tiamat.model.Value;
 import org.rutebanken.tiamat.model.VehicleModeEnumeration;
 import org.rutebanken.tiamat.repository.TopographicPlaceRepository;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class FintrafficAuthorizationServiceTest {
-    private final TopographicPlaceRepository topographicPlaceRepositoryMock = mock(TopographicPlaceRepository.class);
-    private final TrivoreAuthorizations trivoreAuthorizationsMock = mock(TrivoreAuthorizations.class);
 
-    @BeforeEach
-    void setUp() {
-        TopographicPlace place = getTopographicPlace();
-        when(topographicPlaceRepositoryMock.findTopographicPlace(any(TopographicPlaceSearch.class))).thenReturn(List.of(place));
-        when(trivoreAuthorizationsMock.getAccessibleCodespaces()).thenReturn(Set.of("ABC", "XYZ"));
-    }
-
-    private static @NotNull TopographicPlace getTopographicPlace() {
+    private static @Nonnull TopographicPlace getTopographicPlace() {
         TopographicPlace place = new TopographicPlace();
         GeometryFactory fact = new GeometryFactory();
         Coordinate[] coordinates = new Coordinate[] {
@@ -57,12 +51,12 @@ class FintrafficAuthorizationServiceTest {
         return place;
     }
 
-    private static @NotNull Point getPoint(Coordinate coordinate) {
+    private static @Nonnull Point getPoint(Coordinate coordinate) {
         GeometryFactory fact = new GeometryFactory();
         return fact.createPoint(coordinate);
     }
 
-    private static @NotNull StopPlace getStopPlace(String netexId, VehicleModeEnumeration transportMode, Point centroid) {
+    private static @Nonnull StopPlace getStopPlace(String netexId, VehicleModeEnumeration transportMode, Point centroid) {
         StopPlace stopPlace = new StopPlace();
         stopPlace.setNetexId(netexId);
         stopPlace.setTransportMode(transportMode);
@@ -70,13 +64,52 @@ class FintrafficAuthorizationServiceTest {
         return stopPlace;
     }
 
+    private static @Nonnull Parking getParking(String netexId, Point centroid) {
+        Parking parking = new Parking();
+        parking.setNetexId(netexId);
+        parking.setCentroid(centroid);
+        return parking;
+    }
 
-    @Test
-    public void testCanEditEntityPoint() {
-        FintrafficAuthorizationService authorizationService = new FintrafficAuthorizationService(
+    private static @Nonnull Quay getQuay(String netexId, Point centroid) {
+        Quay quay = new Quay();
+        quay.setNetexId(netexId);
+        quay.setCentroid(centroid);
+        return quay;
+    }
+
+    private static FintrafficAuthorizationService getAuthorizationService(
+            boolean enableCodeSpaceFiltering,
+            String allowedCodeSpace
+    ) {
+        TopographicPlaceRepository topographicPlaceRepositoryMock = mock(TopographicPlaceRepository.class);
+        TrivoreAuthorizations trivoreAuthorizationsMock = mock(TrivoreAuthorizations.class);
+
+        TopographicPlace place = getTopographicPlace();
+        when(topographicPlaceRepositoryMock.findTopographicPlace(any(TopographicPlaceSearch.class))).thenReturn(List.of(place));
+        when(trivoreAuthorizationsMock.getAccessibleCodespaces()).thenReturn(Set.of("ABC", "XYZ"));
+
+        when(trivoreAuthorizationsMock.hasAccess(matches("StopPlace"), matches("BUS"), eq(TrivorePermission.MANAGE))).thenReturn(true);
+        when(trivoreAuthorizationsMock.hasAccess(matches("Parking"), matches("\\{all\\}"), eq(TrivorePermission.MANAGE))).thenReturn(true);
+        when(trivoreAuthorizationsMock.hasAccess(matches("Quay"), matches("\\{all\\}"), eq(TrivorePermission.MANAGE))).thenReturn(true);
+        when(trivoreAuthorizationsMock.hasAccess(matches("StopPlace"), matches("RAIL"), eq(TrivorePermission.MANAGE))).thenReturn(false);
+        if (enableCodeSpaceFiltering) {
+            when(trivoreAuthorizationsMock.hasAccessToCodespace(matches(allowedCodeSpace))).thenReturn(true);
+            when(trivoreAuthorizationsMock.hasAccessToCodespace(not(matches(allowedCodeSpace)))).thenReturn(false);
+        } else {
+            when(trivoreAuthorizationsMock.hasAccessToCodespace(anyString())).thenReturn(true);
+        }
+
+        return new FintrafficAuthorizationService(
                 trivoreAuthorizationsMock,
                 topographicPlaceRepositoryMock
         );
+    }
+
+
+    @Test
+    public void testCanEditEntityPoint() {
+        FintrafficAuthorizationService authorizationService = getAuthorizationService(false, null);
         assertThat(authorizationService.canEditEntity(getPoint(new Coordinate(0.5, 0.5))), equalTo(true));
         assertThat(authorizationService.canEditEntity(getPoint(new Coordinate(2, 2))), equalTo(false));
     }
@@ -89,18 +122,45 @@ class FintrafficAuthorizationServiceTest {
         StopPlace stopPlaceForbiddenToEditTransportMode = getStopPlace("FSR:StopPlace:1", VehicleModeEnumeration.RAIL, getPoint(new Coordinate(0.3, 0.3)));
         StopPlace stopPlaceOutOfBounds = getStopPlace("FSR:StopPlace:1", VehicleModeEnumeration.BUS, getPoint(new Coordinate(3, 3)));
 
-        when(trivoreAuthorizationsMock.hasAccess(matches("StopPlace"), matches("BUS"), eq(TrivorePermission.MANAGE))).thenReturn(true);
-        when(trivoreAuthorizationsMock.hasAccess(matches("StopPlace"), matches("RAIL"), eq(TrivorePermission.MANAGE))).thenReturn(false);
-        when(trivoreAuthorizationsMock.hasAccessToCodespace(matches("FSR"))).thenReturn(true);
-        when(trivoreAuthorizationsMock.hasAccessToCodespace(matches("AAA"))).thenReturn(false);
+        FintrafficAuthorizationService authorizationService = getAuthorizationService(true, "FSR");
 
-        FintrafficAuthorizationService authorizationService = new FintrafficAuthorizationService(
-                trivoreAuthorizationsMock,
-                topographicPlaceRepositoryMock
-        );
         assertThat(authorizationService.canEditEntity(stopPlaceAllowedToEdit), equalTo(true));
         assertThat(authorizationService.canEditEntity(stopPlaceForbiddenToEditCodespace), equalTo(false));
         assertThat(authorizationService.canEditEntity(stopPlaceForbiddenToEditTransportMode), equalTo(false));
         assertThat(authorizationService.canEditEntity(stopPlaceOutOfBounds), equalTo(false));
+    }
+
+    @Test
+    public void testCanEditEntityParking() {
+        Parking parkingAllowedToEdit = getParking("FSR:Parking:1", getPoint(new Coordinate(0.3, 0.3)));
+        Parking parkingOutOfBounds = getParking("FSR:Parking:2", getPoint(new Coordinate(3, 3)));
+
+        FintrafficAuthorizationService authorizationService = getAuthorizationService(false, null);
+
+        assertThat(authorizationService.canEditEntity(parkingAllowedToEdit), equalTo(true));
+        assertThat(authorizationService.canEditEntity(parkingOutOfBounds), equalTo(false));
+    }
+
+
+    @Test
+    public void testCanEditStopPlaceWithNestedEntities() {
+        StopPlace stopPlaceWithQuayAndNestedStopPlace = getStopPlace("FSR:StopPlace:1", VehicleModeEnumeration.BUS, getPoint(new Coordinate(0.3, 0.3)));
+        StopPlace childStopPlace = getStopPlace("FSR:StopPlace:2", VehicleModeEnumeration.BUS, getPoint(new Coordinate(0.5, 0.5)));
+        stopPlaceWithQuayAndNestedStopPlace.setChildren(Set.of(childStopPlace));
+        Quay quay = getQuay("FSR:Quay:1", getPoint(new Coordinate(0.4, 0.4)));
+        stopPlaceWithQuayAndNestedStopPlace.setQuays(Set.of(quay));
+        FintrafficAuthorizationService authorizationService = getAuthorizationService(false, null);
+        assertThat(authorizationService.canEditEntity(stopPlaceWithQuayAndNestedStopPlace), equalTo(true));
+    }
+
+    @Test
+    public void testCanEditStopPlaceWithNestedEntitiesNotAllowed() {
+        StopPlace stopPlaceWithQuayAndNestedStopPlace = getStopPlace("FSR:StopPlace:1", VehicleModeEnumeration.BUS, getPoint(new Coordinate(0.3, 0.3)));
+        StopPlace childStopPlace = getStopPlace("FSR:StopPlace:2", VehicleModeEnumeration.BUS, getPoint(new Coordinate(0.5, 0.5)));
+        stopPlaceWithQuayAndNestedStopPlace.setChildren(Set.of(childStopPlace));
+        Quay quay = getQuay("FSR:Quay:1", getPoint(new Coordinate(1.4, 0.4)));
+        stopPlaceWithQuayAndNestedStopPlace.setQuays(Set.of(quay));
+        FintrafficAuthorizationService authorizationService = getAuthorizationService(false, null);
+        assertThat(authorizationService.canEditEntity(stopPlaceWithQuayAndNestedStopPlace), equalTo(false));
     }
 }


### PR DESCRIPTION
### Summary

1. Check edit permissions recursively for nested Entities in ext/Fintraffic Authorization Model
2. Prefetch TopographicPlace->polygon when cache is populated

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


### Issue
##### Change 1
In practice this means that for structure like:
* StopPlace
    * quays
         * Quay

edit-permissions are checked for all quays also.

##### Change 2
Prevent exceptions of using non-existent Hibernate session when .getPolygon() is possibly called from another thread

### Unit tests

Unit tests are written to cover updated logic in `FintrafficAuthorizationService.canEditEntity`



