### PR TITLE
Use permission store proxy in staging

### DIFF
--- a/helm/tiamat/env/values-kub-ent-tst.yaml
+++ b/helm/tiamat/env/values-kub-ent-tst.yaml
@@ -27,7 +27,7 @@ auth0:
 organisation:
   service: http://baba.tst.entur.internal
 
-roleAssignmentExtractor: jwt
+roleAssignmentExtractor: baba
 
 rbac:
   enabled: true


### PR DESCRIPTION
### Summary

Entur-specific: use permission-store-proxy for authorization in the staging environment.
