### PR TITLE
Add param to disable pre- and post-processing on import

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/importer/ImportParams.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/ImportParams.java
@@ -61,4 +61,8 @@ public class ImportParams {
     @Parameter(description = "Import only tariff zones, fare zones and group of tariff zones, ignore rest e.g. stop places, topographic places etc")
     @QueryParam(value = "importOnlyTariffZones")
     public boolean importOnlyTariffZones = false;
+
+    @Parameter(description = "Disable pre and post processing steps, import raw data as is")
+    @QueryParam(value = "disablePreAndPostProcessing")
+    public boolean disablePreAndPostProcessing = false;
 }

--- a/src/main/java/org/rutebanken/tiamat/importer/handler/StopPlaceImportHandler.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/handler/StopPlaceImportHandler.java
@@ -115,7 +115,7 @@ public class StopPlaceImportHandler {
             }
 
             boolean isImportTypeIdMatch = importParams.importType != null && importParams.importType.equals(ImportType.ID_MATCH);
-            if (!isImportTypeIdMatch) {
+            if (!isImportTypeIdMatch && !importParams.disablePreAndPostProcessing) {
                 logger.info("Running stop place pre steps");
                 tiamatStops = stopPlacePreSteps.run(tiamatStops);
             }
@@ -132,7 +132,7 @@ public class StopPlaceImportHandler {
                 logger.info("Got {} stops (was {}) after filtering", tiamatStops.size(), numberOfStopBeforeFiltering);
             }
 
-            if (!isImportTypeIdMatch) {
+            if (!isImportTypeIdMatch && !importParams.disablePreAndPostProcessing) {
                 logger.info("Running stop place post filter steps");
                 tiamatStops = stopPlacePostFilterSteps.run(tiamatStops);
             }


### PR DESCRIPTION
### Summary

Add param to disable pre- and post-processing on import.

The default value for parameter is false. This change should be backwards compatible.


### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

Pre- and post-processing steps during INITIAL import will possible change the data. Query parameter `disablePreAndPostProcessing`  allows explicitly to disable those steps if needed. 


