### PR TITLE
ext/Use URI templates in WebClient calls to ensure correct metrics tagging

### DIFF
--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/TrivoreAuthorizations.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/TrivoreAuthorizations.java
@@ -117,7 +117,8 @@ public class TrivoreAuthorizations {
     private List<GroupMembership> loadUsersGroupMemberships(UserIdentifier userIdentifier) throws CacheLoadingException {
         Optional<List<GroupMembership>> groupMembership = executeRequest(
                 HttpMethod.GET,
-                oidcServerUri + "/api/rest/v1/user/" + userIdentifier.userId() + "/groupmembership",
+                oidcServerUri + "/api/rest/v1/user/{userId}/groupmembership",
+                new String[]{ userIdentifier.userId() },
                 Map.of("Authorization", "Basic " + basicAuthenticationHeaderValue(),
                         "Content-Type", "application/json"),
                 new ParameterizedTypeReference<>() {});
@@ -130,7 +131,8 @@ public class TrivoreAuthorizations {
     private ExternalPermission loadExternalPermission(PermissionIdentifiers permissionIdentifiers) throws CacheLoadingException {
         Optional<ExternalPermission> externalPermission = executeRequest(
                 HttpMethod.GET,
-                oidcServerUri + "/api/rest/v1/externalpermission/group/" + permissionIdentifiers.permissionGroupId() + "/permission/" + permissionIdentifiers.permissionId(),
+                oidcServerUri + "/api/rest/v1/externalpermission/group/{permissionGroupId}/permission/{permissionId}",
+                new String[]{ permissionIdentifiers.permissionGroupId(), permissionIdentifiers.permissionId() },
                 Map.of("Authorization", "Basic " + basicAuthenticationHeaderValue(),
                         "Content-Type", "application/json"),
                 new ParameterizedTypeReference<>() {});
@@ -144,7 +146,8 @@ public class TrivoreAuthorizations {
     private List<ExternalPermissionGrant> loadUsersExternalPermissionGrants(UserIdentifier userIdentifier) throws CacheLoadingException {
         Optional<List<ExternalPermissionGrant>> userExternalPermissionGrants = executeRequest(
                 HttpMethod.GET,
-                oidcServerUri + "/api/rest/v1/user/" + userIdentifier.userId() + "/externalpermissions",
+                oidcServerUri + "/api/rest/v1/user/{userId}/externalpermissions",
+                new String[]{ userIdentifier.userId() },
                 Map.of("Authorization", "Basic " + basicAuthenticationHeaderValue(),
                         "Content-Type", "application/json"),
                 new ParameterizedTypeReference<>() {});
@@ -183,10 +186,10 @@ public class TrivoreAuthorizations {
         }
     }
 
-    private <T> Optional<T> executeRequest(HttpMethod method, String uri, Map<String, String> headers, ParameterizedTypeReference<T> type) {
+    private <T> Optional<T> executeRequest(HttpMethod method, String uri, Object[] uriVariables, Map<String, String> headers, ParameterizedTypeReference<T> type) {
         try {
             return httpClient.method(method)
-                    .uri(uri)
+                    .uri(uri, uriVariables)
                     .accept(org.springframework.http.MediaType.APPLICATION_JSON)
                     .headers(requestHeaders -> headers.forEach(requestHeaders::set))
                     .retrieve()


### PR DESCRIPTION
### Summary

Use URI templates in WebClient calls to ensure correct metrics tagging.

Before this change, the `http.client.requests` metric's `uri` tag was set to the full expanded URI (e.g. /api/rest/v1/user/test-subject/groupmembership), producing a new tag value per unique user/entity — causing high cardinality in metrics.

After this change, WebClient retains the URI template (e.g. /api/rest/v1/user/{userId}/groupmembership) as the uri tag value, grouping all requests to the same endpoint under one tag value regardless of path variable values.


### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

WebClient stores the URI template in request attributes when .uri(String template, Object... vars) is used. 

Spring's DefaultClientRequestObservationConvention reads this attribute to produce a low-cardinality uri tag. 

When URI.create(uri) is used directly, the attribute is never set and the full expanded URI is used instead.
Reference: https://docs.spring.io/spring-framework/reference/integration/observability.html#http-client.webclient

### Unit tests

- All existing unit tests pass after the change

### Documentation

N/A


