### PR TITLE
Fintraffic Feature/ext authorization municipalities

### DIFF
--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficAuthorizationServiceTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficAuthorizationServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.rutebanken.tiamat.exporter.params.TopographicPlaceSearch;
@@ -52,6 +53,18 @@ class FintrafficAuthorizationServiceTest {
         return place;
     }
 
+    private static @Nonnull TopographicPlace getMunicipalityTopographicPlace(String municipalityCode,
+                                                                             Coordinate[] coordinates) {
+        TopographicPlace place = new TopographicPlace();
+        GeometryFactory fact = new GeometryFactory();
+        LinearRing ring = fact.createLinearRing(coordinates);
+        Polygon polygon = new Polygon(ring, null, fact);
+        place.setMultiSurface(new MultiPolygon(new Polygon[]{polygon}, fact));
+        place.setTopographicPlaceType(TopographicPlaceTypeEnumeration.MUNICIPALITY);
+        place.setPrivateCode(new org.rutebanken.tiamat.model.PrivateCodeStructure(municipalityCode, "type"));
+        return place;
+    }
+
     private static @Nonnull Point getPoint(Coordinate coordinate) {
         GeometryFactory fact = new GeometryFactory();
         return fact.createPoint(coordinate);
@@ -80,12 +93,25 @@ class FintrafficAuthorizationServiceTest {
     }
 
     private static FintrafficAuthorizationService getAuthorizationService() {
+        return getAuthorizationService(true, true);
+    }
+
+    private static FintrafficAuthorizationService getAuthorizationService(boolean codespaceEnabled, boolean municipalityEnabled) {
         TopographicPlaceRepository topographicPlaceRepositoryMock = mock(TopographicPlaceRepository.class);
         TrivoreAuthorizations trivoreAuthorizationsMock = mock(TrivoreAuthorizations.class);
 
-        TopographicPlace place = getTopographicPlace();
-        when(topographicPlaceRepositoryMock.findTopographicPlace(any(TopographicPlaceSearch.class))).thenReturn(List.of(place));
+        TopographicPlace regionPlace = getTopographicPlace();
+        TopographicPlace municipalityPlace = getMunicipalityTopographicPlace("091", new Coordinate[] {
+                new Coordinate(2, 2),
+                new Coordinate(3, 2),
+                new Coordinate(3, 3),
+                new Coordinate(2, 3),
+                new Coordinate(2, 2),
+        });
+        when(topographicPlaceRepositoryMock.findTopographicPlace(any(TopographicPlaceSearch.class)))
+                .thenReturn(List.of(regionPlace, municipalityPlace));
         when(trivoreAuthorizationsMock.getAccessibleCodespaces()).thenReturn(Set.of("ABC", "XYZ"));
+        when(trivoreAuthorizationsMock.getAccessibleMunicipalityCodes()).thenReturn(Set.of("091"));
 
         when(trivoreAuthorizationsMock.hasAccess(matches("StopPlace"), matches("BUS"), eq(TrivorePermission.MANAGE), anyBoolean())).thenReturn(true);
         when(trivoreAuthorizationsMock.hasAccess(matches("Parking"), matches("\\{all\\}"), eq(TrivorePermission.MANAGE), anyBoolean())).thenReturn(true);
@@ -94,7 +120,9 @@ class FintrafficAuthorizationServiceTest {
 
         return new FintrafficAuthorizationService(
                 trivoreAuthorizationsMock,
-                topographicPlaceRepositoryMock
+                topographicPlaceRepositoryMock,
+                codespaceEnabled,
+                municipalityEnabled
         );
     }
 
@@ -152,5 +180,59 @@ class FintrafficAuthorizationServiceTest {
         stopPlaceWithQuayAndNestedStopPlace.setQuays(Set.of(quay));
         FintrafficAuthorizationService authorizationService = getAuthorizationService();
         assertThat(authorizationService.canEditEntity(stopPlaceWithQuayAndNestedStopPlace), equalTo(false));
+    }
+
+    @Test
+    public void testCanEditEntityByMunicipalityCodes() {
+        // Point (2.5, 2.5) is inside municipality polygon (2,2)-(3,3) but outside region polygon (0,0)-(1,1)
+        StopPlace stopPlace = getStopPlace("FSR:StopPlace:10", VehicleModeEnumeration.BUS, getPoint(new Coordinate(2.5, 2.5)));
+        FintrafficAuthorizationService authorizationService = getAuthorizationService();
+        assertThat(authorizationService.canEditEntity(stopPlace), equalTo(true));
+    }
+
+    @Test
+    public void testCanEditEntityByMunicipalityCodesOutOfBounds() {
+        // Point (5, 5) is outside both region and municipality polygons
+        StopPlace stopPlace = getStopPlace("FSR:StopPlace:11", VehicleModeEnumeration.BUS, getPoint(new Coordinate(5, 5)));
+        FintrafficAuthorizationService authorizationService = getAuthorizationService();
+        assertThat(authorizationService.canEditEntity(stopPlace), equalTo(false));
+    }
+
+    @Test
+    public void testCanEditEntityByEitherCodespaceOrMunicipality() {
+        // Point (0.5, 0.5) is inside region polygon — should pass via codespace check
+        StopPlace stopPlaceInRegion = getStopPlace("FSR:StopPlace:12", VehicleModeEnumeration.BUS, getPoint(new Coordinate(0.5, 0.5)));
+        // Point (2.5, 2.5) is inside municipality polygon — should pass via municipality check
+        StopPlace stopPlaceInMunicipality = getStopPlace("FSR:StopPlace:13", VehicleModeEnumeration.BUS, getPoint(new Coordinate(2.5, 2.5)));
+
+        FintrafficAuthorizationService authorizationService = getAuthorizationService();
+        assertThat(authorizationService.canEditEntity(stopPlaceInRegion), equalTo(true));
+        assertThat(authorizationService.canEditEntity(stopPlaceInMunicipality), equalTo(true));
+    }
+
+    @Test
+    public void testCodespaceOnlyMode() {
+        FintrafficAuthorizationService authorizationService = getAuthorizationService(true, false);
+        // Point inside region (codespace) — allowed
+        assertThat(authorizationService.canEditEntity(getPoint(new Coordinate(0.5, 0.5))), equalTo(true));
+        // Point inside municipality area but municipality auth disabled — denied
+        assertThat(authorizationService.canEditEntity(getPoint(new Coordinate(2.5, 2.5))), equalTo(false));
+    }
+
+    @Test
+    public void testMunicipalityOnlyMode() {
+        FintrafficAuthorizationService authorizationService = getAuthorizationService(false, true);
+        // Point inside region but codespace auth disabled — denied
+        assertThat(authorizationService.canEditEntity(getPoint(new Coordinate(0.5, 0.5))), equalTo(false));
+        // Point inside municipality area — allowed
+        assertThat(authorizationService.canEditEntity(getPoint(new Coordinate(2.5, 2.5))), equalTo(true));
+    }
+
+    @Test
+    public void testBothAuthorizationMethodsDisabled() {
+        FintrafficAuthorizationService authorizationService = getAuthorizationService(false, false);
+        // Both disabled — all geographic edits denied
+        assertThat(authorizationService.canEditEntity(getPoint(new Coordinate(0.5, 0.5))), equalTo(false));
+        assertThat(authorizationService.canEditEntity(getPoint(new Coordinate(2.5, 2.5))), equalTo(false));
     }
 }

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/TrivoreAuthorizationsTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/TrivoreAuthorizationsTest.java
@@ -45,7 +45,7 @@ class TrivoreAuthorizationsTest {
                             case "/api/rest/v1/user/test-subject/groupmembership" -> Mono.just(
                                     ClientResponse.create(HttpStatus.OK)
                                             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                                            .body("[{\"id\": \"test-id\",\"name\": \"group-name\",\"customFields\":{\"codespaces\": \"ABC,XYZ\"}}]")
+                                            .body("[{\"id\": \"test-id\",\"name\": \"group-name\",\"customFields\":{\"codespaces\": \"ABC,XYZ\",\"municipalityCodes\": \"091,049\"}}]")
                                             .build()
                             );
                             case "/api/rest/v1/user/test-subject/externalpermissions" -> Mono.just(
@@ -106,6 +106,12 @@ class TrivoreAuthorizationsTest {
     void testGetAccessibleCodespaces() {
         Set<String> codespaces = trivoreAuthorizations.getAccessibleCodespaces();
         assertThat(codespaces, equalTo(Set.of("ABC", "XYZ")));
+    }
+
+    @Test
+    void testGetAccessibleMunicipalityCodes() {
+        Set<String> municipalityCodes = trivoreAuthorizations.getAccessibleMunicipalityCodes();
+        assertThat(municipalityCodes, equalTo(Set.of("091", "049")));
     }
 
     @Test

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/model/GroupMembershipTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/model/GroupMembershipTest.java
@@ -1,0 +1,71 @@
+package org.rutebanken.tiamat.ext.fintraffic.auth.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+class GroupMembershipTest {
+
+    private static GroupMembership createMembership(String codespaces, String municipalityCodes) {
+        Map<String, Object> customFields = Map.of(
+                "codespaces", codespaces,
+                "municipalityCodes", municipalityCodes
+        );
+        return new GroupMembership("g1", "Test Group", "desc", true, null, null, customFields);
+    }
+
+    @Test
+    void testValidCodespaces() {
+        GroupMembership gm = createMembership("ABC,XYZ,ÅÄÖ", "");
+        assertThat(gm.getCodespaces(), equalTo(Set.of("ABC", "XYZ", "ÅÄÖ")));
+    }
+
+    @Test
+    void testInvalidCodespacesSkipped() {
+        GroupMembership gm = createMembership("abc,AB,1234", "");
+        assertThat(gm.getCodespaces(), empty());
+    }
+
+    @Test
+    void testMixedCodespaces() {
+        GroupMembership gm = createMembership("ABC, invalid, XYZ, ab", "");
+        assertThat(gm.getCodespaces(), equalTo(Set.of("ABC", "XYZ")));
+    }
+
+    @Test
+    void testValidMunicipalityCodes() {
+        GroupMembership gm = createMembership("", "091,049,1001");
+        assertThat(gm.getMunicipalityCodes(), equalTo(Set.of("091", "049", "1001")));
+    }
+
+    @Test
+    void testInvalidMunicipalityCodesSkipped() {
+        GroupMembership gm = createMembership("", "ABC,12,12345");
+        assertThat(gm.getMunicipalityCodes(), empty());
+    }
+
+    @Test
+    void testMixedMunicipalityCodes() {
+        GroupMembership gm = createMembership("", "091, bad, 049, ABCD");
+        assertThat(gm.getMunicipalityCodes(), equalTo(Set.of("091", "049")));
+    }
+
+    @Test
+    void testNullCustomFields() {
+        GroupMembership gm = new GroupMembership("g1", "Test", "desc", true, null, null, null);
+        assertThat(gm.getCodespaces(), empty());
+        assertThat(gm.getMunicipalityCodes(), empty());
+    }
+
+    @Test
+    void testEmptyValues() {
+        GroupMembership gm = createMembership("", "");
+        assertThat(gm.getCodespaces(), empty());
+        assertThat(gm.getMunicipalityCodes(), empty());
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficConstants.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficConstants.java
@@ -1,0 +1,38 @@
+package org.rutebanken.tiamat.ext.fintraffic;
+
+public final class FintrafficConstants {
+
+    public static final String AREA_CODE_REGEX = "[A-ZÅÄÖ]{3}";
+    // 3 digits for normal municipalities, 4 digits for special areas like Haaparanta and Eurooppa
+    public static final String MUNICIPALITY_CODE_REGEX = "\\d{3,4}";
+
+    private FintrafficConstants() {}
+
+    public static boolean isValidAreaCode(String code) {
+        return code != null && code.matches(AREA_CODE_REGEX);
+    }
+
+    public static boolean isValidMunicipalityCode(String code) {
+        return code != null && code.matches(MUNICIPALITY_CODE_REGEX);
+    }
+
+    public static void validateAreaCodes(String[] areaCodes) {
+        if (areaCodes != null) {
+            for (String code : areaCodes) {
+                if (!isValidAreaCode(code)) {
+                    throw new IllegalArgumentException("Invalid areaCode: " + code);
+                }
+            }
+        }
+    }
+
+    public static void validateMunicipalityCodes(String[] municipalityCodes) {
+        if (municipalityCodes != null) {
+            for (String code : municipalityCodes) {
+                if (!isValidMunicipalityCode(code)) {
+                    throw new IllegalArgumentException("Invalid municipalityCode: " + code);
+                }
+            }
+        }
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficApiController.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficApiController.java
@@ -1,6 +1,7 @@
 package org.rutebanken.tiamat.ext.fintraffic.api;
 
 import jakarta.servlet.http.HttpServletResponse;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficConstants;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.FintrafficReadApiSearchKey;
 import org.rutebanken.tiamat.model.VehicleModeEnumeration;
 import org.springframework.context.annotation.Profile;
@@ -17,9 +18,6 @@ import java.nio.charset.StandardCharsets;
 @Controller
 public class FintrafficApiController {
     private final ReadApiNetexPublicationDeliveryService readApiNetexPublicationDeliveryService;
-    private static final String AREA_CODE_REGEX = "[A-ZÅÄÖ]{3}";
-    // 3 digits for normal municipalities, 4 digits for special areas like Haaparanta and Eurooppa
-    private static final String MUNICIPALITY_CODE_REGEX = "\\d{3,4}";
 
     public FintrafficApiController(
             ReadApiNetexPublicationDeliveryService readApiNetexPublicationDeliveryService
@@ -36,8 +34,8 @@ public class FintrafficApiController {
     ) {
         try {
             validateTransportModes(transportMode);
-            validateAreaCodes(areaCode);
-            validateMunicipalityCodes(municipalityCode);
+            FintrafficConstants.validateAreaCodes(areaCode);
+            FintrafficConstants.validateMunicipalityCodes(municipalityCode);
         } catch (IllegalArgumentException e) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             return;
@@ -59,26 +57,6 @@ public class FintrafficApiController {
         if (transportModes != null) {
             for (String mode : transportModes) {
                 VehicleModeEnumeration.fromValue(mode);
-            }
-        }
-    }
-
-    private void validateAreaCodes(String[] areaCodes) {
-        if (areaCodes != null) {
-            for (String code : areaCodes) {
-                if (!code.matches(AREA_CODE_REGEX)) {
-                    throw new IllegalArgumentException("Invalid areaCode: " + code);
-                }
-            }
-        }
-    }
-
-    private void validateMunicipalityCodes(String[] municipalityCodes) {
-        if (municipalityCodes != null) {
-            for (String code : municipalityCodes) {
-                if (!code.matches(MUNICIPALITY_CODE_REGEX)) {
-                    throw new IllegalArgumentException("Invalid municipalityCode: " + code);
-                }
             }
         }
     }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficAuthorizationService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficAuthorizationService.java
@@ -43,12 +43,24 @@ public class FintrafficAuthorizationService implements AuthorizationService {
 
     private final TopographicPlaceRepository topographicPlaceRepository;
 
+    private final boolean codespaceAuthorizationEnabled;
+
+    private final boolean municipalityAuthorizationEnabled;
+
     private final LoadingCache<String, List<TopographicPlace>> fintrafficAdministrativeZoneCache;
 
+    private final LoadingCache<String, Optional<TopographicPlace>> municipalityCache;
+
     public FintrafficAuthorizationService(TrivoreAuthorizations trivoreAuthorizations,
-                                          TopographicPlaceRepository topographicPlaceRepository) {
+                                          TopographicPlaceRepository topographicPlaceRepository,
+                                          boolean codespaceAuthorizationEnabled,
+                                          boolean municipalityAuthorizationEnabled) {
         this.trivoreAuthorizations = trivoreAuthorizations;
         this.topographicPlaceRepository = topographicPlaceRepository;
+        this.codespaceAuthorizationEnabled = codespaceAuthorizationEnabled;
+        this.municipalityAuthorizationEnabled = municipalityAuthorizationEnabled;
+        logger.info("FintrafficAuthorizationService initialized: codespace authorization={}, municipality authorization={}",
+                codespaceAuthorizationEnabled, municipalityAuthorizationEnabled);
         this.fintrafficAdministrativeZoneCache = CacheBuilder.newBuilder()
                 .maximumSize(100)
                 .expireAfterWrite(Duration.ofMinutes(10))
@@ -57,6 +69,16 @@ public class FintrafficAuthorizationService implements AuthorizationService {
                     @Nonnull
                     public List<TopographicPlace> load(@Nonnull String codespace) {
                         return loadTopographicPlaces(codespace);
+                    }
+                });
+        this.municipalityCache = CacheBuilder.newBuilder()
+                .maximumSize(500)
+                .expireAfterWrite(Duration.ofMinutes(10))
+                .build(new CacheLoader<>() {
+                    @Override
+                    @Nonnull
+                    public Optional<TopographicPlace> load(@Nonnull String municipalityCode) {
+                        return loadMunicipalityTopographicPlace(municipalityCode);
                     }
                 });
     }
@@ -68,8 +90,7 @@ public class FintrafficAuthorizationService implements AuthorizationService {
 
     @Override
     public boolean canEditEntities(Collection<? extends EntityStructure> entities) {
-        return trivoreAuthorizations.hasAccess(ENTITY_TYPE_ALL, TRANSPORT_MODE_ALL, MANAGE, true)
-                || entities.stream().allMatch(e -> canEditEntity(e, true));
+        return entities.stream().allMatch(e -> canEditEntity(e, true));
     }
 
     @Override
@@ -142,29 +163,52 @@ public class FintrafficAuthorizationService implements AuthorizationService {
 
     private boolean canEditEntity(Point point, boolean logAuthorizationCheck) {
         logger.trace("FintrafficAuthorizationService.canEditEntity({})", point);
-        Set<String> accessibleCodespaces = trivoreAuthorizations.getAccessibleCodespaces();
+        return (municipalityAuthorizationEnabled && canEditEntityByMunicipalityCode(point, logAuthorizationCheck))
+                || (codespaceAuthorizationEnabled && canEditEntityByCodespace(point, logAuthorizationCheck));
+    }
 
+    private boolean canEditEntityByCodespace(Point point, boolean logAuthorizationCheck) {
+        Set<String> accessibleCodespaces = trivoreAuthorizations.getAccessibleCodespaces();
         if (accessibleCodespaces.isEmpty()) {
-            if (logAuthorizationCheck) {
-                logger.info("User [{}] has no accessible codespaces, cannot edit entity at point {}.", TrivoreAuthorizations.getCurrentSubject(), point);
-            }
-            logger.trace("FintrafficAuthorizationService.canEditEntity({}) codespaces is empty", point);
+            logger.trace("FintrafficAuthorizationService.canEditEntityByCodespace({}) codespaces is empty", point);
             return false;
         }
         boolean result = accessibleCodespaces.stream().anyMatch(codespace ->
                 {
                     try {
                         List<TopographicPlace> topographicPlacesForCodespace = fintrafficAdministrativeZoneCache.get(codespace);
-                        return topographicPlacesForCodespace.stream().anyMatch(tp -> tp.getPolygon() != null && tp.getPolygon().contains(point));
+                        return topographicPlacesForCodespace.stream().anyMatch(tp -> tp.getGeometry() != null && tp.getGeometry().contains(point));
                     } catch (ExecutionException e) {
                         logger.warn("Failed to fetch topographic places for codespaces [{}]", accessibleCodespaces, e);
                         return false;
                     }
                 }
         );
-        if (logAuthorizationCheck) {
-            String isAllowed = result ? "is allowed": "is not allowed";
-            logger.info("User [{}] with codespaces {} {} to edit entity at point {}.", TrivoreAuthorizations.getCurrentSubject(), accessibleCodespaces, isAllowed, point);
+        if (logAuthorizationCheck && result) {
+            logger.info("User [{}] with codespaces {} is allowed to edit entity at point {} (codespace check).",
+                    TrivoreAuthorizations.getCurrentSubject(), accessibleCodespaces, point);
+        }
+        return result;
+    }
+
+    private boolean canEditEntityByMunicipalityCode(Point point, boolean logAuthorizationCheck) {
+        Set<String> municipalityCodes = trivoreAuthorizations.getAccessibleMunicipalityCodes();
+        if (municipalityCodes.isEmpty()) {
+            logger.trace("FintrafficAuthorizationService.canEditEntityByMunicipalityCode({}) municipalityCodes is empty", point);
+            return false;
+        }
+        boolean result = municipalityCodes.stream().anyMatch(code -> {
+            try {
+                Optional<TopographicPlace> tp = municipalityCache.get(code);
+                return tp.isPresent() && tp.get().getGeometry() != null && tp.get().getGeometry().contains(point);
+            } catch (ExecutionException e) {
+                logger.warn("Failed to fetch municipality TopographicPlace for code [{}]", code, e);
+                return false;
+            }
+        });
+        if (logAuthorizationCheck && result) {
+            logger.info("User [{}] with municipalityCodes {} is allowed to edit entity at point {} (municipality check).",
+                    TrivoreAuthorizations.getCurrentSubject(), municipalityCodes, point);
         }
         return result;
     }
@@ -174,12 +218,23 @@ public class FintrafficAuthorizationService implements AuthorizationService {
         List<TopographicPlace> topographicPlaces = topographicPlaceRepository.findTopographicPlace(
                 TopographicPlaceSearch.newTopographicPlaceSearchBuilder().versionValidity(ExportParams.VersionValidity.CURRENT).build()
         );
-
         return topographicPlaces.stream()
                 .filter(tp -> tp.getTopographicPlaceType().equals(TopographicPlaceTypeEnumeration.REGION))
                 .filter(tp -> tp.getKeyValues().get("codespace").getItems().contains(codespace))
-                .peek(Zone_VersionStructure::getPolygon) // Prefetch polygons
+                .peek(Zone_VersionStructure::getGeometry) // Prefetch geometry
                 .collect(Collectors.toList());
+    }
+
+    private Optional<TopographicPlace> loadMunicipalityTopographicPlace(String municipalityCode) {
+        logger.trace("FintrafficAuthorizationService.loadMunicipalityTopographicPlace({})", municipalityCode);
+        List<TopographicPlace> topographicPlaces = topographicPlaceRepository.findTopographicPlace(
+                TopographicPlaceSearch.newTopographicPlaceSearchBuilder().versionValidity(ExportParams.VersionValidity.CURRENT).build()
+        );
+        return topographicPlaces.stream()
+                .filter(tp -> tp.getTopographicPlaceType().equals(TopographicPlaceTypeEnumeration.MUNICIPALITY))
+                .filter(tp -> tp.getPrivateCode() != null && municipalityCode.equals(tp.getPrivateCode().getValue()))
+                .peek(Zone_VersionStructure::getGeometry) // Prefetch geometry
+                .findFirst();
     }
 
     @Override

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficSecurityConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficSecurityConfig.java
@@ -35,10 +35,12 @@ public class FintrafficSecurityConfig {
             @Value("${tiamat.ext.fintraffic.security.oidc-server-uri}") String oidcServerUri,
             @Value("${tiamat.ext.fintraffic.security.client-id}") String clientId,
             @Value("${tiamat.ext.fintraffic.security.client-secret}") String clientSecret,
+            @Value("${tiamat.ext.fintraffic.auth.codespace-authorization.enabled:true}") boolean codespaceAuthEnabled,
+            @Value("${tiamat.ext.fintraffic.auth.municipality-authorization.enabled:false}") boolean municipalityAuthEnabled,
             TopographicPlaceRepository topographicPlaceRepository
     ) {
         TrivoreAuthorizations trivoreAuthorizations = new TrivoreAuthorizations(prepareWebClient(webClientBuilder), oidcServerUri, clientId, clientSecret);
-        return new FintrafficAuthorizationService(trivoreAuthorizations, topographicPlaceRepository);
+        return new FintrafficAuthorizationService(trivoreAuthorizations, topographicPlaceRepository, codespaceAuthEnabled, municipalityAuthEnabled);
     }
 
     private WebClient prepareWebClient(WebClient.Builder webClientBuilder) {

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/TrivoreAuthorizations.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/TrivoreAuthorizations.java
@@ -231,8 +231,22 @@ public class TrivoreAuthorizations {
                 });
     }
 
+    public Set<String> getAccessibleMunicipalityCodes() {
+        return getToken()
+                .flatMap(jwt -> fetchTrivoreUsersGroupMemberships(jwt.getSubject()))
+                .map(TrivoreAuthorizations::collectAllMunicipalityCodes)
+                .orElseGet(() -> {
+                    logger.trace("Could not resolve municipality codes for user [{}]", getCurrentSubject());
+                    return Set.of();
+                });
+    }
+
     private static Set<String> collectAllCodespaces(List<GroupMembership> groupMemberships) {
         return groupMemberships.stream().flatMap(groupMembership -> groupMembership.getCodespaces().stream()).collect(Collectors.toSet());
+    }
+
+    private static Set<String> collectAllMunicipalityCodes(List<GroupMembership> groupMemberships) {
+        return groupMemberships.stream().flatMap(groupMembership -> groupMembership.getMunicipalityCodes().stream()).collect(Collectors.toSet());
     }
 
     private static final Map<String, List<String>> SUPERCEDING_PERMISSIONS = Map.of(

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/TrivoreAuthorizations.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/TrivoreAuthorizations.java
@@ -54,7 +54,8 @@ public class TrivoreAuthorizations {
      * Poor man's infinite cache. This content needs to be loaded once and should never change.
      */
     private final LoadingCache<PermissionIdentifiers, ExternalPermission> externalPermissionCache;
-    private final LoadingCache<UserIdentifier, List<GroupMembership>> usersGroupMembershipCache;
+    private final LoadingCache<UserIdentifier, Set<String>> usersAccessibleCodespacesCache;
+    private final LoadingCache<UserIdentifier, Set<String>> usersAccessibleMunicipalityCodesCache;
     private final LoadingCache<UserIdentifier, List<ExternalPermissionGrant>> usersExternalPermissionsCache;
 
     public TrivoreAuthorizations(WebClient webClient,
@@ -72,11 +73,18 @@ public class TrivoreAuthorizations {
                 return loadExternalPermission(permissionIdentifiers);
             }
         });
-        this.usersGroupMembershipCache = createCache(1000, Duration.of(5, MINUTES), new CacheLoader<>() {
+        this.usersAccessibleCodespacesCache = createCache(1000, Duration.of(5, MINUTES), new CacheLoader<>() {
             @Override
             @Nonnull
-            public List<GroupMembership> load(@Nonnull UserIdentifier userIdentifier) throws Exception {
-                return loadUsersGroupMemberships(userIdentifier);
+            public Set<String> load(@Nonnull UserIdentifier userIdentifier) throws Exception {
+                return loadUsersAccessibleCodespaces(userIdentifier);
+            }
+        });
+        this.usersAccessibleMunicipalityCodesCache = createCache(1000, Duration.of(5, MINUTES), new CacheLoader<>() {
+            @Override
+            @Nonnull
+            public Set<String> load(@Nonnull UserIdentifier userIdentifier) throws Exception {
+                return loadUsersAccessibleMunicipalityCodes(userIdentifier);
             }
         });
         this.usersExternalPermissionsCache = createCache(50, Duration.of(5, MINUTES), new CacheLoader<>() {
@@ -127,6 +135,19 @@ public class TrivoreAuthorizations {
             throw new CacheLoadingException("Failed to load user's group membership data for user [" + userIdentifier + "]");
         }
     }
+
+    private Set<String> loadUsersAccessibleCodespaces(UserIdentifier userIdentifier) throws CacheLoadingException {
+        return loadUsersGroupMemberships(userIdentifier).stream()
+                .flatMap(groupMembership -> groupMembership.getCodespaces().stream())
+                .collect(Collectors.toSet());
+    }
+
+    private Set<String> loadUsersAccessibleMunicipalityCodes(UserIdentifier userIdentifier) throws CacheLoadingException {
+        return loadUsersGroupMemberships(userIdentifier).stream()
+                .flatMap(groupMembership -> groupMembership.getMunicipalityCodes().stream())
+                .collect(Collectors.toSet());
+    }
+
     private ExternalPermission loadExternalPermission(PermissionIdentifiers permissionIdentifiers) throws CacheLoadingException {
         Optional<ExternalPermission> externalPermission = executeRequest(
                 HttpMethod.GET,
@@ -173,12 +194,22 @@ public class TrivoreAuthorizations {
             return Optional.empty();
         }
     }
-    private Optional<List<GroupMembership>> fetchTrivoreUsersGroupMemberships(String userId) {
+    private Optional<Set<String>> fetchTrivoreUsersAccessibleCodespaces(String userId) {
         UserIdentifier identifier  = new UserIdentifier(userId);
         try {
-            return Optional.of(usersGroupMembershipCache.get(identifier));
+            return Optional.of(usersAccessibleCodespacesCache.get(identifier));
         } catch (ExecutionException e) {
-            logger.warn("Failed to fetch user's group memberships for identifier [{}]", identifier, e);
+            logger.warn("Failed to fetch user's accessible codespaces for identifier [{}]", identifier, e);
+            return Optional.empty();
+        }
+    }
+
+    private Optional<Set<String>> fetchTrivoreUsersAccessibleMunicipalityCodes(String userId) {
+        UserIdentifier identifier  = new UserIdentifier(userId);
+        try {
+            return Optional.of(usersAccessibleMunicipalityCodesCache.get(identifier));
+        } catch (ExecutionException e) {
+            logger.warn("Failed to fetch user's accessible municipality codes for identifier [{}]", identifier, e);
             return Optional.empty();
         }
     }
@@ -223,8 +254,7 @@ public class TrivoreAuthorizations {
 
     public Set<String> getAccessibleCodespaces() {
         return getToken()
-                .flatMap(jwt -> fetchTrivoreUsersGroupMemberships(jwt.getSubject()))
-                .map(TrivoreAuthorizations::collectAllCodespaces)
+                .flatMap(jwt -> fetchTrivoreUsersAccessibleCodespaces(jwt.getSubject()))
                 .orElseGet(() -> {
                     logger.trace("Could not resolve codespaces for user [{}]", getCurrentSubject());
                     return Set.of();
@@ -233,21 +263,13 @@ public class TrivoreAuthorizations {
 
     public Set<String> getAccessibleMunicipalityCodes() {
         return getToken()
-                .flatMap(jwt -> fetchTrivoreUsersGroupMemberships(jwt.getSubject()))
-                .map(TrivoreAuthorizations::collectAllMunicipalityCodes)
+                .flatMap(jwt -> fetchTrivoreUsersAccessibleMunicipalityCodes(jwt.getSubject()))
                 .orElseGet(() -> {
                     logger.trace("Could not resolve municipality codes for user [{}]", getCurrentSubject());
                     return Set.of();
                 });
     }
 
-    private static Set<String> collectAllCodespaces(List<GroupMembership> groupMemberships) {
-        return groupMemberships.stream().flatMap(groupMembership -> groupMembership.getCodespaces().stream()).collect(Collectors.toSet());
-    }
-
-    private static Set<String> collectAllMunicipalityCodes(List<GroupMembership> groupMemberships) {
-        return groupMemberships.stream().flatMap(groupMembership -> groupMembership.getMunicipalityCodes().stream()).collect(Collectors.toSet());
-    }
 
     private static final Map<String, List<String>> SUPERCEDING_PERMISSIONS = Map.of(
             "view", List.of("administer", "manage", "edit", "view"),

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/model/GroupMembership.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/model/GroupMembership.java
@@ -1,11 +1,15 @@
 package org.rutebanken.tiamat.ext.fintraffic.auth.model;
 
-import com.google.common.base.Splitter;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.List;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public record GroupMembership(String id,
                               String name,
@@ -15,6 +19,7 @@ public record GroupMembership(String id,
                               String eligibleUntil,
                               Map<String, Object> customFields) {
 
+    private static final Logger logger = LoggerFactory.getLogger(GroupMembership.class);
 
     /**
      * Metadata field which contains list of NeTEx codespaces members of the group are allowed to access.
@@ -27,23 +32,34 @@ public record GroupMembership(String id,
     private static final String CUSTOM_FIELD_MUNICIPALITY_CODES = "municipalityCodes";
 
     public Set<String> getCodespaces() {
-        return splitCustomField(CUSTOM_FIELD_CODESPACE);
+        return validateValues(splitCustomField(CUSTOM_FIELD_CODESPACE), CUSTOM_FIELD_CODESPACE, FintrafficConstants::isValidAreaCode)
+                .collect(Collectors.toSet());
     }
 
     public Set<String> getMunicipalityCodes() {
-        return splitCustomField(CUSTOM_FIELD_MUNICIPALITY_CODES);
+        return validateValues(splitCustomField(CUSTOM_FIELD_MUNICIPALITY_CODES), CUSTOM_FIELD_MUNICIPALITY_CODES, FintrafficConstants::isValidMunicipalityCode)
+                .collect(Collectors.toSet());
     }
 
-    private Set<String> splitCustomField(String fieldName) {
-        if (customFields != null) {
-            String fieldValue = customFields.getOrDefault(fieldName, "").toString();
-            List<String> values = Splitter.on(",")
-                    .trimResults()
-                    .omitEmptyStrings()
-                    .splitToList(fieldValue);
-            return new HashSet<>(values);
+    private Stream<String> splitCustomField(String fieldName) {
+        if (customFields == null) {
+            return Stream.empty();
         }
-        return Set.of();
+        String fieldValue = customFields.getOrDefault(fieldName, "").toString();
+        return Arrays.stream(fieldValue.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty());
+    }
+
+    private Stream<String> validateValues(Stream<String> values, String fieldName, Predicate<String> validator) {
+        return values.filter(value -> {
+            if (validator.test(value)) {
+                return true;
+            }
+            logger.warn("Skipping invalid value '{}' in field '{}' of group [id={}, name={}]",
+                    value, fieldName, id, name);
+            return false;
+        });
     }
 
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/model/GroupMembership.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/model/GroupMembership.java
@@ -21,14 +21,27 @@ public record GroupMembership(String id,
      */
     private static final String CUSTOM_FIELD_CODESPACE = "codespaces";
 
+    /**
+     * Metadata field which contains list of municipality codes members of the group are allowed to access.
+     */
+    private static final String CUSTOM_FIELD_MUNICIPALITY_CODES = "municipalityCodes";
+
     public Set<String> getCodespaces() {
+        return splitCustomField(CUSTOM_FIELD_CODESPACE);
+    }
+
+    public Set<String> getMunicipalityCodes() {
+        return splitCustomField(CUSTOM_FIELD_MUNICIPALITY_CODES);
+    }
+
+    private Set<String> splitCustomField(String fieldName) {
         if (customFields != null) {
-            String codespaceField = customFields.getOrDefault(CUSTOM_FIELD_CODESPACE, "").toString();
-            List<String> codespaces = Splitter.on(",")
+            String fieldValue = customFields.getOrDefault(fieldName, "").toString();
+            List<String> values = Splitter.on(",")
                     .trimResults()
                     .omitEmptyStrings()
-                    .splitToList(codespaceField);
-            return new HashSet<>(codespaces);
+                    .splitToList(fieldValue);
+            return new HashSet<>(values);
         }
         return Set.of();
     }


### PR DESCRIPTION
### Summary

- Adds municipality-code-based geographic authorization to the stop place editor (DPO-3842)
- Users can now be granted edit access based on Finnish municipality codes, in addition to the existing region/codespace-based access
- The two access checks are combined with OR logic — a user can edit an entity if either check passes
- Delete operations remain unchanged: they require the ADMINISTER permission without any geographic restriction
- Each authorization method can be independently enabled or disabled via application properties, allowing safe rollout

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

**Motivation**

The existing geographic authorization only supports region-level (codespace) access. Finnish municipalities are smaller and more precise units than regions. Several operators and authorities need to manage stop places within specific municipalities, not entire regions. This change adds support for municipality-code-based access control alongside the existing region check.

**How it works**

Each Trivore group can have a `municipalityCodes` custom field containing a comma-separated list of Finnish municipality codes (e.g. `"091,049"`). When a user tries to edit a stop place or other geographic entity, the system checks whether the entity's location falls within any of the municipality polygons that match the user's municipality codes. Municipality polygons are loaded from the existing TopographicPlace data in Tiamat. The check uses the same point-in-polygon approach as the existing codespace check.

The two geographic checks (codespace and municipality) are combined with OR logic. A user can edit an entity if either check passes. This allows gradual migration: users and groups can have codespaces, municipality codes, or both.

**Technical approach**

- `GroupMembership` gains a method to read and validate municipality codes from the Trivore group custom field, following the same pattern as the existing codespace field
- `TrivoreAuthorizations` gains a method to aggregate municipality codes from all of the user's group memberships
- `FintrafficAuthorizationService` gains a municipality cache and a new geographic check method that loads municipality polygons by their private code and checks point containment. The existing codespace check is refactored into its own method, and the two are combined with OR logic
- Shared validation regex constants are extracted into a common class used by both the authorization logic and the Read API controller
- Two feature flags control which checks are active:
  - `tiamat.ext.fintraffic.auth.codespace-authorization.enabled` (default: `true`)
  - `tiamat.ext.fintraffic.auth.municipality-authorization.enabled` (default: `false`)
  - Defaults preserve existing behavior. Both can be enabled during migration.

### Unit tests

Unit tests are added and updated to cover the new behavior:

- `FintrafficAuthorizationServiceTest` — new tests for: entity inside a municipality polygon (allowed), entity outside all municipality polygons (denied), and entity that matches only one of the two checks (allowed, OR logic)
- `GroupMembershipTest` — tests for parsing and deduplicating municipality codes from the custom field, and for rejecting invalid values with a warning
- `TrivoreAuthorizationsTest` — tests for aggregating municipality codes across multiple group memberships

Existing tests are updated where the refactoring of `canEditEntity` affects them. All CI checks pass.

### Documentation

- Validation rules (regex patterns) are documented on the shared constants class

---
<!-- Thank you for your contribution to entur/tiamat! -->
