### PR TITLE
Set Jersey to scan only classes in org.rutebanken.tiamat

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/config/JerseyConfig.java
+++ b/src/main/java/org/rutebanken/tiamat/config/JerseyConfig.java
@@ -103,6 +103,7 @@ public class JerseyConfig {
         publicServicesJersey.setLoadOnStartup(0);
         publicServicesJersey.getInitParameters().put("swagger.scanner.id", PUBLIC_SWAGGER_SCANNER_ID);
         publicServicesJersey.getInitParameters().put("swagger.config.id", PUBLIC_SWAGGER_CONFIG_ID);
+        publicServicesJersey.getInitParameters().put("jersey.config.server.provider.packages", "org.rutebanken.tiamat");
         return publicServicesJersey;
     }
 
@@ -129,6 +130,7 @@ public class JerseyConfig {
 
         healthServicesJersey.getInitParameters().put("swagger.scanner.id", HEALTH_SWAGGER_SCANNER_ID);
         healthServicesJersey.getInitParameters().put("swagger.config.id", HEALTH_SWAGGER_CONFIG_ID);
+        healthServicesJersey.getInitParameters().put("jersey.config.server.provider.packages", "org.rutebanken.tiamat");
         healthServicesJersey.setLoadOnStartup(0);
         return healthServicesJersey;
     }
@@ -156,6 +158,7 @@ public class JerseyConfig {
 
         prometheusServicesJersey.getInitParameters().put("swagger.scanner.id", PROMETHEUS_SWAGGER_SCANNER_ID);
         prometheusServicesJersey.getInitParameters().put("swagger.config.id", PROMETHEUS_SWAGGER_CONFIG_ID);
+        prometheusServicesJersey.getInitParameters().put("jersey.config.server.provider.packages", "org.rutebanken.tiamat");
         prometheusServicesJersey.setLoadOnStartup(0);
         return prometheusServicesJersey;
     }
@@ -184,6 +187,7 @@ public class JerseyConfig {
         adminServicesJersey.setLoadOnStartup(0);
         adminServicesJersey.getInitParameters().put("swagger.scanner.id", ADMIN_SWAGGER_SCANNER_ID);
         adminServicesJersey.getInitParameters().put("swagger.config.id", ADMIN_SWAGGER_CONFIG_ID);
+        adminServicesJersey.getInitParameters().put("jersey.config.server.provider.packages", "org.rutebanken.tiamat");
         return adminServicesJersey;
     }
 


### PR DESCRIPTION
## Set Jersey to scan only classes in org.rutebanken.tiamat

Include only endpoints defined in `org.rutebanken.tiamat` into` **/openapi.json` -response.

Prior to aad9b4c similar behavior was in place. Please see https://github.com/entur/tiamat/commit/aad9b4cff03e951c0ffcfb65d2f0465fee923330#diff-d9d7db1a939640711c55bd1d6c1120f044f745693f859ad367f5fa6b73c47c06L142

Scanning all packages in Tiamat (outside org.rutebanken.tiamat) is a memory heavy operation and because all endpoints are defined in package` org.rutebanken.tiamat` it should be ok to scan only that package.

### Type of change
- [ x ] Bug fix (non-breaking change which fixes an issue)



