### PR TITLE
Save Url-attribute for StopPlace

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/model/StopPlace.java
+++ b/src/main/java/org/rutebanken/tiamat/model/StopPlace.java
@@ -93,6 +93,7 @@ public class StopPlace
     @OneToOne(fetch = FetchType.LAZY)
     @Transient
     protected NavigationPaths_RelStructure navigationPaths;
+    protected String url;
     private boolean parentStopPlace;
     @OneToMany(cascade = CascadeType.ALL)
     private Set<Quay> quays = new HashSet<>();
@@ -303,6 +304,16 @@ public class StopPlace
 
     public void setModificationEnumeration(ModificationEnumeration modificationEnumeration) {
         this.modificationEnumeration = modificationEnumeration;
+    }
+
+    @Override
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public void setUrl(String value) {
+        this.url = value;
     }
 
     @Override

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/GraphQLNames.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/GraphQLNames.java
@@ -321,6 +321,7 @@ public class GraphQLNames {
     public static final String DRY_RUN = "dryRun";
     public static final String PUBLIC_CODE = "publicCode";
     public static final String WEIGHTING = "weighting";
+    public static final String URL = "url";
 
     public static final String IMPORTED_ID_QUERY = "importedId";
     public static final String IMPORTED_ID_ARG_DESCRIPTION = "Searches for StopPlace by importedId.";

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/StopPlaceRegisterGraphQLSchema.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/StopPlaceRegisterGraphQLSchema.java
@@ -1449,6 +1449,9 @@ public class StopPlaceRegisterGraphQLSchema {
                         .name(ADJACENT_SITES)
                         .description(ADJACENT_SITES_DESCRIPTION)
                         .type(new GraphQLList(versionLessRefInputObjectType)))
+                .field(newInputObjectField()
+                        .name(URL)
+                        .type(GraphQLString).build())
                 .build();
     }
 

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/StopPlaceMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/StopPlaceMapper.java
@@ -49,6 +49,7 @@ import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.STOP_PLACE_TYPE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.SUBMODE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.TRANSPORT_MODE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.TYPE;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.URL;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VALID_BETWEEN;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VALUE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.WEIGHTING;
@@ -123,6 +124,11 @@ public class StopPlaceMapper {
             }
             stopPlace.getPrivateCode().setType((String) privateCodeInputMap.get(TYPE));
             stopPlace.getPrivateCode().setValue((String) privateCodeInputMap.get(VALUE));
+            isUpdated = true;
+        }
+
+        if (input.get(URL) != null) {
+            stopPlace.setUrl((String) input.get(URL));
             isUpdated = true;
         }
 

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/types/ParentStopPlaceInputObjectTypeCreator.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/types/ParentStopPlaceInputObjectTypeCreator.java
@@ -29,6 +29,7 @@ import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
 import static graphql.schema.GraphQLInputObjectType.newInputObject;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.CHILDREN;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.INPUT_TYPE_PARENT_STOPPLACE;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.URL;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VALID_BETWEEN;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VERSION_COMMENT;
 
@@ -51,6 +52,9 @@ public class ParentStopPlaceInputObjectTypeCreator {
                 .field(newInputObjectField()
                         .name(VALID_BETWEEN)
                         .type(validBetweenInputObjectType))
+                .field(newInputObjectField()
+                        .name(URL)
+                        .type(GraphQLString))
                 .field(newInputObjectField()
                         .name(CHILDREN)
                         .type(new GraphQLList(stopPlaceInputObjectType)))

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/types/StopPlaceInterfaceCreator.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/types/StopPlaceInterfaceCreator.java
@@ -40,6 +40,7 @@ import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.STOP_PLACE_GROUPS;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.TAGS;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.TARIFF_ZONES;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.TOPOGRAPHIC_PLACE;
+import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.URL;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VALID_BETWEEN;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VERSION_COMMENT;
 import static org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes.alternativeNameObjectType;
@@ -98,6 +99,10 @@ public class StopPlaceInterfaceCreator {
         stopPlaceInterfaceFields.add(newFieldDefinition()
                 .name(PERMISSIONS)
                 .type(entityPermissionObjectType)
+                .build());
+        stopPlaceInterfaceFields.add(newFieldDefinition()
+                .name(URL)
+                .type(GraphQLString)
                 .build());
         return stopPlaceInterfaceFields;
     }

--- a/src/main/resources/db/migration/V49__add_column_url_for_stop_place.sql
+++ b/src/main/resources/db/migration/V49__add_column_url_for_stop_place.sql
@@ -1,0 +1,1 @@
+ALTER TABLE stop_place ADD COLUMN url VARCHAR(2048);

--- a/src/test/java/org/rutebanken/tiamat/model/StopPlaceTest.java
+++ b/src/test/java/org/rutebanken/tiamat/model/StopPlaceTest.java
@@ -251,6 +251,15 @@ public class StopPlaceTest extends TiamatIntegrationTest {
     }
 
     @Test
+    public void persistStopPlaceWithUrl() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setUrl("https://example.com/test-stop-place");
+        stopPlaceRepository.save(stopPlace);
+        StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
+        assertThat(actualStopPlace.getUrl()).isEqualTo("https://example.com/test-stop-place");
+    }
+
+    @Test
     public void persistStopPlaceWithValidBetween() {
 
         StopPlace stopPlace = new StopPlace();

--- a/src/test/java/org/rutebanken/tiamat/rest/graphql/GraphQLResourceStopPlaceIntegrationTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/graphql/GraphQLResourceStopPlaceIntegrationTest.java
@@ -968,6 +968,7 @@ public class GraphQLResourceStopPlaceIntegrationTest extends AbstractGraphQLReso
         String name = "Testing name";
         String shortName = "Testing shortname";
         String description = "Testing description";
+        String url = "https://example.com/test-stop-place-mutation";
 
         Float lon =  Float.valueOf("10.11111");
         Float lat = Float.valueOf("59.11111");
@@ -983,6 +984,7 @@ public class GraphQLResourceStopPlaceIntegrationTest extends AbstractGraphQLReso
                                                  type: Point
                                                  coordinates: [%s,%s]
                                                }
+                                               url:"%s"
                                        }) {
                                   id
                                   weighting
@@ -991,9 +993,10 @@ public class GraphQLResourceStopPlaceIntegrationTest extends AbstractGraphQLReso
                                   description { value }
                                   stopPlaceType
                                   geometry { type coordinates }
+                                  url
                                  }
                                 }
-                """.formatted(GraphQLNames.MUTATE_STOPPLACE,name, shortName, description,StopTypeEnumeration.TRAM_STATION.value(), lon, lat);
+                """.formatted(GraphQLNames.MUTATE_STOPPLACE,name, shortName, description,StopTypeEnumeration.TRAM_STATION.value(), lon, lat, url);
 
         executeGraphqQLQueryOnly(graphQlJsonQuery)
                 .rootPath("data.stopPlace[0]")
@@ -1005,7 +1008,8 @@ public class GraphQLResourceStopPlaceIntegrationTest extends AbstractGraphQLReso
                     .body("geometry.type", equalTo("Point"))
                     .body("geometry.coordinates[0]", comparesEqualTo(lon))
                     .body("geometry.coordinates[1]", comparesEqualTo(lat))
-                    .body("weighting", comparesEqualTo(InterchangeWeightingEnumeration.INTERCHANGE_ALLOWED.value()));
+                    .body("weighting", comparesEqualTo(InterchangeWeightingEnumeration.INTERCHANGE_ALLOWED.value()))
+                    .body("url", comparesEqualTo(url));
 
         // for unit test we don't have a real JMS listener, so we need to check the event manually
         assertThat(entityChangedJMSListener.hasReceivedEvent(null, 1L, EntityChangedEvent.CrudAction.CREATE, null)).isFalse();


### PR DESCRIPTION
### Save Url-attribute to StopPlace

Currently AddressablePlace has a Transient attribute Url which is not persisted to the database.

This PR overrides the Transient annotation from AddressablePlace.Url in StopPlace and adds it (StopPlace.Url) to the GraphQL API and the NeTEx-export API.


### Type of change
- [ x ] New feature (non-breaking change which adds functionality)

### Issue

NeTEx supports Url-element under AddressablePlace (StopPlace, Quay, Parking etc.). This PR adds Url-element for StopPlace.

### Unit tests

Existing unit tests and integration test have been updated to also test the Url -attribute if applicable.


