### PR TITLE
Validate stopPlaceType is compatible with transportMode

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/StopPlaceMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/StopPlaceMapper.java
@@ -38,6 +38,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -64,6 +67,26 @@ import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.WEIGHTING;
 public class StopPlaceMapper {
 
     private static final Logger logger = LoggerFactory.getLogger(StopPlaceMapper.class);
+
+    private static final Map<VehicleModeEnumeration, Set<StopTypeEnumeration>> VALID_STOP_TYPES_FOR_MODE;
+
+    static {
+        Map<VehicleModeEnumeration, Set<StopTypeEnumeration>> map = new EnumMap<>(VehicleModeEnumeration.class);
+        map.put(VehicleModeEnumeration.AIR,         EnumSet.of(StopTypeEnumeration.AIRPORT,        StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.BUS,         EnumSet.of(StopTypeEnumeration.ONSTREET_BUS,   StopTypeEnumeration.BUS_STATION,    StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.CABLEWAY,    EnumSet.of(StopTypeEnumeration.LIFT_STATION,   StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.COACH,       EnumSet.of(StopTypeEnumeration.COACH_STATION,  StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.FERRY,       EnumSet.of(StopTypeEnumeration.FERRY_PORT,     StopTypeEnumeration.FERRY_STOP,     StopTypeEnumeration.HARBOUR_PORT, StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.FUNICULAR,   EnumSet.of(StopTypeEnumeration.LIFT_STATION,   StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.LIFT,        EnumSet.of(StopTypeEnumeration.LIFT_STATION,   StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.METRO,       EnumSet.of(StopTypeEnumeration.METRO_STATION,  StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.RAIL,        EnumSet.of(StopTypeEnumeration.RAIL_STATION,   StopTypeEnumeration.VEHICLE_RAIL_INTERCHANGE, StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.TRAM,        EnumSet.of(StopTypeEnumeration.ONSTREET_TRAM,  StopTypeEnumeration.TRAM_STATION,   StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.TROLLEY_BUS, EnumSet.of(StopTypeEnumeration.ONSTREET_BUS,   StopTypeEnumeration.BUS_STATION,    StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.WATER,       EnumSet.of(StopTypeEnumeration.HARBOUR_PORT,   StopTypeEnumeration.FERRY_PORT,     StopTypeEnumeration.FERRY_STOP,   StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.OTHER,       EnumSet.of(StopTypeEnumeration.OTHER));
+        VALID_STOP_TYPES_FOR_MODE = Collections.unmodifiableMap(map);
+    }
 
     @Autowired
     private QuayMapper quayMapper;
@@ -152,6 +175,10 @@ public class StopPlaceMapper {
 
         isUpdated = isUpdated | setTransportModeSubMode(stopPlace, input.get(TRANSPORT_MODE), input.get(SUBMODE));
 
+        if (input.get(STOP_PLACE_TYPE) != null || input.get(TRANSPORT_MODE) != null) {
+            validateStopPlaceTypeForTransportMode(stopPlace);
+        }
+
         if (input.get(QUAYS) != null) {
             List quays = (List) input.get(QUAYS);
             for (Object quayObject : quays) {
@@ -232,6 +259,22 @@ public class StopPlaceMapper {
             return true;
         }
         return false;
+    }
+
+    private void validateStopPlaceTypeForTransportMode(StopPlace stopPlace) {
+        VehicleModeEnumeration transportMode = stopPlace.getTransportMode();
+        StopTypeEnumeration stopPlaceType = stopPlace.getStopPlaceType();
+
+        if (transportMode == null || stopPlaceType == null) {
+            return;
+        }
+
+        Set<StopTypeEnumeration> validTypes = VALID_STOP_TYPES_FOR_MODE.get(transportMode);
+        Preconditions.checkArgument(
+                validTypes != null && validTypes.contains(stopPlaceType),
+                "StopPlaceType %s is not valid for TransportMode %s. Valid types are: %s",
+                stopPlaceType, transportMode, validTypes
+        );
     }
 
     private boolean setFacilities(StopPlace stopPlace, Object facilitiesListObject) {

--- a/src/test/java/org/rutebanken/tiamat/rest/graphql/GraphQLResourceStopPlaceIntegrationTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/graphql/GraphQLResourceStopPlaceIntegrationTest.java
@@ -65,6 +65,8 @@ import org.rutebanken.tiamat.model.ValidBetween;
 import org.rutebanken.tiamat.model.Value;
 import org.rutebanken.tiamat.model.VehicleModeEnumeration;
 import org.rutebanken.tiamat.model.WaitingRoomEquipment;
+import org.rutebanken.tiamat.auth.MockedRoleAssignmentExtractor;
+import org.rutebanken.tiamat.auth.RoleAssignmentListBuilder;
 import org.rutebanken.tiamat.netex.mapping.mapper.NetexIdMapper;
 import org.rutebanken.tiamat.service.stopplace.MultiModalStopPlaceEditor;
 import org.rutebanken.tiamat.time.ExportTimeZone;
@@ -104,6 +106,9 @@ public class GraphQLResourceStopPlaceIntegrationTest extends AbstractGraphQLReso
 
     @Autowired
     private ExportTimeZone exportTimeZone;
+
+    @Autowired
+    private MockedRoleAssignmentExtractor mockedRoleAssignmentExtractor;
 
     private Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
 
@@ -1671,24 +1676,28 @@ public class GraphQLResourceStopPlaceIntegrationTest extends AbstractGraphQLReso
 
         String newTransportMode = VehicleModeEnumeration.TRAM.value();
         String newSubmode = TramSubmodeEnumeration.LOCAL_TRAM.value();
+        String newStopPlaceType = StopTypeEnumeration.ONSTREET_TRAM.value();
         String graphQlJsonQuery = """
                  mutation {
                   stopPlace: mutateStopPlace (StopPlace: {
                           id: "%s"
                           transportMode: %s
                           submode: %s
+                          stopPlaceType: %s
                       }) {
                           id
                           transportMode
                           submode
+                          stopPlaceType
                       }
-                  }""".formatted(stopPlace.getNetexId(), newTransportMode, newSubmode);
+                  }""".formatted(stopPlace.getNetexId(), newTransportMode, newSubmode, newStopPlaceType);
 
         executeGraphqQLQueryOnly(graphQlJsonQuery)
                 .rootPath("data.stopPlace[0]")
                 .body("id", equalTo(stopPlace.getNetexId()))
                 .body("transportMode", equalTo(newTransportMode))
-                .body("submode", equalTo(newSubmode));
+                .body("submode", equalTo(newSubmode))
+                .body("stopPlaceType", equalTo(newStopPlaceType));
 
         var stopPlaces = stopPlaceRepository.findAll();
         for(StopPlace stopPlaceVersion : stopPlaces) {
@@ -1768,25 +1777,29 @@ public class GraphQLResourceStopPlaceIntegrationTest extends AbstractGraphQLReso
 
         String newTransportMode = VehicleModeEnumeration.TRAM.value();
         String newSubmode = TramSubmodeEnumeration.CITY_TRAM.value();
+        String newStopPlaceType = StopTypeEnumeration.ONSTREET_TRAM.value();
         String graphQlJsonQuery = """
                 mutation {
                     stopPlace: mutateStopPlace (StopPlace: {
                         id: "%s"
                         transportMode: %s
                         submode: %s
+                        stopPlaceType: %s
                     }) {
                         id
                         transportMode
                         submode
+                        stopPlaceType
                     }
                 }
-                """.formatted(stopPlace.getNetexId(), newTransportMode, newSubmode);
+                """.formatted(stopPlace.getNetexId(), newTransportMode, newSubmode, newStopPlaceType);
 
         executeGraphqQLQueryOnly(graphQlJsonQuery)
                 .rootPath("data.stopPlace[0]")
                 .body("id", equalTo(stopPlace.getNetexId()))
                 .body("transportMode", equalTo(newTransportMode))
-                .body("submode", equalTo(newSubmode));
+                .body("submode", equalTo(newSubmode))
+                .body("stopPlaceType", equalTo(newStopPlaceType));
 
         var stopPlaces = stopPlaceRepository.findAll();
         for(StopPlace stopPlaceVersion : stopPlaces) {
@@ -1800,6 +1813,99 @@ public class GraphQLResourceStopPlaceIntegrationTest extends AbstractGraphQLReso
         }
     }
 
+
+    /**
+     * A user with full access should still not be able to create a stop place with a stopPlaceType
+     * that is incompatible with the selected transportMode (domain validation).
+     */
+    @Test
+    public void testMutationRejectsStopPlaceTypeInvalidForTransportMode() {
+        // Full access — failure must come from domain validation, not authorization
+        mockedRoleAssignmentExtractor.setNextReturnedRoleAssignment(
+                RoleAssignmentListBuilder.builder().withAccessAllAreas().build());
+
+        // BUS transport mode is incompatible with RAIL_STATION stop place type
+        String graphQlJsonQuery = """
+                mutation {
+                    stopPlace: mutateStopPlace (StopPlace: {
+                        name: { value: "Invalid Stop" }
+                        transportMode: %s
+                        stopPlaceType: %s
+                    }) {
+                        id
+                        transportMode
+                        stopPlaceType
+                    }
+                }
+                """.formatted(VehicleModeEnumeration.BUS.value(), StopTypeEnumeration.RAIL_STATION.value());
+
+        executeGraphqQLQueryOnly(graphQlJsonQuery, 400);
+    }
+
+    /**
+     * A valid (transportMode, stopPlaceType) combination must still be accepted after the fix.
+     */
+    @Test
+    public void testMutationAcceptsStopPlaceTypeValidForTransportMode() {
+        mockedRoleAssignmentExtractor.setNextReturnedRoleAssignment(
+                RoleAssignmentListBuilder.builder().withStopPlaceOfType(StopTypeEnumeration.BUS_STATION).build());
+
+        String graphQlJsonQuery = """
+                mutation {
+                    stopPlace: mutateStopPlace (StopPlace: {
+                        name: { value: "Bus Stop" }
+                        transportMode: %s
+                        stopPlaceType: %s
+                    }) {
+                        id
+                        transportMode
+                        stopPlaceType
+                    }
+                }
+                """.formatted(VehicleModeEnumeration.BUS.value(), StopTypeEnumeration.BUS_STATION.value());
+
+        executeGraphqQLQueryOnly(graphQlJsonQuery)
+                .rootPath("data.stopPlace[0]")
+                .body("id", notNullValue())
+                .body("transportMode", equalTo(VehicleModeEnumeration.BUS.value()))
+                .body("stopPlaceType", equalTo(StopTypeEnumeration.BUS_STATION.value()));
+    }
+
+    /**
+     * Changing transportMode to one that is incompatible with the existing stopPlaceType must be rejected.
+     * The user has full access (via withAccessAllAreas) so the failure is from domain validation.
+     */
+    @Test
+    public void testMutationRejectsStopPlaceTypeInvalidWhenOnlyTransportModeUpdated() {
+        // Full access — failure must come from domain validation, not authorization
+        mockedRoleAssignmentExtractor.setNextReturnedRoleAssignment(
+                RoleAssignmentListBuilder.builder().withAccessAllAreas().build());
+
+        StopPlace stopPlace = createStopPlace("Train station");
+        stopPlace.setTransportMode(VehicleModeEnumeration.RAIL);
+        stopPlace.setStopPlaceType(StopTypeEnumeration.RAIL_STATION);
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(10, 59)));
+        stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+
+        mockedRoleAssignmentExtractor.setNextReturnedRoleAssignment(
+                RoleAssignmentListBuilder.builder().withAccessAllAreas().build());
+
+        // RAIL_STATION is incompatible with BUS — updating transportMode should be rejected
+        String graphQlJsonQuery = """
+                mutation {
+                    stopPlace: mutateStopPlace (StopPlace: {
+                        id: "%s"
+                        transportMode: %s
+                    }) {
+                        id
+                        transportMode
+                        stopPlaceType
+                    }
+                }
+                """.formatted(stopPlace.getNetexId(), VehicleModeEnumeration.BUS.value());
+
+        executeGraphqQLQueryOnly(graphQlJsonQuery, 400);
+    }
 
     @Test
     public void testSimpleMutationCreateQuay() throws Exception {


### PR DESCRIPTION
### Summary

- Adds domain validation to ensure `stopPlaceType` is compatible with `transportMode` when creating or updating a stop place via the GraphQL mutation.
- A static map in `StopPlaceMapper` defines which `StopTypeEnumeration` values are valid for each `VehicleModeEnumeration` (e.g. `BUS` → `ONSTREET_BUS`, `BUS_STATION`; `RAIL` → `RAIL_STATION`, `VEHICLE_RAIL_INTERCHANGE`).
- Validation fires whenever either field is present in the mutation input, checking the resulting state on the entity. Returns HTTP 400 if the combination is invalid.

### Type of change
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Root cause

`StopPlaceMapper.populateStopPlaceFromInput` set `stopPlaceType` and `transportMode` in two independent `if` blocks with no cross-validation. The existing submode validation (`setTransportModeSubMode`) was the correct pattern but was never extended to cover the type/mode relationship.

### Solution

Added `validateStopPlaceTypeForTransportMode(StopPlace)` in `StopPlaceMapper`, modelled after `setTransportModeSubMode`. Called after both fields are resolved on the entity (post-`setTransportModeSubMode`), skips gracefully when either field is null.

### Tests

- `testMutationRejectsStopPlaceTypeInvalidForTransportMode` — `BUS` + `RAIL_STATION` → 400
- `testMutationAcceptsStopPlaceTypeValidForTransportMode` — `BUS` + `BUS_STATION` → succeeds
- `testMutationRejectsStopPlaceTypeInvalidWhenOnlyTransportModeUpdated` — existing `RAIL/RAIL_STATION` stop, update `transportMode` to `BUS` only → 400

Two existing tests (`testSimpleMutationUpdateTransportModeStopPlace`, `testMutationUpdateStopPlaceToCityTramSubmode`) were updated to also supply a consistent `stopPlaceType` when changing `transportMode`, as they previously left the entity in an invalid state.