### PR TITLE
Add Micrometer CloudWatch metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,35 @@ Create a new file according to the flyway documentation in the folder `resources
 Commit the migration together with code changes that requires this schema change. Follow the naming convention.
 
 
+## Metrics
+
+Tiamat uses Micrometer for application metrics.
+
+### CloudWatch
+
+`micrometer-registry-cloudwatch2` is included as a dependency but is **only activated when the
+`management.cloudwatch.metrics.export.namespace` property is set**. Without this property
+the CloudWatch registry is not injected and no metrics are exported to CloudWatch.
+
+Example configuration:
+
+```properties
+management.cloudwatch.metrics.export.namespace=tiamat
+management.cloudwatch.metrics.export.step=1m
+
+spring.cloud.aws.cloudwatch.region=eu-north-1
+# Optional: override endpoint, e.g. for LocalStack in development
+#spring.cloud.aws.cloudwatch.endpoint=http://localhost:4566
+```
+
+AWS credentials are resolved through the standard AWS credential chain.
+For local development with LocalStack you can supply static credentials:
+
+```properties
+spring.cloud.aws.credentials.access-key=localstack
+spring.cloud.aws.credentials.secret-key=localstack
+```
+
 ## Tiamat scripts
 Various queries and scripts related to tiamat, has been collected here:
 https://github.com/entur/tiamat-scripts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - DEBUG=${DEBUG-}
       - DOCKER_HOST=unix:///var/run/docker.sock
       - DISABLE_EVENTS=1
-      - SERVICES=s3
+      - SERVICES=s3,cloudwatch
       - AWS_ACCESS_KEY_ID=localstack
       - AWS_SECRET_ACCESS_KEY=localstack
       - AWS_DEFAULT_REGION=eu-north-1

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,10 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-cloudwatch2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-spring</artifactId>
             <version>${hazelcast.version}</version>


### PR DESCRIPTION
### Summary

Add Micrometer CloudWatch metrics

`micrometer-registry-cloudwatch2` is included as a dependency but is **only activated when the
`management.cloudwatch.metrics.export.namespace` property is set**. Without this property
the CloudWatch registry is not injected and no metrics are exported to CloudWatch.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

Add support for sending Micrometer metrics to AWS CloudWatch

### Unit tests

No changes in application logic. All existing tests pass.

### Documentation

Documentation in README.md has been updated with a section about Metrics


