### PR TITLE
Update superpom from 4.10-0 to 5.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>4.10.0</version>
+        <version>5.6.0</version>
     </parent>
     <groupId>org.rutebanken</groupId>
     <artifactId>tiamat</artifactId>

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingService.java
@@ -217,6 +217,7 @@ public class ReadApiNetexMarshallingService {
             JAXBElement<?> jaxbElement = createJAXBElementForEntity(netexEntity);
             Marshaller marshaller = createMarshaller(netexEntity.getClass());
             marshaller.marshal(jaxbElement, xsw);
+            xsw.flush();
             return stringWriter.toString();
         } catch (JAXBException | XMLStreamException | IOException e) {
             logger.error(e.getMessage(), e);


### PR DESCRIPTION
### Summary

Dependency update superpom 5.6.0

Fix bug in ReadApiNetexMarshallingService, Woodstox 7.0.0 (StAX XML streaming implementation, pulled in via google-cloud-storage) changed its buffering behavior for Writer-backed streams. The XMLStreamWriter.marshal() call writes content into Woodstox's internal buffer, but that buffer is no longer implicitly flushed to the underlying StringWriter until flush() is called.



### Type of change
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ x  ] Dependency Update


### Unit tests

- Were unit tests added/updated? (no)
- Was any manual verification done? (yes)
- Any observations on changes to performance? (no)
- Was the code designed so it is unit testable? (n/a)
- Were any tests applied to the smallest appropriate unit? (n/a
- Do all tests
  pass (One test in ReadApiNetexMarshallingServiceTest was failing, fixed the bug in code read summary)



