### PR TITLE
Use permission store proxy in production

### DIFF
--- a/helm/tiamat/env/values-kub-ent-prd.yaml
+++ b/helm/tiamat/env/values-kub-ent-prd.yaml
@@ -27,7 +27,7 @@ auth0:
 organisation:
   service: http://baba.prd.entur.internal
 
-roleAssignmentExtractor: jwt
+roleAssignmentExtractor: baba
 
 rbac:
   enabled: true


### PR DESCRIPTION

### Summary

Entur-specific: use permission-store-proxy for authorization in the production environment.