### PR TITLE
Feature/ext read api municipalities

### DIFF
--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficApiControllerTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficApiControllerTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class FintrafficApiControllerTest {
@@ -48,7 +50,7 @@ class FintrafficApiControllerTest {
                 "1.12:FI-NeTEx-stops:1.0"
         );
 
-        controller = new FintrafficApiController(publicationDeliveryService, "[A-ZÅÄÖ]{3}");
+        controller = new FintrafficApiController(publicationDeliveryService, "[A-ZÅÄÖ]{3}", "\\d{3}");
 
         // Setup mock response
         response = mock(HttpServletResponse.class);
@@ -81,6 +83,11 @@ class FintrafficApiControllerTest {
                 "<ScheduledStopPoint id=\"FSR:ScheduledStopPoint:1\" version=\"1\"/>".getBytes(StandardCharsets.UTF_8)
         );
 
+        ReadApiEntityOutRecord topographicPlace = new ReadApiEntityOutRecord(
+                "TopographicPlace",
+                "<TopographicPlace id=\"FSR:TopographicPlace:91\" version=\"1\"/>".getBytes(StandardCharsets.UTF_8)
+        );
+
         ReadApiEntityOutRecord stopPlace = new ReadApiEntityOutRecord(
                 "StopPlace",
                 "<StopPlace id=\"FSR:StopPlace:1\" version=\"1\"/>".getBytes(StandardCharsets.UTF_8)
@@ -92,20 +99,50 @@ class FintrafficApiControllerTest {
         );
 
         when(netexRepository.streamStopPlaces(any(ReadApiSearchKey.class)))
-                .thenReturn(Stream.of(scheduledStopPoint, stopPlace, parking));
+                .thenReturn(Stream.of(scheduledStopPoint, topographicPlace, stopPlace, parking));
 
-        controller.getNetexStream(transportModes, areaCodes, response);
+        controller.getNetexStream(transportModes, areaCodes, null, response);
 
         String output = outputStream.toString(StandardCharsets.UTF_8);
         assertThat(output, containsString("FSR:ScheduledStopPoint:1"));
+        assertThat(output, containsString("FSR:TopographicPlace:91"));
         assertThat(output, containsString("FSR:StopPlace:1"));
         assertThat(output, containsString("FSR:Parking:1"));
         assertThat(output, containsString("<scheduledStopPoints>"));
         assertThat(output, containsString("</scheduledStopPoints>"));
+        assertThat(output, containsString("<topographicPlaces>"));
+        assertThat(output, containsString("</topographicPlaces>"));
         assertThat(output, containsString("<stopPlaces>"));
         assertThat(output, containsString("</stopPlaces>"));
         assertThat(output, containsString("<parkings>"));
         assertThat(output, containsString("</parkings>"));
+    }
+
+    @Test
+    void getNetexStreamRejectsInvalidMunicipalityCode() {
+        controller.getNetexStream(null, null, new String[]{"ABC"}, response);
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test
+    void getNetexStreamRejectsInvalidMunicipalityCodeTooShort() {
+        controller.getNetexStream(null, null, new String[]{"09"}, response);
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test
+    void getNetexStreamRejectsInvalidAreaCode() {
+        controller.getNetexStream(null, new String[]{"123"}, null, response);
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test
+    void getNetexStreamAcceptsValidMunicipalityCode() {
+        when(netexRepository.streamStopPlaces(any(ReadApiSearchKey.class)))
+                .thenReturn(Stream.empty());
+
+        controller.getNetexStream(null, null, new String[]{"091"}, response);
+        verify(response, never()).setStatus(HttpServletResponse.SC_BAD_REQUEST);
     }
 }
 

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficApiControllerTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficApiControllerTest.java
@@ -50,7 +50,7 @@ class FintrafficApiControllerTest {
                 "1.12:FI-NeTEx-stops:1.0"
         );
 
-        controller = new FintrafficApiController(publicationDeliveryService, "[A-ZÅÄÖ]{3}", "\\d{3}");
+        controller = new FintrafficApiController(publicationDeliveryService);
 
         // Setup mock response
         response = mock(HttpServletResponse.class);
@@ -119,14 +119,14 @@ class FintrafficApiControllerTest {
     }
 
     @Test
-    void getNetexStreamRejectsInvalidMunicipalityCode() {
+    void getNetexStreamRejectsNonNumericMunicipalityCode() {
         controller.getNetexStream(null, null, new String[]{"ABC"}, response);
         verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
     }
 
     @Test
-    void getNetexStreamRejectsInvalidMunicipalityCodeTooShort() {
-        controller.getNetexStream(null, null, new String[]{"09"}, response);
+    void getNetexStreamRejectsTwoDigitMunicipalityCode() {
+        controller.getNetexStream(null, null, new String[]{"99"}, response);
         verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
     }
 
@@ -137,12 +137,27 @@ class FintrafficApiControllerTest {
     }
 
     @Test
-    void getNetexStreamAcceptsValidMunicipalityCode() {
+    void getNetexStreamAcceptsFirstThreeDigitMunicipalityCode() {
         when(netexRepository.streamStopPlaces(any(ReadApiSearchKey.class)))
                 .thenReturn(Stream.empty());
 
-        controller.getNetexStream(null, null, new String[]{"091"}, response);
+        controller.getNetexStream(null, null, new String[]{"000"}, response);
         verify(response, never()).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test
+    void getNetexStreamAcceptsLastFourDigitMunicipalityCode() {
+        when(netexRepository.streamStopPlaces(any(ReadApiSearchKey.class)))
+                .thenReturn(Stream.empty());
+
+        controller.getNetexStream(null, null, new String[]{"9999"}, response);
+        verify(response, never()).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test
+    void getNetexStreamRejectsFiveDigitMunicipalityCode() {
+        controller.getNetexStream(null, null, new String[]{"10000"}, response);
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
     }
 }
 

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/model/FintrafficReadApiSearchKeyTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/model/FintrafficReadApiSearchKeyTest.java
@@ -19,25 +19,29 @@ class FintrafficReadApiSearchKeyTest {
         FintrafficReadApiSearchKey searchKey = FintrafficReadApiSearchKey.empty();
         assertThat(searchKey.transportModes().length, equalTo(0));
         assertThat(searchKey.areaCodes().length, equalTo(0));
+        assertThat(searchKey.municipalityCodes().length, equalTo(0));
     }
 
     @Test
     void constructorWithValues() {
         String[] modes = {"bus", "tram"};
         String[] codes = {"ABC", "DEF"};
+        String[] municipalities = {"091", "049"};
 
-        FintrafficReadApiSearchKey searchKey = new FintrafficReadApiSearchKey(modes, codes);
+        FintrafficReadApiSearchKey searchKey = new FintrafficReadApiSearchKey(modes, codes, municipalities);
 
         assertThat(searchKey.transportModes(), equalTo(modes));
         assertThat(searchKey.areaCodes(), equalTo(codes));
+        assertThat(searchKey.municipalityCodes(), equalTo(municipalities));
     }
 
     @Test
     void constructorWithNullValues() {
-        FintrafficReadApiSearchKey searchKey = new FintrafficReadApiSearchKey(null, null);
+        FintrafficReadApiSearchKey searchKey = new FintrafficReadApiSearchKey(null, null, null);
 
         assertThat(searchKey.transportModes(), equalTo(null));
         assertThat(searchKey.areaCodes(), equalTo(null));
+        assertThat(searchKey.municipalityCodes(), equalTo(null));
     }
 }
 

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficApiController.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficApiController.java
@@ -19,25 +19,31 @@ import java.nio.charset.StandardCharsets;
 public class FintrafficApiController {
     private final ReadApiNetexPublicationDeliveryService readApiNetexPublicationDeliveryService;
     private final String areaCodeRegex;
+    private final String municipalityCodeRegex;
 
     public FintrafficApiController(
             ReadApiNetexPublicationDeliveryService readApiNetexPublicationDeliveryService,
             @Value("${tiamat.ext.fintraffic.area-code-pattern:[A-ZÅÄÖ]{3}}")
-            String areaCodeRegex
+            String areaCodeRegex,
+            @Value("${tiamat.ext.fintraffic.municipality-code-pattern:\\d{3}}")
+            String municipalityCodeRegex
     ) {
         this.readApiNetexPublicationDeliveryService = readApiNetexPublicationDeliveryService;
         this.areaCodeRegex = areaCodeRegex;
+        this.municipalityCodeRegex = municipalityCodeRegex;
     }
 
     @GetMapping("/fintraffic/v1/stops")
     public void getNetexStream(
             @RequestParam(value = "transportModes", required = false) String[] transportMode,
             @RequestParam(value = "areaCodes", required = false) String[] areaCode,
+            @RequestParam(value = "municipalityCodes", required = false) String[] municipalityCode,
             HttpServletResponse response
     ) {
         try {
             validateTransportModes(transportMode);
             validateAreaCodes(areaCode);
+            validateMunicipalityCodes(municipalityCode);
         } catch (IllegalArgumentException e) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             return;
@@ -48,7 +54,7 @@ public class FintrafficApiController {
         response.setBufferSize(32 * 1024); // 32 KB buffer size for efficient streaming
 
         try (OutputStream outputStream = response.getOutputStream()) {
-            FintrafficReadApiSearchKey searchKey = new FintrafficReadApiSearchKey(transportMode, areaCode);
+            FintrafficReadApiSearchKey searchKey = new FintrafficReadApiSearchKey(transportMode, areaCode, municipalityCode);
             readApiNetexPublicationDeliveryService.streamPublicationDelivery(searchKey, outputStream);
         } catch (IOException e) {
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -68,6 +74,16 @@ public class FintrafficApiController {
             for (String code : areaCodes) {
                 if (!code.matches(areaCodeRegex)) {
                     throw new IllegalArgumentException("Invalid areaCode: " + code);
+                }
+            }
+        }
+    }
+
+    private void validateMunicipalityCodes(String[] municipalityCodes) {
+        if (municipalityCodes != null) {
+            for (String code : municipalityCodes) {
+                if (!code.matches(municipalityCodeRegex)) {
+                    throw new IllegalArgumentException("Invalid municipalityCode: " + code);
                 }
             }
         }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficApiController.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficApiController.java
@@ -3,7 +3,6 @@ package org.rutebanken.tiamat.ext.fintraffic.api;
 import jakarta.servlet.http.HttpServletResponse;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.FintrafficReadApiSearchKey;
 import org.rutebanken.tiamat.model.VehicleModeEnumeration;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -18,19 +17,14 @@ import java.nio.charset.StandardCharsets;
 @Controller
 public class FintrafficApiController {
     private final ReadApiNetexPublicationDeliveryService readApiNetexPublicationDeliveryService;
-    private final String areaCodeRegex;
-    private final String municipalityCodeRegex;
+    private static final String AREA_CODE_REGEX = "[A-ZÅÄÖ]{3}";
+    // 3 digits for normal municipalities, 4 digits for special areas like Haaparanta and Eurooppa
+    private static final String MUNICIPALITY_CODE_REGEX = "\\d{3,4}";
 
     public FintrafficApiController(
-            ReadApiNetexPublicationDeliveryService readApiNetexPublicationDeliveryService,
-            @Value("${tiamat.ext.fintraffic.area-code-pattern:[A-ZÅÄÖ]{3}}")
-            String areaCodeRegex,
-            @Value("${tiamat.ext.fintraffic.municipality-code-pattern:\\d{3}}")
-            String municipalityCodeRegex
+            ReadApiNetexPublicationDeliveryService readApiNetexPublicationDeliveryService
     ) {
         this.readApiNetexPublicationDeliveryService = readApiNetexPublicationDeliveryService;
-        this.areaCodeRegex = areaCodeRegex;
-        this.municipalityCodeRegex = municipalityCodeRegex;
     }
 
     @GetMapping("/fintraffic/v1/stops")
@@ -72,7 +66,7 @@ public class FintrafficApiController {
     private void validateAreaCodes(String[] areaCodes) {
         if (areaCodes != null) {
             for (String code : areaCodes) {
-                if (!code.matches(areaCodeRegex)) {
+                if (!code.matches(AREA_CODE_REGEX)) {
                     throw new IllegalArgumentException("Invalid areaCode: " + code);
                 }
             }
@@ -82,7 +76,7 @@ public class FintrafficApiController {
     private void validateMunicipalityCodes(String[] municipalityCodes) {
         if (municipalityCodes != null) {
             for (String code : municipalityCodes) {
-                if (!code.matches(municipalityCodeRegex)) {
+                if (!code.matches(MUNICIPALITY_CODE_REGEX)) {
                     throw new IllegalArgumentException("Invalid municipalityCode: " + code);
                 }
             }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyService.java
@@ -15,6 +15,7 @@ import org.rutebanken.tiamat.ext.fintraffic.api.model.FintrafficReadApiSearchKey
 import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiSearchKey;
 import org.rutebanken.tiamat.model.EntityInVersionStructure;
 import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PrivateCodeStructure;
 import org.rutebanken.tiamat.model.SiteRefStructure;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.TopographicPlace;
@@ -95,13 +96,20 @@ public class FintrafficSearchKeyService implements SearchKeyService {
                         Stream.of(parentSearchKey.areaCodes())
                 ).distinct().toArray(String[]::new);
 
-                return new FintrafficReadApiSearchKey(mergedTransportModes, mergedAreaCodes);
+                String[] mergedMunicipalityCodes = Stream.concat(
+                        Stream.of(stopPlaceSearchKey.municipalityCodes()),
+                        Stream.of(parentSearchKey.municipalityCodes())
+                ).distinct().toArray(String[]::new);
+
+                return new FintrafficReadApiSearchKey(mergedTransportModes, mergedAreaCodes, mergedMunicipalityCodes);
             } else {
                 return stopPlaceSearchKey;
             }
         } else if (entity instanceof Parking) {
             // For Parking, use parent StopPlace search key if available
             return searchKeyFromParent.orElse(FintrafficReadApiSearchKey.empty());
+        } else if (entity instanceof TopographicPlace) {
+            return FintrafficReadApiSearchKey.empty();
         } else {
             return FintrafficReadApiSearchKey.empty();
         }
@@ -146,7 +154,15 @@ public class FintrafficSearchKeyService implements SearchKeyService {
                 : new String[]{};
         Optional<Point> stopPlaceCentroid = Optional.ofNullable(stopPlace.getCentroid());
         Optional<String[]> areaCodes = stopPlaceCentroid.map(this::getAdministrativeZonesForPoint);
-        return new FintrafficReadApiSearchKey(transportModes, areaCodes.orElse(new String[]{}));
+
+        String[] municipalityCodes = Optional.ofNullable(stopPlace.getTopographicPlace())
+                .map(TopographicPlace::getPrivateCode)
+                .map(PrivateCodeStructure::getValue)
+                .filter(Objects::nonNull)
+                .map(code -> new String[]{code})
+                .orElse(new String[]{});
+
+        return new FintrafficReadApiSearchKey(transportModes, areaCodes.orElse(new String[]{}), municipalityCodes);
     }
 
     private String createJSONString(ReadApiSearchKey searchKey) {

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyService.java
@@ -158,7 +158,6 @@ public class FintrafficSearchKeyService implements SearchKeyService {
         String[] municipalityCodes = Optional.ofNullable(stopPlace.getTopographicPlace())
                 .map(TopographicPlace::getPrivateCode)
                 .map(PrivateCodeStructure::getValue)
-                .filter(Objects::nonNull)
                 .map(code -> new String[]{code})
                 .orElse(new String[]{});
 

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingService.java
@@ -122,6 +122,7 @@ public class ReadApiNetexMarshallingService {
             records.add(createEntityRecord(stopPlace, status, searchKey));
             return records;
         }
+        // TopographicPlace, Parking, etc. — single record per entity, no ServiceFrame sub-elements
         return List.of(createEntityRecord(entity, status, searchKey));
     }
 

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryService.java
@@ -24,14 +24,17 @@ public class ReadApiNetexPublicationDeliveryService {
     // Predefined string constants for collection tags
     private static final String COLLECTION_TAG_SCHEDULED_STOP_POINTS = "<scheduledStopPoints/>";
     private static final String COLLECTION_TAG_STOP_ASSIGNMENTS = "<stopAssignments/>";
+    private static final String COLLECTION_TAG_TOPOGRAPHIC_PLACES = "<topographicPlaces/>";
     private static final String COLLECTION_TAG_STOP_PLACES = "<stopPlaces/>";
     private static final String COLLECTION_TAG_PARKINGS = "<parkings/>";
     private static final byte[] START_TAG_SCHEDULED_STOP_POINTS = "<scheduledStopPoints>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] START_TAG_STOP_ASSIGNMENTS = "<stopAssignments>".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] START_TAG_TOPOGRAPHIC_PLACES = "<topographicPlaces>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] START_TAG_STOP_PLACES = "<stopPlaces>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] START_TAG_PARKINGS = "<parkings>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] END_TAG_SCHEDULED_STOP_POINTS = "</scheduledStopPoints>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] END_TAG_STOP_ASSIGNMENTS = "</stopAssignments>".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] END_TAG_TOPOGRAPHIC_PLACES = "</topographicPlaces>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] END_TAG_STOP_PLACES = "</stopPlaces>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] END_TAG_PARKINGS = "</parkings>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] NEWLINE = "\n".getBytes(StandardCharsets.UTF_8);
@@ -60,6 +63,7 @@ public class ReadApiNetexPublicationDeliveryService {
                                 <DefaultLanguage>{defaultLanguage}</DefaultLanguage>
                             </DefaultLocale>
                         </FrameDefaults>
+                        <topographicPlaces/>
                         <stopPlaces/>
                         <parkings/>
                     </SiteFrame>
@@ -103,6 +107,7 @@ public class ReadApiNetexPublicationDeliveryService {
         return switch (type) {
             case "ScheduledStopPoint" -> COLLECTION_TAG_SCHEDULED_STOP_POINTS;
             case "PassengerStopAssignment" -> COLLECTION_TAG_STOP_ASSIGNMENTS;
+            case "TopographicPlace" -> COLLECTION_TAG_TOPOGRAPHIC_PLACES;
             case "StopPlace" -> COLLECTION_TAG_STOP_PLACES;
             case "Parking" -> COLLECTION_TAG_PARKINGS;
             default -> throw new IllegalArgumentException("Unsupported type for collection tag: " + type);
@@ -113,6 +118,7 @@ public class ReadApiNetexPublicationDeliveryService {
         return switch (type) {
             case "ScheduledStopPoint" -> START_TAG_SCHEDULED_STOP_POINTS;
             case "PassengerStopAssignment" -> START_TAG_STOP_ASSIGNMENTS;
+            case "TopographicPlace" -> START_TAG_TOPOGRAPHIC_PLACES;
             case "StopPlace" -> START_TAG_STOP_PLACES;
             case "Parking" -> START_TAG_PARKINGS;
             default -> throw new IllegalArgumentException("Unsupported type for collection start tag: " + type);
@@ -123,6 +129,7 @@ public class ReadApiNetexPublicationDeliveryService {
         return switch (type) {
             case "ScheduledStopPoint" -> END_TAG_SCHEDULED_STOP_POINTS;
             case "PassengerStopAssignment" -> END_TAG_STOP_ASSIGNMENTS;
+            case "TopographicPlace" -> END_TAG_TOPOGRAPHIC_PLACES;
             case "StopPlace" -> END_TAG_STOP_PLACES;
             case "Parking" -> END_TAG_PARKINGS;
             default -> throw new IllegalArgumentException("Unsupported type for collection end tag: " + type);
@@ -133,6 +140,7 @@ public class ReadApiNetexPublicationDeliveryService {
         String trimmed = new String(bytes, StandardCharsets.UTF_8).trim();
         if (trimmed.equals(COLLECTION_TAG_SCHEDULED_STOP_POINTS)
                 || trimmed.equals(COLLECTION_TAG_STOP_ASSIGNMENTS)
+                || trimmed.equals(COLLECTION_TAG_TOPOGRAPHIC_PLACES)
                 || trimmed.equals(COLLECTION_TAG_STOP_PLACES)
                 || trimmed.equals(COLLECTION_TAG_PARKINGS)) {
             return new byte[]{};

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/batch/ReadApiBatchConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/batch/ReadApiBatchConfig.java
@@ -4,6 +4,7 @@ import org.rutebanken.tiamat.ext.fintraffic.api.ReadApiNetexMarshallingService;
 import org.rutebanken.tiamat.ext.fintraffic.api.repository.NetexRepository;
 import org.rutebanken.tiamat.repository.ParkingRepository;
 import org.rutebanken.tiamat.repository.StopPlaceRepository;
+import org.rutebanken.tiamat.repository.TopographicPlaceRepository;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,12 +17,14 @@ public class ReadApiBatchConfig {
     public ReadApiBatchUpdateService readApiBatchUpdateService(
             ReadApiNetexMarshallingService marshallingService,
             StopPlaceRepository stopPlaceRepository,
-            ParkingRepository parkingRepository
+            ParkingRepository parkingRepository,
+            TopographicPlaceRepository topographicPlaceRepository
     ) {
         return new ReadApiBatchUpdateService(
                 marshallingService,
                 stopPlaceRepository,
-                parkingRepository
+                parkingRepository,
+                topographicPlaceRepository
         );
     }
 

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/batch/ReadApiBatchUpdateService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/batch/ReadApiBatchUpdateService.java
@@ -3,14 +3,18 @@ package org.rutebanken.tiamat.ext.fintraffic.api.batch;
 import org.rutebanken.tiamat.exporter.params.ExportParams;
 import org.rutebanken.tiamat.exporter.params.ParkingSearch;
 import org.rutebanken.tiamat.exporter.params.StopPlaceSearch;
+import org.rutebanken.tiamat.exporter.params.TopographicPlaceSearch;
 import org.rutebanken.tiamat.ext.fintraffic.api.ReadApiNetexMarshallingService;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiEntityInRecord;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiEntityStatus;
 import org.rutebanken.tiamat.model.EntityInVersionStructure;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.StopPlace;
+import org.rutebanken.tiamat.model.TopographicPlace;
+import org.rutebanken.tiamat.model.TopographicPlaceTypeEnumeration;
 import org.rutebanken.tiamat.repository.ParkingRepository;
 import org.rutebanken.tiamat.repository.StopPlaceRepository;
+import org.rutebanken.tiamat.repository.TopographicPlaceRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,14 +33,17 @@ public class ReadApiBatchUpdateService {
     private final ReadApiNetexMarshallingService marshallingService;
     private final StopPlaceRepository stopPlaceRepository;
     private final ParkingRepository parkingRepository;
+    private final TopographicPlaceRepository topographicPlaceRepository;
 
     public ReadApiBatchUpdateService(
             ReadApiNetexMarshallingService marshallingService,
             StopPlaceRepository stopPlaceRepository,
-            ParkingRepository parkingRepository) {
+            ParkingRepository parkingRepository,
+            TopographicPlaceRepository topographicPlaceRepository) {
         this.marshallingService = marshallingService;
         this.stopPlaceRepository = stopPlaceRepository;
         this.parkingRepository = parkingRepository;
+        this.topographicPlaceRepository = topographicPlaceRepository;
     }
 
     /**
@@ -81,6 +88,30 @@ public class ReadApiBatchUpdateService {
 
         Iterator<Parking> parkingIterator = parkingRepository.scrollParkings(parkingSearch);
         return processEntitiesInBatches(parkingIterator, batchSize, batchConsumer, "Parking");
+    }
+
+    /**
+     * Process municipality TopographicPlaces in batches.
+     *
+     * Unlike StopPlaces and Parkings which use scrollable results for large datasets,
+     * TopographicPlaces are loaded as a list since municipalities are few (~300 in Finland).
+     *
+     * @param batchSize Number of entities to process before flushing to database
+     * @param batchConsumer Consumer that handles each batch (typically database upsert)
+     * @return Statistics about the processing
+     */
+    @Transactional(readOnly = true)
+    public ProcessingStats processTopographicPlacesInBatches(int batchSize, Consumer<List<ReadApiEntityInRecord>> batchConsumer) {
+        TopographicPlaceSearch search = TopographicPlaceSearch.newTopographicPlaceSearchBuilder()
+                .versionValidity(ExportParams.VersionValidity.CURRENT)
+                .build();
+
+        List<TopographicPlace> municipalities = topographicPlaceRepository.findTopographicPlace(search).stream()
+                .filter(tp -> tp.getTopographicPlaceType() == TopographicPlaceTypeEnumeration.MUNICIPALITY)
+                .toList();
+
+        Iterator<TopographicPlace> municipalityIterator = municipalities.iterator();
+        return processEntitiesInBatches(municipalityIterator, batchSize, batchConsumer, "TopographicPlace");
     }
 
     /**

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/batch/ReadApiBatchUpdateTask.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/batch/ReadApiBatchUpdateTask.java
@@ -53,12 +53,30 @@ public class ReadApiBatchUpdateTask implements ApplicationRunner {
 
         try {
             // Step 1: Mark all rows as STALE
-            logger.info("Step 1/4: Marking all entities as STALE");
+            logger.info("Step 1/5: Marking all entities as STALE");
             int markedStale = netexRepository.markAllEntitiesAsStale();
             logger.info("Marked {} entities as STALE", markedStale);
 
-            // Step 2: Process StopPlaces in batches (streaming)
-            logger.info("Step 2/4: Processing StopPlaces (this may take 1-2 hours)");
+            // Step 2: Process TopographicPlaces (municipalities only)
+            logger.info("Step 2/5: Processing TopographicPlaces");
+            ReadApiBatchUpdateService.ProcessingStats topographicPlaceStats =
+                readApiBatchUpdateService.processTopographicPlacesInBatches(DEFAULT_BATCH_SIZE, batch -> {
+                    readApiBatchWriteService.upsertBatch(batch);
+                    logger.debug("Upserted batch of {} TopographicPlace records", batch.size());
+                });
+
+            totalEntitiesProcessed += topographicPlaceStats.entitiesProcessed();
+            totalRecordsGenerated += topographicPlaceStats.recordsGenerated();
+            totalEntitiesFailed += topographicPlaceStats.entitiesFailed();
+
+            logger.info("TopographicPlace processing completed: {} entities → {} records ({} failed) in {}",
+                topographicPlaceStats.entitiesProcessed(),
+                topographicPlaceStats.recordsGenerated(),
+                topographicPlaceStats.entitiesFailed(),
+                formatDuration(topographicPlaceStats.duration()));
+
+            // Step 3: Process StopPlaces in batches (streaming)
+            logger.info("Step 3/5: Processing StopPlaces (this may take 1-2 hours)");
             ReadApiBatchUpdateService.ProcessingStats stopPlaceStats =
                 readApiBatchUpdateService.processStopPlacesInBatches(DEFAULT_BATCH_SIZE, batch -> {
                     readApiBatchWriteService.upsertBatch(batch);
@@ -75,8 +93,8 @@ public class ReadApiBatchUpdateTask implements ApplicationRunner {
                 stopPlaceStats.entitiesFailed(),
                 formatDuration(stopPlaceStats.duration()));
 
-            // Step 3: Process Parkings in batches (streaming)
-            logger.info("Step 3/4: Processing Parkings");
+            // Step 4: Process Parkings in batches (streaming)
+            logger.info("Step 4/5: Processing Parkings");
             ReadApiBatchUpdateService.ProcessingStats parkingStats =
                 readApiBatchUpdateService.processParkingsInBatches(DEFAULT_BATCH_SIZE, batch -> {
                     readApiBatchWriteService.upsertBatch(batch);
@@ -93,8 +111,8 @@ public class ReadApiBatchUpdateTask implements ApplicationRunner {
                 parkingStats.entitiesFailed(),
                 formatDuration(parkingStats.duration()));
 
-            // Step 4: Clean up deleted entities
-            logger.info("Step 4/4: Cleaning up stale entities");
+            // Step 5: Clean up deleted entities
+            logger.info("Step 5/5: Cleaning up stale entities");
             int deletedCount = -1;
             if (totalEntitiesFailed > 0) {
                 logger.warn("There were {} failed entities during processing. " +

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/model/FintrafficReadApiSearchKey.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/model/FintrafficReadApiSearchKey.java
@@ -4,9 +4,10 @@ package org.rutebanken.tiamat.ext.fintraffic.api.model;
  * Fintraffic Read API search key.
  * @param transportModes Transport modes
  * @param areaCodes Area codes
+ * @param municipalityCodes Municipality codes (e.g. "091" for Helsinki)
  */
-public record FintrafficReadApiSearchKey(String[] transportModes, String[] areaCodes) implements ReadApiSearchKey {
+public record FintrafficReadApiSearchKey(String[] transportModes, String[] areaCodes, String[] municipalityCodes) implements ReadApiSearchKey {
     public static FintrafficReadApiSearchKey empty() {
-        return new FintrafficReadApiSearchKey(new String[]{}, new String[]{});
+        return new FintrafficReadApiSearchKey(new String[]{}, new String[]{}, new String[]{});
     }
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/repository/FintrafficNetexRepository.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/repository/FintrafficNetexRepository.java
@@ -28,6 +28,7 @@ public class FintrafficNetexRepository extends AbstractNetexRepository {
             WHERE status IN ('STALE', 'CURRENT') AND type IN (
                 'ScheduledStopPoint',
                 'PassengerStopAssignment',
+                'TopographicPlace',
                 'StopPlace',
                 'Parking'
             )
@@ -35,15 +36,30 @@ public class FintrafficNetexRepository extends AbstractNetexRepository {
 
         List<Object> params = new ArrayList<>();
 
-        if (searchKey instanceof FintrafficReadApiSearchKey(String[] transportModes, String[] areaCodes)) {
+        if (searchKey instanceof FintrafficReadApiSearchKey(String[] transportModes, String[] areaCodes, String[] municipalityCodes)) {
+            List<String> filters = new ArrayList<>();
+
             if (transportModes != null && transportModes.length > 0) {
-                sql.append(" AND search_key->'transportModes' ??| ?::text[] ");
+                filters.add("search_key->'transportModes' ??| ?::text[]");
                 params.add(transportModes);
             }
 
             if (areaCodes != null && areaCodes.length > 0) {
-                sql.append(" AND search_key->'areaCodes' ??| ?::text[] ");
+                filters.add("search_key->'areaCodes' ??| ?::text[]");
                 params.add(areaCodes);
+            }
+
+            if (municipalityCodes != null && municipalityCodes.length > 0) {
+                filters.add("search_key->'municipalityCodes' ??| ?::text[]");
+                params.add(municipalityCodes);
+            }
+
+            if (!filters.isEmpty()) {
+                // TopographicPlace is always included regardless of search filters because it provides geographic
+                // context needed for all stop place data
+                sql.append(" AND (type = 'TopographicPlace' OR (");
+                sql.append(String.join(" AND ", filters));
+                sql.append("))");
             }
         }
 
@@ -52,9 +68,10 @@ public class FintrafficNetexRepository extends AbstractNetexRepository {
             CASE type
                 WHEN 'ScheduledStopPoint' THEN 1
                 WHEN 'PassengerStopAssignment' THEN 2
-                WHEN 'StopPlace' THEN 3
-                WHEN 'Parking' THEN 4
-                ELSE 5
+                WHEN 'TopographicPlace' THEN 3
+                WHEN 'StopPlace' THEN 4
+                WHEN 'Parking' THEN 5
+                ELSE 6
             END
         """);
 


### PR DESCRIPTION
### Summary

Adds municipality TopographicPlace entities to the Fintraffic Read API NeTEx export (`GET /fintraffic/v1/stops`) and exposes a new `municipalityCodes` query parameter for filtering StopPlaces by Finnish municipality code.

- TopographicPlace entities (municipalities only) are now included in the `<topographicPlaces>` collection within the SiteFrame
- A new `municipalityCodes` query parameter filters StopPlaces by the linked TopographicPlace's PrivateCode (e.g. `?municipalityCodes=091`)
- TopographicPlaces are always returned as reference data, regardless of filters
- The batch rebuild pipeline now processes TopographicPlaces alongside StopPlaces and Parkings
- Input validation added for `municipalityCodes` (configurable regex, default `\d{3}`)

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Issue

**Motivation:** The Read API export was missing municipality TopographicPlace data. API consumers need municipality reference data and the ability to filter stops by municipality code.

**Technical approach:**
- **Batch pipeline:** `ReadApiBatchUpdateService.processTopographicPlacesInBatches()` fetches all CURRENT MUNICIPALITY-type TopographicPlaces, marshals them to NeTEx XML, and upserts into `ext_fintraffic_netex_entity`
- **Search key:** `FintrafficSearchKeyService` extracts the municipality code from `StopPlace → TopographicPlace → PrivateCode → value` and stores it in the JSONB search key
- **SQL query:** `FintrafficNetexRepository` adds TopographicPlace to the entity type list, bypasses all filters for TopographicPlace rows (`type = 'TopographicPlace' OR <filters>`), and adds JSONB filtering for `municipalityCodes`
- **Streaming:** TopographicPlace is ordered between PassengerStopAssignment and StopPlace in the ORDER BY clause to match the XML template's linear scanning algorithm
- **Validation:** `municipalityCodes` validated via configurable regex (`tiamat.ext.fintraffic.municipality-code-pattern`, default `\d{3}`)

### Unit tests

- `FintrafficApiControllerTest`: Updated to include TopographicPlace in the streaming output test; added 4 new tests for validation (invalid municipality code, too short, invalid area code, valid municipality code)
- `FintrafficReadApiSearchKeyTest`: Updated constructor calls for the new 3-field record; added assertions for `municipalityCodes`
- All existing tests continue to pass
- Manual verification: compilation succeeds, all related test classes pass

### Documentation

- Inline Javadoc added to `processTopographicPlacesInBatches()` explaining the municipality filtering approach
- Comments in `FintrafficNetexRepository` explain the TopographicPlace filter bypass pattern and ORDER BY rationale
