### PR TITLE
Make NeTEx id ranges configurable

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/netex/id/GaplessIdGeneratorService.java
+++ b/src/main/java/org/rutebanken/tiamat/netex/id/GaplessIdGeneratorService.java
@@ -66,24 +66,36 @@ public class GaplessIdGeneratorService {
 
     private static BasicFormatterImpl basicFormatter = new BasicFormatterImpl();
 
+    /**
+     * Percentage of the configured range that triggers a warning when the high-water mark is approaching the max.
+     */
+    private static final double HIGH_WATER_MARK_WARNING_THRESHOLD = 0.9;
+
     private final int fetchSize;
 
     private final EntityManagerFactory entityManagerFactory;
     private final HazelcastInstance hazelcastInstance;
     private final GeneratedIdState generatedIdState;
+    private final NetexIdRangeConfiguration netexIdRangeConfiguration;
 
     @Autowired
-    public GaplessIdGeneratorService(EntityManagerFactory entityManagerFactory, HazelcastInstance hazelcastInstance, GeneratedIdState generatedIdState) {
+    public GaplessIdGeneratorService(EntityManagerFactory entityManagerFactory, HazelcastInstance hazelcastInstance, GeneratedIdState generatedIdState, NetexIdRangeConfiguration netexIdRangeConfiguration) {
         this.entityManagerFactory = entityManagerFactory;
         this.hazelcastInstance = hazelcastInstance;
         this.generatedIdState = generatedIdState;
+        this.netexIdRangeConfiguration = netexIdRangeConfiguration;
         this.fetchSize = DEFAULT_FETCH_SIZE;
     }
 
     public GaplessIdGeneratorService(EntityManagerFactory entityManagerFactory, HazelcastInstance hazelcastInstance, GeneratedIdState generatedIdState, int fetchSize) {
+        this(entityManagerFactory, hazelcastInstance, generatedIdState, new NetexIdRangeConfiguration(), fetchSize);
+    }
+
+    public GaplessIdGeneratorService(EntityManagerFactory entityManagerFactory, HazelcastInstance hazelcastInstance, GeneratedIdState generatedIdState, NetexIdRangeConfiguration netexIdRangeConfiguration, int fetchSize) {
         this.entityManagerFactory = entityManagerFactory;
         this.hazelcastInstance = hazelcastInstance;
         this.generatedIdState = generatedIdState;
+        this.netexIdRangeConfiguration = netexIdRangeConfiguration;
 
         if (fetchSize < LOW_LEVEL_AVAILABLE_IDS) {
             logger.warn("Fetch size {} cannot be lower than LOW LEVEL AVAILABLE IDS {}. Setting fetch size to {}", fetchSize, LOW_LEVEL_AVAILABLE_IDS, LOW_LEVEL_AVAILABLE_IDS);
@@ -207,6 +219,8 @@ public class GaplessIdGeneratorService {
     private List<Long> retrieveIds(String entityTypeName, EntityManager entityManager) {
         long lastId = generatedIdState.getLastIdForEntity(entityTypeName);
 
+        checkHighWaterMark(entityTypeName, lastId);
+
         List<Long> retrievedIds = selectNextAvailableIds(entityTypeName, lastId, entityManager);
 
         logger.trace("Generated for {}: {}", entityTypeName, retrievedIds);
@@ -218,6 +232,31 @@ public class GaplessIdGeneratorService {
             generatedIdState.setLastIdForEntity(entityTypeName, Collections.max(retrievedIds));
         }
         return retrievedIds;
+    }
+
+    /**
+     * Log a warning when the high-water mark for an entity type is approaching the configured max.
+     * This serves as an early warning that the ID range is running out.
+     *
+     * @param entityTypeName the entity type name
+     * @param lastId the current high-water mark
+     */
+    private void checkHighWaterMark(String entityTypeName, long lastId) {
+        netexIdRangeConfiguration.getRangeForEntity(entityTypeName).ifPresent(range -> {
+            long min = range.getMin();
+            long max = range.getMax();
+            long totalRange = max - min;
+            long used = lastId - min;
+            double usageRatio = (double) used / totalRange;
+
+            if (usageRatio >= HIGH_WATER_MARK_WARNING_THRESHOLD) {
+                long remaining = max - lastId;
+                logger.warn("ID range for {} is {}% exhausted. Last ID: {}, configured max: {}, remaining: {}",
+                        entityTypeName,
+                        String.format("%.1f", usageRatio * 100),
+                        lastId, max, remaining);
+            }
+        });
     }
 
     /**

--- a/src/main/java/org/rutebanken/tiamat/netex/id/GeneratedIdState.java
+++ b/src/main/java/org/rutebanken/tiamat/netex/id/GeneratedIdState.java
@@ -35,10 +35,12 @@ public class GeneratedIdState implements Serializable{
     public static final String ENTITY_NAMES_REGISTERED = "entityNamesRegistered";
 
     private final HazelcastInstance hazelcastInstance;
+    private final NetexIdRangeConfiguration netexIdRangeConfiguration;
 
     @Autowired
-    public GeneratedIdState(HazelcastInstance hazelcastInstance) {
+    public GeneratedIdState(HazelcastInstance hazelcastInstance, NetexIdRangeConfiguration netexIdRangeConfiguration) {
         this.hazelcastInstance = hazelcastInstance;
+        this.netexIdRangeConfiguration = netexIdRangeConfiguration;
     }
 
 
@@ -56,15 +58,20 @@ public class GeneratedIdState implements Serializable{
     }
 
     /**
-     * Last generated id for entity
-     * If no value for entity, INITIAL_LAST_ID is set.
+     * Last generated id for entity.
+     * If no value for entity, uses the configured range minimum minus one
+     * (so the first generated ID will be exactly the range minimum),
+     * or falls back to {@link GaplessIdGeneratorService#INITIAL_LAST_ID}.
      *
-     * @param entityTypeName
+     * @param entityTypeName the entity type name
      * @return the last generated id.
      */
     public long getLastIdForEntity(String entityTypeName) {
         ConcurrentMap<String, Long> lastIdMap = hazelcastInstance.getMap(LAST_IDS_FOR_ENTITY);
-        lastIdMap.putIfAbsent(entityTypeName, INITIAL_LAST_ID);
+        long initialId = netexIdRangeConfiguration.getRangeForEntity(entityTypeName)
+                .map(range -> range.getMin() - 1)
+                .orElse(INITIAL_LAST_ID);
+        lastIdMap.putIfAbsent(entityTypeName, initialId);
         return lastIdMap.get(entityTypeName);
     }
 

--- a/src/main/java/org/rutebanken/tiamat/netex/id/NetexIdProvider.java
+++ b/src/main/java/org/rutebanken/tiamat/netex/id/NetexIdProvider.java
@@ -38,17 +38,22 @@ public class NetexIdProvider {
 
     private final NetexIdHelper netexIdHelper;
 
+    private final NetexIdRangeConfiguration netexIdRangeConfiguration;
+
     @Autowired
-    public NetexIdProvider(GaplessIdGeneratorService gaplessIdGenerator, ValidPrefixList validPrefixList, NetexIdHelper netexIdHelper) {
+    public NetexIdProvider(GaplessIdGeneratorService gaplessIdGenerator, ValidPrefixList validPrefixList, NetexIdHelper netexIdHelper, NetexIdRangeConfiguration netexIdRangeConfiguration) {
         this.gaplessIdGenerator = gaplessIdGenerator;
         this.validPrefixList = validPrefixList;
         this.netexIdHelper = netexIdHelper;
+        this.netexIdRangeConfiguration = netexIdRangeConfiguration;
     }
 
     public String getGeneratedId(IdentifiedEntity identifiedEntity) {
         String entityTypeName = key(identifiedEntity);
 
         long longId = gaplessIdGenerator.getNextIdForEntity(entityTypeName);
+
+        validateIdRange(entityTypeName, String.valueOf(longId));
 
         return netexIdHelper.getNetexId(entityTypeName, longId);
     }
@@ -60,10 +65,12 @@ public class NetexIdProvider {
         if(validPrefixList.isValidPrefixForType(prefix, identifiedEntity.getClass())) {
             logger.debug("Claimed ID {} contains valid prefix for claiming: {}", identifiedEntity.getNetexId(), prefix);
 
+            String entityTypeName = key(identifiedEntity);
+            String idPostfix = netexIdHelper.extractIdPostfix(identifiedEntity.getNetexId());
+            validateIdRange(entityTypeName, idPostfix);
+
             if(netexIdHelper.isNsrId(identifiedEntity.getNetexId())) {
                 Long claimedId = netexIdHelper.extractIdPostfixNumeric(identifiedEntity.getNetexId());
-
-                String entityTypeName = key(identifiedEntity);
 
                 gaplessIdGenerator.getNextIdForEntity(entityTypeName, claimedId);
             } else {
@@ -73,6 +80,23 @@ public class NetexIdProvider {
             // Because IDs might end with non-numbers we cannot support claiming for any ID other than NSR.
         } else {
             logger.warn("Detected non NSR ID: {} with prefix {}", identifiedEntity.getNetexId(), prefix);
+        }
+    }
+
+    /**
+     * Validates that the given ID postfix is within the configured range for the entity type.
+     * Throws {@link IdGeneratorException} if the ID is outside the configured range.
+     *
+     * @param entityTypeName the entity type name
+     * @param idPostfix the postfix part of the NeTEx ID (numeric or alphanumeric)
+     */
+    private void validateIdRange(String entityTypeName, String idPostfix) {
+        if (!netexIdRangeConfiguration.isIdInRange(entityTypeName, idPostfix)) {
+            throw new IdGeneratorException(
+                    String.format("ID %s is outside the configured range %s for entity type %s",
+                            idPostfix,
+                            netexIdRangeConfiguration.getRangeForEntity(entityTypeName).orElse(null),
+                            entityTypeName));
         }
     }
 

--- a/src/main/java/org/rutebanken/tiamat/netex/id/NetexIdRangeConfiguration.java
+++ b/src/main/java/org/rutebanken/tiamat/netex/id/NetexIdRangeConfiguration.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.netex.id;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Configuration for valid NeTEx ID numeric ranges per entity type.
+ * Configured in application.properties as a map:
+ * <pre>
+ * netex.id.range.StopPlace.min=10000
+ * netex.id.range.StopPlace.max=20000
+ * netex.id.range.Quay.min=50000
+ * netex.id.range.Quay.max=60000
+ * </pre>
+ */
+@Configuration
+@ConfigurationProperties(prefix = "netex.id")
+public class NetexIdRangeConfiguration {
+
+    private Map<String, IdRange> range = new HashMap<>();
+
+    public Map<String, IdRange> getRange() {
+        return range;
+    }
+
+    public void setRange(Map<String, IdRange> range) {
+        this.range = range;
+    }
+
+    /**
+     * Get the configured ID range for the given entity type name, if any.
+     *
+     * @param entityTypeName e.g. "StopPlace", "Quay"
+     * @return Optional containing the range, or empty if no range is configured for this type
+     */
+    public Optional<IdRange> getRangeForEntity(String entityTypeName) {
+        return Optional.ofNullable(range.get(entityTypeName));
+    }
+
+    /**
+     * Check if the given numeric ID is within the configured range for the entity type.
+     * If no range is configured for the entity type, the ID is considered valid.
+     *
+     * @param entityTypeName e.g. "StopPlace", "Quay"
+     * @param numericId      the numeric part of the NeTEx ID
+     * @return true if valid (in range or no range configured)
+     */
+    public boolean isIdInRange(String entityTypeName, long numericId) {
+        return getRangeForEntity(entityTypeName)
+                .map(r -> r.isInRange(numericId))
+                .orElse(true);
+    }
+
+    /**
+     * Check if the given ID postfix (as string) is a valid numeric ID within the configured range for the entity type.
+     * If the postfix is not a valid number, it is considered out of range.
+     * If no range is configured for the entity type, all IDs are considered valid.
+     *
+     * @param entityTypeName e.g. "StopPlace", "Quay"
+     * @param idPostfix      the numeric part of the NeTEx ID as string
+     * @return true if valid (in range or no range configured), false if not a valid number or out of range
+     */
+    public boolean isIdInRange(String entityTypeName, String idPostfix) {
+        try {
+            boolean hasRange = getRangeForEntity(entityTypeName).isPresent();
+            if (!hasRange) {
+                // If no range is configured for this entity type, we consider all IDs valid.
+                return true;
+            }
+            long numericId = Long.parseLong(idPostfix);
+            return isIdInRange(entityTypeName, numericId);
+        } catch (NumberFormatException e) {
+            // If the postfix is not a valid number, we consider it out of range.
+            return false;
+        }
+    }
+
+    public static class IdRange {
+        private long min;
+        private long max;
+
+        public IdRange() {
+        }
+
+        public IdRange(long min, long max) {
+            this.min = min;
+            this.max = max;
+            if (min >= max) {
+                throw new IllegalArgumentException("IdRange min must be less than max");
+            }
+        }
+
+        public long getMin() {
+            return min;
+        }
+
+        public void setMin(long min) {
+            this.min = min;
+        }
+
+        public long getMax() {
+            return max;
+        }
+
+        public void setMax(long max) {
+            this.max = max;
+        }
+
+        public boolean isInRange(long numericId) {
+            return numericId >= min && numericId <= max;
+        }
+
+        @Override
+        public String toString() {
+            return "[" + min + ", " + max + "]";
+        }
+    }
+}

--- a/src/test/java/org/rutebanken/tiamat/netex/id/GeneratedIdStateRangeTest.java
+++ b/src/test/java/org/rutebanken/tiamat/netex/id/GeneratedIdStateRangeTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.netex.id;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.rutebanken.tiamat.netex.id.GaplessIdGeneratorService.INITIAL_LAST_ID;
+
+/**
+ * Tests for {@link GeneratedIdState} with configured ID ranges.
+ * Validates that entities with a configured range get the range minimum as their initial last ID,
+ * while entities without a configured range fall back to {@link GaplessIdGeneratorService#INITIAL_LAST_ID}.
+ */
+public class GeneratedIdStateRangeTest {
+
+    private HazelcastInstance hazelcastInstance;
+
+    @Before
+    public void setUp() {
+        Config config = new Config();
+        config.setClusterName("generatedIdStateRangeTest-" + System.currentTimeMillis());
+        hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+    }
+
+    @After
+    public void tearDown() {
+        if (hazelcastInstance != null) {
+            hazelcastInstance.shutdown();
+        }
+    }
+
+    @Test
+    public void entityWithConfiguredRangeSeedsWithMinMinusOne() {
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        GeneratedIdState state = new GeneratedIdState(hazelcastInstance, rangeConfig);
+
+        long lastId = state.getLastIdForEntity("StopPlace");
+
+        // Seeded with min - 1 so that generate_series(lastId + 1, ...) starts exactly at min
+        assertThat(lastId).isEqualTo(99L);
+    }
+
+    @Test
+    public void quayWithConfiguredRangeSeedsWithMinMinusOne() {
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        GeneratedIdState state = new GeneratedIdState(hazelcastInstance, rangeConfig);
+
+        long lastId = state.getLastIdForEntity("Quay");
+
+        assertThat(lastId).isEqualTo(499L);
+    }
+
+    @Test
+    public void entityWithoutConfiguredRangeFallsBackToDefault() {
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        GeneratedIdState state = new GeneratedIdState(hazelcastInstance, rangeConfig);
+
+        long lastId = state.getLastIdForEntity("TopographicPlace");
+
+        assertThat(lastId).isEqualTo(INITIAL_LAST_ID);
+    }
+
+    @Test
+    public void emptyRangeConfigFallsBackToDefault() {
+        NetexIdRangeConfiguration emptyConfig = new NetexIdRangeConfiguration();
+        GeneratedIdState state = new GeneratedIdState(hazelcastInstance, emptyConfig);
+
+        long lastId = state.getLastIdForEntity("StopPlace");
+
+        assertThat(lastId).isEqualTo(INITIAL_LAST_ID);
+    }
+
+    private NetexIdRangeConfiguration createRangeConfig() {
+        NetexIdRangeConfiguration config = new NetexIdRangeConfiguration();
+        Map<String, NetexIdRangeConfiguration.IdRange> ranges = new HashMap<>();
+        ranges.put("StopPlace", new NetexIdRangeConfiguration.IdRange(100, 200));
+        ranges.put("Quay", new NetexIdRangeConfiguration.IdRange(500, 600));
+        config.setRange(ranges);
+        return config;
+    }
+}
+

--- a/src/test/java/org/rutebanken/tiamat/netex/id/NetexIdProviderRangeTest.java
+++ b/src/test/java/org/rutebanken/tiamat/netex/id/NetexIdProviderRangeTest.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.netex.id;
+
+import org.junit.Test;
+import org.rutebanken.tiamat.model.Quay;
+import org.rutebanken.tiamat.model.StopPlace;
+import org.rutebanken.tiamat.model.TopographicPlace;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link NetexIdProvider} with configured ID ranges.
+ * Existing tests in {@link NetexIdProviderTest} cover the default (no range) behaviour.
+ */
+public class NetexIdProviderRangeTest {
+
+    private static NetexIdRangeConfiguration createRangeConfig() {
+        NetexIdRangeConfiguration config = new NetexIdRangeConfiguration();
+        Map<String, NetexIdRangeConfiguration.IdRange> ranges = new HashMap<>();
+        ranges.put("StopPlace", new NetexIdRangeConfiguration.IdRange(100, 200));
+        ranges.put("Quay", new NetexIdRangeConfiguration.IdRange(500, 600));
+        config.setRange(ranges);
+        return config;
+    }
+
+    private static ValidPrefixList createValidPrefixList() {
+        Map<String, List<String>> validPrefixesPerType = new HashMap<>();
+        validPrefixesPerType.put("StopPlace", List.of("NSR"));
+        return new ValidPrefixList("NSR", validPrefixesPerType);
+    }
+
+    @Test
+    public void claimStopPlaceIdWithinRangeSucceeds() {
+        GaplessIdGeneratorService gaplessIdGeneratorServiceMock = mock(GaplessIdGeneratorService.class);
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        ValidPrefixList validPrefixList = createValidPrefixList();
+        NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
+        NetexIdProvider provider = new NetexIdProvider(gaplessIdGeneratorServiceMock, validPrefixList, netexIdHelper, rangeConfig);
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:150");
+
+        provider.claimId(stopPlace);
+        verify(gaplessIdGeneratorServiceMock, times(1)).getNextIdForEntity("StopPlace", 150L);
+    }
+
+    @Test
+    public void claimStopPlaceIdOutsideRangeThrowsException() {
+        GaplessIdGeneratorService gaplessIdGeneratorServiceMock = mock(GaplessIdGeneratorService.class);
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        ValidPrefixList validPrefixList = createValidPrefixList();
+        NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
+        NetexIdProvider provider = new NetexIdProvider(gaplessIdGeneratorServiceMock, validPrefixList, netexIdHelper, rangeConfig);
+
+        StopPlace stopPlace = new StopPlace();
+        // ID 1 is below StopPlace range [100, 200]
+        stopPlace.setNetexId("NSR:StopPlace:1");
+
+        assertThatThrownBy(() -> provider.claimId(stopPlace))
+                .isInstanceOf(IdGeneratorException.class)
+                .hasMessageContaining("outside the configured range");
+        verify(gaplessIdGeneratorServiceMock, times(0)).getNextIdForEntity("StopPlace", 1L);
+    }
+
+    @Test
+    public void claimIdForEntityWithoutRangeSucceeds() {
+        GaplessIdGeneratorService gaplessIdGeneratorServiceMock = mock(GaplessIdGeneratorService.class);
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        ValidPrefixList validPrefixList = createValidPrefixList();
+        NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
+        NetexIdProvider provider = new NetexIdProvider(gaplessIdGeneratorServiceMock, validPrefixList, netexIdHelper, rangeConfig);
+
+        TopographicPlace tp = new TopographicPlace();
+        tp.setNetexId("NSR:TopographicPlace:1");
+
+        provider.claimId(tp);
+        verify(gaplessIdGeneratorServiceMock, times(1)).getNextIdForEntity("TopographicPlace", 1L);
+    }
+
+    @Test
+    public void generateIdWithinRangeSucceeds() {
+        GaplessIdGeneratorService gaplessIdGeneratorServiceMock = mock(GaplessIdGeneratorService.class);
+        when(gaplessIdGeneratorServiceMock.getNextIdForEntity("StopPlace")).thenReturn(160L);
+
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        ValidPrefixList validPrefixList = createValidPrefixList();
+        NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
+        NetexIdProvider provider = new NetexIdProvider(gaplessIdGeneratorServiceMock, validPrefixList, netexIdHelper, rangeConfig);
+
+        StopPlace stopPlace = new StopPlace();
+        String generatedId = provider.getGeneratedId(stopPlace);
+
+        assertThat(generatedId).isEqualTo("NSR:StopPlace:160");
+    }
+
+    @Test
+    public void generateIdOutsideRangeThrowsException() {
+        GaplessIdGeneratorService gaplessIdGeneratorServiceMock = mock(GaplessIdGeneratorService.class);
+        // Simulate generator returning an ID outside the configured range
+        when(gaplessIdGeneratorServiceMock.getNextIdForEntity("StopPlace")).thenReturn(201L);
+
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        ValidPrefixList validPrefixList = createValidPrefixList();
+        NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
+        NetexIdProvider provider = new NetexIdProvider(gaplessIdGeneratorServiceMock, validPrefixList, netexIdHelper, rangeConfig);
+
+        StopPlace stopPlace = new StopPlace();
+
+        assertThatThrownBy(() -> provider.getGeneratedId(stopPlace))
+                .isInstanceOf(IdGeneratorException.class)
+                .hasMessageContaining("outside the configured range");
+    }
+
+    @Test
+    public void generateIdForEntityWithoutRangeSucceeds() {
+        GaplessIdGeneratorService gaplessIdGeneratorServiceMock = mock(GaplessIdGeneratorService.class);
+        when(gaplessIdGeneratorServiceMock.getNextIdForEntity("TopographicPlace")).thenReturn(1L);
+
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        ValidPrefixList validPrefixList = createValidPrefixList();
+        NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
+        NetexIdProvider provider = new NetexIdProvider(gaplessIdGeneratorServiceMock, validPrefixList, netexIdHelper, rangeConfig);
+
+        TopographicPlace tp = new TopographicPlace();
+        String generatedId = provider.getGeneratedId(tp);
+
+        assertThat(generatedId).isEqualTo("NSR:TopographicPlace:1");
+    }
+
+    @Test
+    public void claimStopPlaceIdAtMinBoundarySucceeds() {
+        GaplessIdGeneratorService gaplessIdGeneratorServiceMock = mock(GaplessIdGeneratorService.class);
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        ValidPrefixList validPrefixList = createValidPrefixList();
+        NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
+        NetexIdProvider provider = new NetexIdProvider(gaplessIdGeneratorServiceMock, validPrefixList, netexIdHelper, rangeConfig);
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:100");
+
+        provider.claimId(stopPlace);
+        verify(gaplessIdGeneratorServiceMock, times(1)).getNextIdForEntity("StopPlace", 100L);
+    }
+
+    @Test
+    public void claimStopPlaceIdAtMaxBoundarySucceeds() {
+        GaplessIdGeneratorService gaplessIdGeneratorServiceMock = mock(GaplessIdGeneratorService.class);
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        ValidPrefixList validPrefixList = createValidPrefixList();
+        NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
+        NetexIdProvider provider = new NetexIdProvider(gaplessIdGeneratorServiceMock, validPrefixList, netexIdHelper, rangeConfig);
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:200");
+
+        provider.claimId(stopPlace);
+        verify(gaplessIdGeneratorServiceMock, times(1)).getNextIdForEntity("StopPlace", 200L);
+    }
+
+    @Test
+    public void claimStopPlaceIdOneBelowMinIsRejected() {
+        GaplessIdGeneratorService gaplessIdGeneratorServiceMock = mock(GaplessIdGeneratorService.class);
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        ValidPrefixList validPrefixList = createValidPrefixList();
+        NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
+        NetexIdProvider provider = new NetexIdProvider(gaplessIdGeneratorServiceMock, validPrefixList, netexIdHelper, rangeConfig);
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:99");
+
+        assertThatThrownBy(() -> provider.claimId(stopPlace))
+                .isInstanceOf(IdGeneratorException.class)
+                .hasMessageContaining("outside the configured range");
+        verify(gaplessIdGeneratorServiceMock, times(0)).getNextIdForEntity("StopPlace", 99L);
+    }
+
+    @Test
+    public void claimStopPlaceIdOneAboveMaxIsRejected() {
+        GaplessIdGeneratorService gaplessIdGeneratorServiceMock = mock(GaplessIdGeneratorService.class);
+        NetexIdRangeConfiguration rangeConfig = createRangeConfig();
+        ValidPrefixList validPrefixList = createValidPrefixList();
+        NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
+        NetexIdProvider provider = new NetexIdProvider(gaplessIdGeneratorServiceMock, validPrefixList, netexIdHelper, rangeConfig);
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:201");
+
+        assertThatThrownBy(() -> provider.claimId(stopPlace))
+                .isInstanceOf(IdGeneratorException.class)
+                .hasMessageContaining("outside the configured range");
+        verify(gaplessIdGeneratorServiceMock, times(0)).getNextIdForEntity("StopPlace", 201L);
+    }
+}
+

--- a/src/test/java/org/rutebanken/tiamat/netex/id/NetexIdProviderTest.java
+++ b/src/test/java/org/rutebanken/tiamat/netex/id/NetexIdProviderTest.java
@@ -47,7 +47,12 @@ public class NetexIdProviderTest {
 
         ValidPrefixList validPrefixList = new ValidPrefixList("NSR", validPrefixesPerType);
         NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
-        NetexIdProvider netexIdProvider = new NetexIdProvider(gaplessIdGeneratorService, validPrefixList, netexIdHelper);
+        NetexIdProvider netexIdProvider = new NetexIdProvider(
+                gaplessIdGeneratorService,
+                validPrefixList,
+                netexIdHelper,
+                new NetexIdRangeConfiguration()
+        );
 
         netexIdProvider.claimId(topographicPlace);
         verify(gaplessIdGeneratorService, times(1)).getNextIdForEntity(TopographicPlace.class.getSimpleName(),1L);
@@ -69,7 +74,12 @@ public class NetexIdProviderTest {
         validPrefixesPerType.put("TopographicPlace", Arrays.asList("KVE", "VVV"));
         ValidPrefixList validPrefixList = new ValidPrefixList("NSR", validPrefixesPerType);
         NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
-        NetexIdProvider netexIdProvider = new NetexIdProvider(gaplessIdGeneratorService, validPrefixList, netexIdHelper);
+        NetexIdProvider netexIdProvider = new NetexIdProvider(
+                gaplessIdGeneratorService,
+                validPrefixList,
+                netexIdHelper,
+                new NetexIdRangeConfiguration()
+        );
 
         netexIdProvider.claimId(topographicPlace);
         verify(gaplessIdGeneratorService, times(0)).getNextIdForEntity(TopographicPlace.class.getSimpleName(),1L);
@@ -95,7 +105,12 @@ public class NetexIdProviderTest {
 
         NetexIdHelper netexIdHelper = new NetexIdHelper(validPrefixList);
 
-        NetexIdProvider netexIdProvider = new NetexIdProvider(gaplessIdGeneratorService, validPrefixList, netexIdHelper);
+        NetexIdProvider netexIdProvider = new NetexIdProvider(
+                gaplessIdGeneratorService,
+                validPrefixList,
+                netexIdHelper,
+                new NetexIdRangeConfiguration()
+        );
 
         netexIdProvider.claimId(topographicPlace);
 

--- a/src/test/java/org/rutebanken/tiamat/netex/id/NetexIdRangeConfigurationTest.java
+++ b/src/test/java/org/rutebanken/tiamat/netex/id/NetexIdRangeConfigurationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.netex.id;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NetexIdRangeConfigurationTest {
+
+    @Test
+    public void emptyConfigurationAllowsAnyId() {
+        NetexIdRangeConfiguration config = new NetexIdRangeConfiguration();
+        assertThat(config.isIdInRange("StopPlace", 1L)).isTrue();
+        assertThat(config.isIdInRange("StopPlace", 999999999L)).isTrue();
+        assertThat(config.isIdInRange("Quay", 1L)).isTrue();
+    }
+
+    @Test
+    public void idWithinConfiguredRangeIsValid() {
+        NetexIdRangeConfiguration config = createConfigWithRanges();
+        assertThat(config.isIdInRange("StopPlace", 100L)).isTrue();
+        assertThat(config.isIdInRange("StopPlace", 150L)).isTrue();
+        assertThat(config.isIdInRange("StopPlace", 200L)).isTrue();
+    }
+
+    @Test
+    public void idOutsideConfiguredRangeIsInvalid() {
+        NetexIdRangeConfiguration config = createConfigWithRanges();
+        assertThat(config.isIdInRange("StopPlace", 99L)).isFalse();
+        assertThat(config.isIdInRange("StopPlace", 201L)).isFalse();
+        assertThat(config.isIdInRange("StopPlace", 1L)).isFalse();
+    }
+
+    @Test
+    public void quayRangeIsValidated() {
+        NetexIdRangeConfiguration config = createConfigWithRanges();
+        assertThat(config.isIdInRange("Quay", 500L)).isTrue();
+        assertThat(config.isIdInRange("Quay", 550L)).isTrue();
+        assertThat(config.isIdInRange("Quay", 600L)).isTrue();
+        assertThat(config.isIdInRange("Quay", 499L)).isFalse();
+        assertThat(config.isIdInRange("Quay", 601L)).isFalse();
+    }
+
+    @Test
+    public void entityWithoutConfiguredRangeAllowsAnyId() {
+        NetexIdRangeConfiguration config = createConfigWithRanges();
+        assertThat(config.isIdInRange("TopographicPlace", 1L)).isTrue();
+        assertThat(config.isIdInRange("TopographicPlace", Long.MAX_VALUE)).isTrue();
+    }
+
+    @Test
+    public void getRangeForEntityReturnsEmptyWhenNotConfigured() {
+        NetexIdRangeConfiguration config = createConfigWithRanges();
+        assertThat(config.getRangeForEntity("TopographicPlace")).isEmpty();
+    }
+
+    @Test
+    public void getRangeForEntityReturnsPresentWhenConfigured() {
+        NetexIdRangeConfiguration config = createConfigWithRanges();
+        Optional<NetexIdRangeConfiguration.IdRange> stopPlaceRange = config.getRangeForEntity("StopPlace");
+        assertThat(stopPlaceRange).isPresent();
+        assertThat(stopPlaceRange.get().getMin()).isEqualTo(100L);
+        assertThat(stopPlaceRange.get().getMax()).isEqualTo(200L);
+    }
+
+    @Test
+    public void stringOverloadValidatesNumericPostfix() {
+        NetexIdRangeConfiguration config = createConfigWithRanges();
+        assertThat(config.isIdInRange("StopPlace", "150")).isTrue();
+        assertThat(config.isIdInRange("StopPlace", "1")).isFalse();
+    }
+
+    @Test
+    public void stringOverloadRejectsNonNumericPostfixWhenRangeConfigured() {
+        NetexIdRangeConfiguration config = createConfigWithRanges();
+        assertThat(config.isIdInRange("StopPlace", "ABC")).isFalse();
+    }
+
+    @Test
+    public void stringOverloadAllowsNonNumericPostfixWhenNoRangeConfigured() {
+        NetexIdRangeConfiguration config = createConfigWithRanges();
+        assertThat(config.isIdInRange("TopographicPlace", "ABC")).isTrue();
+    }
+
+    @Test
+    public void idRangeBoundaryMinIsInclusive() {
+        NetexIdRangeConfiguration.IdRange range = new NetexIdRangeConfiguration.IdRange(100, 200);
+        assertThat(range.isInRange(100)).isTrue();
+    }
+
+    @Test
+    public void idRangeBoundaryMaxIsInclusive() {
+        NetexIdRangeConfiguration.IdRange range = new NetexIdRangeConfiguration.IdRange(100, 200);
+        assertThat(range.isInRange(200)).isTrue();
+    }
+
+    private NetexIdRangeConfiguration createConfigWithRanges() {
+        NetexIdRangeConfiguration config = new NetexIdRangeConfiguration();
+        Map<String, NetexIdRangeConfiguration.IdRange> ranges = new HashMap<>();
+        ranges.put("StopPlace", new NetexIdRangeConfiguration.IdRange(100, 200));
+        ranges.put("Quay", new NetexIdRangeConfiguration.IdRange(500, 600));
+        config.setRange(ranges);
+        return config;
+    }
+}
+


### PR DESCRIPTION
### Summary

Make NeTEx id ranges configurable. After this change, it is possible to configure NeTEx id numeric parts to be in a certain range.

**Example:**

```
// application.properties
netex.id.range.StopPlace.min=10000
netex.id.range.StopPlace.max=20000
```

This will generate StopPlace NeTEx ids from `NSR:StopPlace:10000` to `NSR:StopPlace:20000` and reject ids whose numeric part is outside the defined range.

If there is no range defined for an entity type (default behavior), it will use the `GaplessIdGeneratorService.INITIAL_LAST_ID`, and therefore this change should not affect existing installations unless configured with netex.id.range.* parameters.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

No GitHub issue created.

This change will allow fine-grained control over NeTEx id number space for all entity types. 

### Unit tests

- Existing tests pass without modifications (except for a constructor signature change)
- New tests have been created to cover changes

### Documentation

TODO: Update README with configuration examples.


