### PR TITLE
Fix JPA mapping incompatibilities in @Embeddable / @ElementCollection hierarchy (Hibernate 6.5 + 6.6)

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/model/AccessSpaceRefStructure.java
+++ b/src/main/java/org/rutebanken/tiamat/model/AccessSpaceRefStructure.java
@@ -15,10 +15,10 @@
 
 package org.rutebanken.tiamat.model;
 
-import jakarta.persistence.Embeddable;
+import jakarta.persistence.MappedSuperclass;
 
 
-@Embeddable
+@MappedSuperclass
 public class AccessSpaceRefStructure
         extends StopPlaceSpaceRefStructure {
 

--- a/src/main/java/org/rutebanken/tiamat/model/AddressablePlaceRefStructure.java
+++ b/src/main/java/org/rutebanken/tiamat/model/AddressablePlaceRefStructure.java
@@ -16,10 +16,8 @@
 package org.rutebanken.tiamat.model;
 
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.MappedSuperclass;
 
 
-@MappedSuperclass
 @Embeddable
 public class AddressablePlaceRefStructure extends PlaceRefStructure {
 

--- a/src/main/java/org/rutebanken/tiamat/model/AlternativeName.java
+++ b/src/main/java/org/rutebanken/tiamat/model/AlternativeName.java
@@ -34,6 +34,7 @@ import java.math.BigInteger;
 public class AlternativeName
         extends VersionedChildStructure {
 
+    @Transient
     protected VersionOfObjectRefStructure namedObjectRef;
 
     protected String lang;

--- a/src/main/java/org/rutebanken/tiamat/model/FareZone.java
+++ b/src/main/java/org/rutebanken/tiamat/model/FareZone.java
@@ -15,7 +15,10 @@
 
 package org.rutebanken.tiamat.model;
 
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -45,6 +48,10 @@ public class FareZone extends Zone_VersionStructure {
     @CollectionTable(
             name = "fare_zone_members"
     )
+    @AttributeOverrides({
+            @AttributeOverride(name = "ref", column = @Column(name = "ref")),
+            @AttributeOverride(name = "version", column = @Column(name = "version"))
+    })
     private Set<StopPlaceReference> fareZoneMembers = new HashSet<>();
 
 

--- a/src/main/java/org/rutebanken/tiamat/model/GroupOfStopPlaces.java
+++ b/src/main/java/org/rutebanken/tiamat/model/GroupOfStopPlaces.java
@@ -16,8 +16,11 @@
 package org.rutebanken.tiamat.model;
 
 import com.google.common.base.MoreObjects;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -40,6 +43,10 @@ public class GroupOfStopPlaces extends GroupOfEntities_VersionStructure {
     @CollectionTable(
             name = "group_of_stop_places_members"
     )
+    @AttributeOverrides({
+            @AttributeOverride(name = "ref", column = @Column(name = "ref")),
+            @AttributeOverride(name = "version", column = @Column(name = "version"))
+    })
     private Set<StopPlaceReference> members = new HashSet<>();
     private Point centroid;
 

--- a/src/main/java/org/rutebanken/tiamat/model/ParkingCapacity.java
+++ b/src/main/java/org/rutebanken/tiamat/model/ParkingCapacity.java
@@ -18,6 +18,7 @@ package org.rutebanken.tiamat.model;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Transient;
 
 import java.math.BigInteger;
 
@@ -25,6 +26,7 @@ import java.math.BigInteger;
 public class ParkingCapacity
         extends VersionedChildStructure {
 
+    @Transient
     protected SiteElementRefStructure parentRef;
     @Enumerated(EnumType.STRING)
     protected ParkingUserEnumeration parkingUserType;

--- a/src/main/java/org/rutebanken/tiamat/model/SiteElementRefStructure.java
+++ b/src/main/java/org/rutebanken/tiamat/model/SiteElementRefStructure.java
@@ -15,10 +15,10 @@
 
 package org.rutebanken.tiamat.model;
 
-import jakarta.persistence.Embeddable;
+import jakarta.persistence.MappedSuperclass;
 
 
-@Embeddable
+@MappedSuperclass
 public class SiteElementRefStructure extends AddressablePlaceRefStructure {
 
     public SiteElementRefStructure() {

--- a/src/main/java/org/rutebanken/tiamat/model/SiteElementRefStructure.java
+++ b/src/main/java/org/rutebanken/tiamat/model/SiteElementRefStructure.java
@@ -15,10 +15,10 @@
 
 package org.rutebanken.tiamat.model;
 
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Embeddable;
 
 
-@MappedSuperclass
+@Embeddable
 public class SiteElementRefStructure extends AddressablePlaceRefStructure {
 
     public SiteElementRefStructure() {

--- a/src/main/java/org/rutebanken/tiamat/model/SiteRefStructure.java
+++ b/src/main/java/org/rutebanken/tiamat/model/SiteRefStructure.java
@@ -16,11 +16,9 @@
 package org.rutebanken.tiamat.model;
 
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.MappedSuperclass;
 
 @Embeddable
-@MappedSuperclass
-public class SiteRefStructure extends SiteElementRefStructure {
+public class SiteRefStructure extends PlaceRefStructure {
 
     public SiteRefStructure() {
         super();

--- a/src/main/java/org/rutebanken/tiamat/model/Site_VersionStructure.java
+++ b/src/main/java/org/rutebanken/tiamat/model/Site_VersionStructure.java
@@ -65,6 +65,10 @@ public abstract class Site_VersionStructure
     protected SiteRefStructure parentSiteRef;
 
     @ElementCollection(targetClass = SiteRefStructure.class, fetch = FetchType.EAGER)
+    @AttributeOverrides({
+            @AttributeOverride(name = "ref", column = @Column(name = "ref")),
+            @AttributeOverride(name = "version", column = @Column(name = "version"))
+    })
     protected Set<SiteRefStructure> adjacentSites = new HashSet<>();
 
     @Transient

--- a/src/main/java/org/rutebanken/tiamat/model/StopPlaceReference.java
+++ b/src/main/java/org/rutebanken/tiamat/model/StopPlaceReference.java
@@ -18,7 +18,7 @@ package org.rutebanken.tiamat.model;
 import jakarta.persistence.Embeddable;
 
 @Embeddable
-public class StopPlaceReference extends SiteRefStructure {
+public class StopPlaceReference extends PlaceRefStructure {
 
     public StopPlaceReference() {
     }

--- a/src/main/java/org/rutebanken/tiamat/versioning/save/GroupOfStopPlacesSaverService.java
+++ b/src/main/java/org/rutebanken/tiamat/versioning/save/GroupOfStopPlacesSaverService.java
@@ -140,7 +140,7 @@ public class GroupOfStopPlacesSaverService {
     /**
      * Validates that each member exists, is valid, and user has authorization to edit it.
      */
-    private void validateAndAuthorizeMembers(Collection<? extends org.rutebanken.tiamat.model.SiteRefStructure> members) {
+    private void validateAndAuthorizeMembers(Collection<? extends org.rutebanken.tiamat.model.PlaceRefStructure> members) {
         members.forEach(member -> {
             String memberRef = member.getRef();
             StopPlace resolvedMember = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(memberRef);

--- a/src/test/java/org/rutebanken/tiamat/model/StopPlaceTest.java
+++ b/src/test/java/org/rutebanken/tiamat/model/StopPlaceTest.java
@@ -270,7 +270,7 @@ public class StopPlaceTest extends TiamatIntegrationTest {
     public void persistStopPlaceWithParentReference() {
         StopPlace stopPlace = new StopPlace();
 
-        StopPlaceReference stopPlaceReference = new StopPlaceReference();
+        SiteRefStructure stopPlaceReference = new SiteRefStructure();
         stopPlaceReference.setRef("id-to-another-stop-place");
         stopPlaceReference.setVersion("001");
 


### PR DESCRIPTION
### Summary

Fix JPA mapping incompatibilities in the `@Embeddable` / `@ElementCollection` annotation hierarchy that caused runtime failures under Hibernate 6.5 and Hibernate 6.6. 

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [x] Refactoring for hibernate upgrade

### Issue

Two distinct Hibernate bugs blocked the removal of the version pin:

**1. Hibernate 6.5 — ArrayIndexOutOfBoundsException in `@ElementCollection`**

Hibernate 6.5's `fillEmbeddable` only traverses `@MappedSuperclass` ancestors when populating `@ElementCollection` element types. Several embeddable classes used in element collections had a deep inheritance chain:

```
StopPlaceReference → SiteRefStructure → SiteElementRefStructure → AddressablePlaceRefStructure
```

The intermediate `@MappedSuperclass` classes caused fields to be mapped at the wrong array index, triggering an AIOOBE at runtime when loading or saving:
- `FareZone.fareZoneMembers` (`Set<StopPlaceReference>`)
- `GroupOfStopPlaces.members` (`Set<StopPlaceReference>`)
- `Site_VersionStructure.adjacentSites` (`Set<SiteRefStructure>`)

**2. Hibernate 6.6 — phantom discriminator column `place_ref_dtype`**

Hibernate 6.6 introduced automatic discriminator column generation (`{fieldName}_dtype`) for any `@Embedded` field whose declared type has an `@Embeddable` subtype anywhere in the hierarchy (including transitive subtypes through `@MappedSuperclass` chains).

`PathLinkEnd.placeRef` is typed as `AddressablePlaceRefStructure (@Embeddable)`. Two `@Embeddable` subtypes existed in that hierarchy:
- `SiteElementRefStructure` — inadvertently marked `@Embeddable` during the 6.5 fix
- `AccessSpaceRefStructure` — a pre-existing `@Embeddable` in the same hierarchy

Hibernate 6.6 therefore generated a `place_ref_dtype` column on insert that does not exist in `path_link_end`, failing all PathLink tests.


### Unit tests

Existing unit test and integration tests works
Manual testing 



