### PR TITLE
Override UsernameFetcher Bean for ext/Fintraffic

### DIFF
--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficSecurityConfigTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficSecurityConfigTest.java
@@ -1,0 +1,52 @@
+package org.rutebanken.tiamat.ext.fintraffic.auth;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.rutebanken.helper.organisation.user.UserInfoExtractor;
+import org.rutebanken.tiamat.auth.UsernameFetcher;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2Token;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FintrafficSecurityConfigTest {
+    private final UserInfoExtractor userInfoExtractor = mock(UserInfoExtractor.class);
+
+    private void mockAuthenticatedUser() {
+        Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject("test-subject").build();
+        mockPrincipal(jwt);
+    }
+
+    private void mockAuthentication(Authentication authentication) {
+        SecurityContext securityContextMock = mock(SecurityContext.class);
+        SecurityContextHolder.setContext(securityContextMock);
+        when(securityContextMock.getAuthentication()).thenReturn(authentication);
+    }
+
+    private void mockPrincipal(OAuth2Token principal) {
+        JwtAuthenticationToken authenticationMock = mock(JwtAuthenticationToken.class);
+        mockAuthentication(authenticationMock);
+        when(authenticationMock.getPrincipal()).thenReturn(principal);
+    }
+
+    @Test
+    public void testUserNameFetcherAuthenticated() {
+        mockAuthenticatedUser();
+        UsernameFetcher usernameFetcher = new FintrafficSecurityConfig().usernameFetcher(userInfoExtractor);
+        Assertions.assertEquals("test-subject", usernameFetcher.getUserNameForAuthenticatedUser());
+    }
+
+    @Test
+    public void testUserNameFetcherUnauthenticated() {
+        UsernameFetcher usernameFetcher = new FintrafficSecurityConfig().usernameFetcher(userInfoExtractor);
+        Assertions.assertEquals("<unknown user>", usernameFetcher.getUserNameForAuthenticatedUser());
+
+        mockAuthentication(null);
+        Assertions.assertEquals("<unknown user>", usernameFetcher.getUserNameForAuthenticatedUser());
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficSecurityConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficSecurityConfig.java
@@ -1,16 +1,23 @@
 package org.rutebanken.tiamat.ext.fintraffic.auth;
 
+import org.rutebanken.helper.organisation.user.UserInfoExtractor;
 import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.auth.UsernameFetcher;
 import org.rutebanken.tiamat.repository.TopographicPlaceRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
 @Configuration
 @Profile("fintraffic")
@@ -34,5 +41,24 @@ public class FintrafficSecurityConfig {
         return webClientBuilder
                 .defaultHeader("User-Agent", "Entur Tiamat/" + LocalDate.now().format(DateTimeFormatter.ISO_DATE))
                 .build();
+    }
+
+    private Optional<String> getSubject() {
+        if (SecurityContextHolder.getContext().getAuthentication() instanceof JwtAuthenticationToken token
+                && (token.getPrincipal() instanceof Jwt jwt)) {
+            return Optional.of(jwt.getSubject());
+        }
+        return Optional.empty();
+    }
+
+    @Bean
+    @Primary
+    public UsernameFetcher usernameFetcher(UserInfoExtractor userInfoExtractor) {
+        return new UsernameFetcher(userInfoExtractor) {
+            @Override
+            public String getUserNameForAuthenticatedUser() {
+                return getSubject().orElse("<unknown user>");
+            }
+        };
     }
 }


### PR DESCRIPTION
## Override UsernameFetcher Bean for ext/Fintraffic

Return user id (JWT-token subject) instead of UserInfoExtractor::preferredName when profile "fintraffic" is active.

UsernameFetcher::getUserNameForAuthenticatedUser is used to get username to be stored in the database when entities are updated and therefore it is safe to be overridden in ext/Fintraffic -context. Overriding UserInfoExtractor to return user id is not suitable as UserInfoExtractor is also used to return preferredUsername in GraphQL-response and therefore overriding it has unwanted side effects in frontend.

### Type of change
- [ x ] New feature (non-breaking change which adds functionality)

### Unit tests

Unit tests have been added to cover the implementation.

