### PR TITLE
Add support for MultiPolygon FareZones

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/repository/FareZoneRepositoryImpl.java
+++ b/src/main/java/org/rutebanken/tiamat/repository/FareZoneRepositoryImpl.java
@@ -335,13 +335,17 @@ public class FareZoneRepositoryImpl implements FareZoneRepositoryCustom {
                     "                                    ON SP.NETEX_ID = FZM.REF" +
                     "                                    AND FZ.SCOPING_METHOD='EXPLICIT_STOPS'";
         } else {
-            subQuery = "        JOIN" +
+            subQuery = "        LEFT JOIN" +
                     "                     PERSISTABLE_POLYGON PP " +
                     "                       ON PP.ID = FZ.POLYGON_ID " +
+                    "                        LEFT JOIN" +
+                    "                         PERSISTABLE_MULTI_POLYGON PMP " +
+                    "                           ON PMP.ID = FZ.MULTI_SURFACE_ID " +
                     "                        JOIN" +
                     "                         STOP_PLACE SP " +
-                    "                           ON ST_CONTAINS(PP.POLYGON,SP.CENTROID) " +
-                    "                           AND FZ.SCOPING_METHOD='IMPLICIT_SPATIAL_PROJECTION' ";
+                    "                           ON FZ.SCOPING_METHOD='IMPLICIT_SPATIAL_PROJECTION' " +
+                    "                           AND (FZ.POLYGON_ID IS NOT NULL OR FZ.MULTI_SURFACE_ID IS NOT NULL) " +
+                    "                           AND (ST_CONTAINS(PP.POLYGON,SP.CENTROID) OR ST_CONTAINS(PMP.MULTI_POLYGON,SP.CENTROID)) ";
         }
         return subQuery;
     }

--- a/src/test/java/org/rutebanken/tiamat/repository/FareZoneRepositoryImplTest.java
+++ b/src/test/java/org/rutebanken/tiamat/repository/FareZoneRepositoryImplTest.java
@@ -17,10 +17,16 @@ package org.rutebanken.tiamat.repository;
 
 import com.google.common.collect.Sets;
 import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 import org.rutebanken.tiamat.TiamatIntegrationTest;
 import org.rutebanken.tiamat.exporter.params.FareZoneSearch;
 import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
 import org.rutebanken.tiamat.model.FareZone;
+import org.rutebanken.tiamat.model.ScopingMethodEnumeration;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.TariffZoneRef;
 import org.rutebanken.tiamat.model.ValidBetween;
@@ -201,6 +207,82 @@ public class FareZoneRepositoryImplTest extends TiamatIntegrationTest {
 
         assertThat(fareZones).hasSize(1);
         assertThat(fareZones.getFirst().getVersion()).isEqualTo(v2.getVersion());
+    }
+
+    @Test
+    public void updateStopPlaceTariffZoneRef_stopPlaceInsideMultiSurface_shouldAssignFareZone() {
+        MultiPolygon multiPolygon = createTwoPolygonMultiSurface();
+
+        FareZone fareZone = new FareZone();
+        fareZone.setNetexId("TST:FareZone:MultiSurface2");
+        fareZone.setName(new EmbeddableMultilingualString("Implicit Spatial Zone"));
+        fareZone.setScopingMethod(ScopingMethodEnumeration.IMPLICIT_SPATIAL_PROJECTION);
+        fareZone.setMultiSurface(multiPolygon);
+        fareZone.setValidBetween(new ValidBetween(Instant.now().minusSeconds(3600), null));
+        fareZoneRepository.saveAndFlush(fareZone);
+
+        // Centroid at (0.5, 0.5) is inside Polygon 1: (0,0)-(0,1)-(1,1)-(1,0)-(0,0)
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setName(new EmbeddableMultilingualString("Stop Inside Zone"));
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(0.5, 0.5)));
+        stopPlace.setValidBetween(new ValidBetween(Instant.now().minusSeconds(3600), null));
+        stopPlaceRepository.saveAndFlush(stopPlace);
+
+        fareZoneRepository.updateStopPlaceTariffZoneRef();
+
+        StopPlace updated = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
+        assertThat(updated.getTariffZones())
+                .extracting(TariffZoneRef::getRef)
+                .contains(fareZone.getNetexId());
+    }
+
+    @Test
+    public void updateStopPlaceTariffZoneRef_stopPlaceOutsideMultiSurface_shouldNotAssignFareZone() {
+        MultiPolygon multiPolygon = createTwoPolygonMultiSurface();
+
+        FareZone fareZone = new FareZone();
+        fareZone.setNetexId("TST:FareZone:MultiSurface3");
+        fareZone.setName(new EmbeddableMultilingualString("Implicit Spatial Zone Outside"));
+        fareZone.setScopingMethod(ScopingMethodEnumeration.IMPLICIT_SPATIAL_PROJECTION);
+        fareZone.setMultiSurface(multiPolygon);
+        fareZone.setValidBetween(new ValidBetween(Instant.now().minusSeconds(3600), null));
+        fareZoneRepository.saveAndFlush(fareZone);
+
+        // Centroid at (10.0, 10.0) is outside both polygons
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setName(new EmbeddableMultilingualString("Stop Outside Zone"));
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(10.0, 10.0)));
+        stopPlace.setValidBetween(new ValidBetween(Instant.now().minusSeconds(3600), null));
+        stopPlaceRepository.saveAndFlush(stopPlace);
+
+        fareZoneRepository.updateStopPlaceTariffZoneRef();
+
+        StopPlace updated = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
+        assertThat(updated.getTariffZones())
+                .extracting(TariffZoneRef::getRef)
+                .doesNotContain(fareZone.getNetexId());
+    }
+
+    /**
+     * Creates a MultiPolygon with two disconnected unit squares:
+     * - Polygon 1: (0,0), (0,1), (1,1), (1,0), (0,0)
+     * - Polygon 2: (3,0), (3,1), (4,1), (4,0), (3,0)
+     */
+    private MultiPolygon createTwoPolygonMultiSurface() {
+        Polygon polygon1 = createPolygon(
+                new Coordinate(0, 0), new Coordinate(0, 1),
+                new Coordinate(1, 1), new Coordinate(1, 0),
+                new Coordinate(0, 0));
+        Polygon polygon2 = createPolygon(
+                new Coordinate(3, 0), new Coordinate(3, 1),
+                new Coordinate(4, 1), new Coordinate(4, 0),
+                new Coordinate(3, 0));
+        return geometryFactory.createMultiPolygon(new Polygon[]{polygon1, polygon2});
+    }
+
+    private Polygon createPolygon(Coordinate... coordinates) {
+        LinearRing ring = new LinearRing(new CoordinateArraySequence(coordinates), geometryFactory);
+        return geometryFactory.createPolygon(ring, null);
     }
 
 }


### PR DESCRIPTION
### Summary

Adds support for multi-polygon spatial matching in FareZone StopPlace assignment

- getSubQuery now `LEFT JOIN`s `PERSISTABLE_MULTI_POLYGON on FZ.MULTI_SURFACE_ID` in addition to `PERSISTABLE_POLYGON`, so FareZones using multi-surface geometry correctly match stop places via `ST_CONTAINS` 
- Rows where neither polygon nor multi-polygon is set are excluded

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

Problem: FareZones with MULTI_SURFACE_ID set (instead of POLYGON_ID) were not matching any StopPlaces during the implicit spatial projection query. The getSubQuery method only joined PERSISTABLE_POLYGON, ignoring multi-polygon geometries entirely.

Fix: The implicit spatial projection branch now LEFT JOINs both PERSISTABLE_POLYGON and PERSISTABLE_MULTI_POLYGON, and uses an OR-based ST_CONTAINS check against both. A guard clause ensures at least one of POLYGON_ID or MULTI_SURFACE_ID is non-null to prevent empty matches.

### Unit tests

- No existing tests were affected by this change
- The existing FareZoneRepositoryImplTest tests all remain passing
- Manual verification was done to confirm fare zones with MULTI_SURFACE_ID now correctly resolve stop places

### Documentation

- Have you added documentation in code covering design and rationale behind the code?
- Were all non-trivial public classes and methods documented with Javadoc?
---
<!-- Thank you for your contribution to entur/tiamat! -->


