### PR TITLE
update helm config, set logging level to ERROR for ReflectionAuthorizationService

### DIFF
--- a/helm/tiamat/templates/configmap.yaml
+++ b/helm/tiamat/templates/configmap.yaml
@@ -95,6 +95,7 @@ data:
     logging.level.io.micrometer.prometheus=WARN
     logging.level.org.geotools=WARN
     logging.level.hsqldb.db=WARN
+    logging.level.org.rutebanken.helper.organisation.ReflectionAuthorizationService=ERROR
 
     #Profile
     spring.profiles.active=gcs-blobstore,google-pubsub


### PR DESCRIPTION
### Summary

This PR updates the logging configuration to suppress noisy warning messages originating from
org.rutebanken.helper.organisation.ReflectionAuthorizationService. Specifically, it hides the recurring log line:
```aiignore
Role assignment entity classifications cannot be null: RoleAssignment{r=editRouteData, o=KOL, z=null, e=null}
```




### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [x ] Other 

### Motivation
- The message is emitted frequently and clutters the application logs.
- It does not indicate a functional issue in our current usage context.
- Suppressing it improves log readability and helps focus on meaningful warnings and errors.

### Changes
- Adjusted logging level for ReflectionAuthorizationService to ERROR (warnings and below are no longer logged).

### Impact
- Application functionality is unchanged.
- Log output is cleaner and easier to monitor.
- Critical error messages from this class will still appear in logs.



