### PR TITLE
ext/Read API: Add transient numeric id for Fintraffic Read API

### DIFF
--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficNetexEntityEnricherTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficNetexEntityEnricherTest.java
@@ -1,0 +1,152 @@
+package org.rutebanken.tiamat.ext.fintraffic.api;
+
+import jakarta.xml.bind.JAXBElement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.rutebanken.netex.model.KeyValueStructure;
+import org.rutebanken.netex.model.Parking;
+import org.rutebanken.netex.model.Quay;
+import org.rutebanken.netex.model.Quays_RelStructure;
+import org.rutebanken.netex.model.StopPlace;
+import org.rutebanken.netex.model.TopographicPlace;
+
+import javax.xml.namespace.QName;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class FintrafficNetexEntityEnricherTest {
+
+    private FintrafficNetexEntityEnricher enricher;
+
+    @BeforeEach
+    void setUp() {
+        enricher = new FintrafficNetexEntityEnricher();
+    }
+
+    @Test
+    void enrichStopPlace_addsNumericIdWithOffset() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setId("ABC:StopPlace:123");
+
+        enricher.enrich(stopPlace);
+
+        assertNumericId(stopPlace.getKeyList().getKeyValue(), 1_000_123L);
+    }
+
+    @Test
+    void enrichStopPlace_withExistingKeyList_appendsNumericId() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setId("ABC:StopPlace:1");
+        stopPlace.withKeyList(new org.rutebanken.netex.model.KeyListStructure()
+                .withKeyValue(new KeyValueStructure().withKey("existingKey").withValue("existingValue")));
+
+        enricher.enrich(stopPlace);
+
+        List<KeyValueStructure> keyValues = stopPlace.getKeyList().getKeyValue();
+        assertThat(keyValues).hasSize(2);
+        assertThat(keyValues).anyMatch(kv -> "existingKey".equals(kv.getKey()));
+        assertNumericId(keyValues, 1_000_001L);
+    }
+
+    @Test
+    void enrichStopPlace_withQuays_addsNumericIdToEachQuay() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setId("ABC:StopPlace:10");
+
+        Quay quay1 = new Quay();
+        quay1.setId("ABC:Quay:1");
+        Quay quay2 = new Quay();
+        quay2.setId("ABC:Quay:2");
+
+        stopPlace.withQuays(new Quays_RelStructure()
+                .withQuayRefOrQuay(toJaxbElement(quay1), toJaxbElement(quay2)));
+
+        enricher.enrich(stopPlace);
+
+        assertNumericId(stopPlace.getKeyList().getKeyValue(), 1_000_010L);
+        assertNumericId(quay1.getKeyList().getKeyValue(), 5_000_001L);
+        assertNumericId(quay2.getKeyList().getKeyValue(), 5_000_002L);
+    }
+
+    @Test
+    void enrichStopPlace_withEmptyQuays_doesNotFail() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setId("ABC:StopPlace:10");
+        stopPlace.withQuays(new Quays_RelStructure());
+
+        assertThatNoException().isThrownBy(() -> enricher.enrich(stopPlace));
+        assertNumericId(stopPlace.getKeyList().getKeyValue(), 1_000_010L);
+    }
+
+    @Test
+    void enrichStopPlace_withNullQuays_doesNotFail() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setId("ABC:StopPlace:10");
+
+        assertThatNoException().isThrownBy(() -> enricher.enrich(stopPlace));
+        assertNumericId(stopPlace.getKeyList().getKeyValue(), 1_000_010L);
+    }
+
+    @Test
+    void enrichParking_doesNothing() {
+        Parking parking = new Parking();
+        parking.setId("ABC:Parking:1");
+
+        enricher.enrich(parking);
+
+        assertThat(parking.getKeyList()).isNull();
+    }
+
+    @Test
+    void enrichTopographicPlace_doesNothing() {
+        TopographicPlace tp = new TopographicPlace();
+        tp.setId("ABC:TopographicPlace:1");
+
+        enricher.enrich(tp);
+
+        assertThat(tp.getKeyList()).isNull();
+    }
+
+    @Test
+    void enrichStopPlace_withMalformedId_doesNotThrow() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setId("ABC:StopPlace:not-a-number");
+
+        assertThatNoException().isThrownBy(() -> enricher.enrich(stopPlace));
+        assertThat(stopPlace.getKeyList()).isNull();
+    }
+
+    @Test
+    void enrichStopPlace_withNullId_doesNotThrow() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setId(null);
+
+        assertThatNoException().isThrownBy(() -> enricher.enrich(stopPlace));
+        assertThat(stopPlace.getKeyList()).isNull();
+    }
+
+    @Test
+    void enrichQuay_withMalformedId_doesNotThrow() {
+        Quay quay = new Quay();
+        quay.setId("ABC:Quay:bad");
+
+        assertThatNoException().isThrownBy(() -> enricher.enrich(quay));
+        assertThat(quay.getKeyList()).isNull();
+    }
+
+    private static void assertNumericId(List<KeyValueStructure> keyValues, long expectedValue) {
+        assertThat(keyValues)
+                .filteredOn(kv -> "peti_numeric_id".equals(kv.getKey()))
+                .hasSize(1)
+                .first()
+                .extracting(KeyValueStructure::getValue)
+                .isEqualTo(String.valueOf(expectedValue));
+    }
+
+    private static JAXBElement<Quay> toJaxbElement(Quay quay) {
+        return new JAXBElement<>(new QName("Quay"), Quay.class, quay);
+    }
+}
+

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingServiceTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingServiceTest.java
@@ -32,6 +32,7 @@ class ReadApiNetexMarshallingServiceTest {
     private NetexRepository netexRepository;
     private ServiceFrameElementCreator serviceFrameElementCreator;
     private SearchKeyService searchKeyService;
+    private NetexEntityEnricher netexEntityEnricher;
     private ReadApiNetexMarshallingService marshallingService;
 
     @BeforeEach
@@ -40,12 +41,14 @@ class ReadApiNetexMarshallingServiceTest {
         netexRepository = mock(NetexRepository.class);
         serviceFrameElementCreator = mock(ServiceFrameElementCreator.class);
         searchKeyService = mock(SearchKeyService.class);
+        netexEntityEnricher = mock(NetexEntityEnricher.class);
 
         marshallingService = new ReadApiNetexMarshallingService(
                 netexMapper,
                 netexRepository,
                 serviceFrameElementCreator,
-                searchKeyService
+                searchKeyService,
+                netexEntityEnricher
         );
     }
 
@@ -169,6 +172,24 @@ class ReadApiNetexMarshallingServiceTest {
         marshallingService.handleEntityChange(stopPlace, event);
 
         verify(netexRepository, times(1)).upsertEntities(any());
+    }
+
+    @Test
+    void marshallToXMLInvokesEnricher() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("FSR:StopPlace:1");
+        stopPlace.setVersion(1L);
+        stopPlace.setChanged(Instant.now());
+
+        org.rutebanken.netex.model.StopPlace netexStopPlace = new org.rutebanken.netex.model.StopPlace();
+        netexStopPlace.setId(stopPlace.getNetexId());
+        netexStopPlace.setVersion(String.valueOf(stopPlace.getVersion()));
+
+        when(netexMapper.mapToNetexModel(stopPlace)).thenReturn(netexStopPlace);
+
+        marshallingService.marshallToXML(stopPlace);
+
+        verify(netexEntityEnricher, times(1)).enrich(netexStopPlace);
     }
 
     @Test

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficNetexEntityEnricher.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficNetexEntityEnricher.java
@@ -1,0 +1,82 @@
+package org.rutebanken.tiamat.ext.fintraffic.api;
+
+import jakarta.xml.bind.JAXBElement;
+import org.rutebanken.netex.model.EntityInVersionStructure;
+import org.rutebanken.netex.model.KeyListStructure;
+import org.rutebanken.netex.model.KeyValueStructure;
+import org.rutebanken.netex.model.Quay;
+import org.rutebanken.netex.model.SiteElement_VersionStructure;
+import org.rutebanken.netex.model.StopPlace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FintrafficNetexEntityEnricher implements NetexEntityEnricher {
+
+    private static final Logger logger = LoggerFactory.getLogger(FintrafficNetexEntityEnricher.class);
+
+    private static final long STOP_PLACE_OFFSET = 1_000_000L;
+    private static final long QUAY_OFFSET = 5_000_000L;
+    private static final String NUMERIC_ID_KEY = "peti_numeric_id";
+
+    @Override
+    public void enrich(EntityInVersionStructure entity) {
+        try {
+            if (entity instanceof StopPlace stopPlace) {
+                addNumericId(stopPlace, STOP_PLACE_OFFSET);
+                enrichQuays(stopPlace);
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to enrich NeTEx entity {}: {}", entity.getId(), e.getMessage(), e);
+        }
+    }
+
+    private void enrichQuays(StopPlace stopPlace) {
+        try {
+            if (stopPlace.getQuays() == null || stopPlace.getQuays().getQuayRefOrQuay() == null) {
+                return;
+            }
+            for (JAXBElement<?> element : stopPlace.getQuays().getQuayRefOrQuay()) {
+                try {
+                    if (element.getValue() instanceof Quay quay) {
+                        addNumericId(quay, QUAY_OFFSET);
+                    }
+                } catch (Exception e) {
+                    logger.warn("Failed to enrich Quay in StopPlace {}: {}", stopPlace.getId(), e.getMessage(), e);
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to enrich Quays for StopPlace {}: {}", stopPlace.getId(), e.getMessage(), e);
+        }
+    }
+
+    private void addNumericId(SiteElement_VersionStructure entity, long offset) {
+        String id = entity.getId();
+        if (id == null || !id.contains(":")) {
+            logger.warn("Entity has invalid or missing ID: {}", id);
+            return;
+        }
+        String numericPart = id.substring(id.lastIndexOf(':') + 1);
+        long numericId = Long.parseLong(numericPart) + offset;
+
+        if (entity instanceof StopPlace) {
+            checkNumericIdIsLessThanMaxValue(id, numericId, QUAY_OFFSET);
+        } else if (entity instanceof Quay) {
+            checkNumericIdIsLessThanMaxValue(id, numericId, 10_000_000L);
+        }
+
+        if (entity.getKeyList() == null) {
+            entity.withKeyList(new KeyListStructure());
+        }
+        entity.getKeyList().getKeyValue().removeIf(kv -> NUMERIC_ID_KEY.equals(kv.getKey()));
+        entity.getKeyList()
+                .withKeyValue(new KeyValueStructure()
+                        .withKey(NUMERIC_ID_KEY)
+                        .withValue(String.valueOf(numericId)));
+    }
+
+    private void checkNumericIdIsLessThanMaxValue(String id, long numericId, long maxValue) {
+        if (numericId > maxValue) {
+            logger.warn("Numeric ID for entity {} exceeds maximum value: {}", id, numericId);
+        }
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficReadApiConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficReadApiConfig.java
@@ -62,13 +62,15 @@ public class FintrafficReadApiConfig {
             NetexMapper netexMapper,
             NetexRepository netexRepository,
             ServiceFrameElementCreator serviceFrameElementCreator,
-            SearchKeyService searchKeyService
+            SearchKeyService searchKeyService,
+            NetexEntityEnricher netexEntityEnricher
     ) {
         return new ReadApiNetexMarshallingService(
                 netexMapper,
                 netexRepository,
                 serviceFrameElementCreator,
-                searchKeyService
+                searchKeyService,
+                netexEntityEnricher
         );
     }
 
@@ -88,5 +90,10 @@ public class FintrafficReadApiConfig {
                 netexRepository,
                 backgroundJobsEnabled
         );
+    }
+
+    @Bean
+    public NetexEntityEnricher fintrafficNetexEntityEnricher() {
+        return new FintrafficNetexEntityEnricher();
     }
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/NetexEntityEnricher.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/NetexEntityEnricher.java
@@ -1,0 +1,8 @@
+package org.rutebanken.tiamat.ext.fintraffic.api;
+
+import org.rutebanken.netex.model.EntityInVersionStructure;
+
+public interface NetexEntityEnricher {
+    void enrich(EntityInVersionStructure entity);
+}
+

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingService.java
@@ -41,6 +41,7 @@ public class ReadApiNetexMarshallingService {
     private final NetexRepository netexRepository;
     private final ServiceFrameElementCreator serviceFrameElementCreator;
     private final SearchKeyService searchKeyService;
+    private final NetexEntityEnricher netexEntityEnricher;
 
     private static final Map<Class<?>, Function<org.rutebanken.netex.model.EntityInVersionStructure, JAXBElement<?>>> JAXB_ELEMENT_FACTORIES = Map.of(
             org.rutebanken.netex.model.StopPlace.class, e -> objectFactory.createStopPlace((org.rutebanken.netex.model.StopPlace) e),
@@ -56,12 +57,14 @@ public class ReadApiNetexMarshallingService {
             NetexMapper netexMapper,
             NetexRepository netexRepository,
             ServiceFrameElementCreator serviceFrameElementCreator,
-            SearchKeyService searchKeyService
+            SearchKeyService searchKeyService,
+            NetexEntityEnricher netexEntityEnricher
     ) {
         this.netexMapper = netexMapper;
         this.netexRepository = netexRepository;
         this.serviceFrameElementCreator = serviceFrameElementCreator;
         this.searchKeyService = searchKeyService;
+        this.netexEntityEnricher = netexEntityEnricher;
     }
 
     @PostConstruct
@@ -205,6 +208,7 @@ public class ReadApiNetexMarshallingService {
     }
 
     public String marshallToXML(org.rutebanken.netex.model.EntityInVersionStructure netexEntity) {
+        netexEntityEnricher.enrich(netexEntity);
         XMLOutputFactory xof = XMLOutputFactory.newInstance();
 
         try (StringWriter stringWriter = new StringWriter(512)) {


### PR DESCRIPTION
### Summary

- Adds a computed `KeyValue` called `peti_numeric_id` for the Fintraffic Read API, enriching `StopPlace` and `Quay` entities with additional metadata for external consumption.
- This is a sandbox feature change specific to the Fintraffic deployment (`src/ext/fintraffic`).

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

No issue created — this is a sandbox-scoped feature change for the Fintraffic Read API. The motivation is to provide a computed `KeyValue` on exported entities so that downstream consumers of the Read API have access to a derived identifier without requiring changes to persisted data.

### Unit tests

- Unit tests have been created and updated where applicable to cover the new computed `KeyValue` logic.
- The code is designed to be unit testable with the enrichment logic isolated in its own component under `src/ext`.
- Manual verification has been performed.

### Documentation

N/A


