### PR TITLE
Spring Boot 4 / Hibernate 7 / Java 25 upgrade

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,10 @@ jobs:
       TZ: Europe/Oslo
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
           cache: maven
 
@@ -40,10 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
           cache: maven
       - name: set variables

--- a/.github/workflows/entur-push.yml
+++ b/.github/workflows/entur-push.yml
@@ -8,9 +8,6 @@ on:
       - master
 jobs:
   maven-verify:
-    env:
-      JFROG_USER: ${{ secrets.ARTIFACTORY_AUTH_USER }}
-      JFROG_PASS: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -18,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
       - name: Cache Maven dependencies
         uses: actions/cache@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-noble
+FROM eclipse-temurin:25-noble
 WORKDIR /deployments
 COPY target/tiamat-*-SNAPSHOT.jar tiamat.jar
 RUN addgroup --gid 2000 appuser && adduser --uid 2000 --disabled-password --ingroup appuser appuser

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webclient</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>5.6.0</version>
+        <version>6.4.0</version>
     </parent>
     <groupId>org.rutebanken</groupId>
     <artifactId>tiamat</artifactId>
@@ -59,7 +59,7 @@
         <hazelcast.version>5.2.5</hazelcast.version>
         <swagger-jersey2.version>2.2.46</swagger-jersey2.version>
         <netex-java-model.version>2.0.16</netex-java-model.version>
-        <entur.helpers.version>5.50.0</entur.helpers.version>
+        <entur.helpers.version>7.1.0</entur.helpers.version>
         <jts-core.version>1.20.0</jts-core.version>
         <groovy-all.version>4.0.31</groovy-all.version>
         <rest-assured.version>5.5.7</rest-assured.version>
@@ -88,6 +88,10 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-flyway</artifactId>
         </dependency>
 
         <dependency>
@@ -168,6 +172,11 @@
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-spring</artifactId>
             <version>${hazelcast.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-hazelcast</artifactId>
         </dependency>
 
         <dependency>
@@ -337,7 +346,11 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-restclient-test</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -477,6 +477,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Xlint:-path</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>${build-helper-maven-plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     </scm>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <spring-cloud-gcp.version>5.13.11</spring-cloud-gcp.version>
         <geotools.version>30.2</geotools.version>
         <orika-core.version>1.5.4</orika-core.version>

--- a/src/ext/java/org/rutebanken/tiamat/ext/entur/auth/EnturOauth2Config.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/entur/auth/EnturOauth2Config.java
@@ -9,7 +9,7 @@ import org.rutebanken.helper.organisation.RoleAssignmentExtractor;
 import org.rutebanken.helper.organisation.user.UserInfoExtractor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/model/GroupMembership.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/model/GroupMembership.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 public record GroupMembership(String id,
                               String name,
                               String description,
-                              boolean member,
+                              Boolean member,
                               String eligibleFrom,
                               String eligibleUntil,
                               Map<String, Object> customFields) {

--- a/src/main/java/org/rutebanken/tiamat/TiamatApplication.java
+++ b/src/main/java/org/rutebanken/tiamat/TiamatApplication.java
@@ -18,7 +18,7 @@ package org.rutebanken.tiamat;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters;

--- a/src/main/java/org/rutebanken/tiamat/auth/TiamatSecurityConfig.java
+++ b/src/main/java/org/rutebanken/tiamat/auth/TiamatSecurityConfig.java
@@ -24,7 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationManagerResolver;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -42,7 +42,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @Profile("!test")
 @Configuration()
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableMethodSecurity
 public class TiamatSecurityConfig {
 
     private static final Logger logger = LoggerFactory.getLogger(TiamatSecurityConfig.class);

--- a/src/main/java/org/rutebanken/tiamat/changelog/LocalChangelogConfiguration.java
+++ b/src/main/java/org/rutebanken/tiamat/changelog/LocalChangelogConfiguration.java
@@ -1,8 +1,8 @@
 package org.rutebanken.tiamat.changelog;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.jms.JmsAutoConfiguration;
-import org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration;
+import org.springframework.boot.jms.autoconfigure.JmsAutoConfiguration;
+import org.springframework.boot.activemq.autoconfigure.ActiveMQAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 

--- a/src/main/java/org/rutebanken/tiamat/config/JettyConfig.java
+++ b/src/main/java/org/rutebanken/tiamat/config/JettyConfig.java
@@ -19,7 +19,7 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
+import org.springframework.boot.jetty.servlet.JettyServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -35,12 +35,8 @@ public class JettyConfig {
 
         logger.info("Configuring jetty with minThreads: {} and maxThreads: {}", jettyMinThreads, jettyMaxThreads);
 
-        final JettyServletWebServerFactory factory = new JettyServletWebServerFactory() {
-            @Override
-            public QueuedThreadPool getThreadPool() {
-                return new QueuedThreadPool(jettyMaxThreads, jettyMinThreads);
-            }
-        };
+        JettyServletWebServerFactory factory = new JettyServletWebServerFactory();
+        factory.setThreadPool(new QueuedThreadPool(jettyMaxThreads, jettyMinThreads));
         return factory;
     }
 }

--- a/src/main/java/org/rutebanken/tiamat/model/AssistanceService.java
+++ b/src/main/java/org/rutebanken/tiamat/model/AssistanceService.java
@@ -4,16 +4,14 @@ import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import org.hibernate.annotations.LazyCollection;
-import org.hibernate.annotations.LazyCollectionOption;
+import jakarta.persistence.FetchType;
 
 import java.util.List;
 
 @Entity
 public class AssistanceService extends LocalService {
 
-    @ElementCollection(targetClass = AssistanceFacilityEnumeration.class)
-    @LazyCollection(LazyCollectionOption.FALSE)
+    @ElementCollection(targetClass = AssistanceFacilityEnumeration.class, fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     protected List<AssistanceFacilityEnumeration> assistanceFacilityList;
 

--- a/src/main/java/org/rutebanken/tiamat/model/Parking.java
+++ b/src/main/java/org/rutebanken/tiamat/model/Parking.java
@@ -21,10 +21,9 @@ import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Transient;
-import org.hibernate.annotations.LazyCollection;
-import org.hibernate.annotations.LazyCollectionOption;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -61,13 +60,11 @@ public class Parking
     @Enumerated(EnumType.STRING)
     protected ParkingTypeEnumeration parkingType;
 
-    @ElementCollection(targetClass = ParkingPaymentProcessEnumeration.class)
-    @LazyCollection(LazyCollectionOption.FALSE)
+    @ElementCollection(targetClass = ParkingPaymentProcessEnumeration.class, fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     protected List<ParkingPaymentProcessEnumeration> parkingPaymentProcess;
 
-    @ElementCollection(targetClass = ParkingVehicleEnumeration.class)
-    @LazyCollection(LazyCollectionOption.FALSE)
+    @ElementCollection(targetClass = ParkingVehicleEnumeration.class, fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     protected List<ParkingVehicleEnumeration> parkingVehicleTypes;
     protected ParkingLayoutEnumeration parkingLayout;

--- a/src/main/java/org/rutebanken/tiamat/model/PerTableSequence.java
+++ b/src/main/java/org/rutebanken/tiamat/model/PerTableSequence.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.model;
+
+import org.hibernate.annotations.IdGeneratorType;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@IdGeneratorType(PerTableSequenceGenerator.class)
+@Target({METHOD, FIELD})
+@Retention(RUNTIME)
+public @interface PerTableSequence {
+    int allocationSize() default 10;
+}

--- a/src/main/java/org/rutebanken/tiamat/model/PerTableSequenceGenerator.java
+++ b/src/main/java/org/rutebanken/tiamat/model/PerTableSequenceGenerator.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.model;
+
+import org.hibernate.MappingException;
+import org.hibernate.generator.GeneratorCreationContext;
+import org.hibernate.id.OptimizableGenerator;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
+
+import java.lang.reflect.Member;
+import java.util.Properties;
+
+/**
+ * Derives a per-entity sequence name by converting the entity's simple class name
+ * from CamelCase to snake_case and appending "_seq" (e.g. StopPlace → stop_place_seq).
+ * Replaces the deprecated {@code @GenericGenerator} with {@code type = SequenceStyleGenerator.class}
+ * and {@code CONFIG_SEQUENCE_PER_ENTITY_SUFFIX = "_seq"}.
+ *
+ * Hibernate invokes the 3-arg constructor reflectively during bootstrap (via @IdGeneratorType),
+ * then calls callConfigure() which delegates to configure() below. The {@code member} parameter
+ * is part of Hibernate's required signature — without it, Hibernate falls back to its
+ * ManagedBeanRegistry path and Spring tries to autowire the generator as a bean, which fails
+ * because @PerTableSequence is an annotation type, not a bean.
+ */
+public class PerTableSequenceGenerator extends SequenceStyleGenerator {
+
+    private final String sequenceName;
+    private final int allocationSize;
+
+    @SuppressWarnings("unused")
+    public PerTableSequenceGenerator(PerTableSequence config, Member member, GeneratorCreationContext ctx) {
+        String simpleName = ctx.getPersistentClass().getMappedClass().getSimpleName();
+        // Match only lowercase→uppercase boundaries so class names containing an underscore
+        // (e.g. InstalledEquipment_VersionStructure) don't produce a doubled "__".
+        this.sequenceName = simpleName.replaceAll("(?<=[a-z])(?=[A-Z])", "_").toLowerCase() + "_seq";
+        this.allocationSize = config.allocationSize();
+        // configure() is NOT called here — Hibernate calls it via callConfigure() after instantiation
+    }
+
+    @Override
+    public void configure(GeneratorCreationContext creationContext, Properties parameters) throws MappingException {
+        parameters.setProperty(SEQUENCE_PARAM, sequenceName);
+        parameters.setProperty(OptimizableGenerator.INCREMENT_PARAM, String.valueOf(allocationSize));
+        parameters.setProperty(OptimizableGenerator.INITIAL_PARAM, "1");
+        super.configure(creationContext, parameters);
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/model/PersistableMultiPolygon.java
+++ b/src/main/java/org/rutebanken/tiamat/model/PersistableMultiPolygon.java
@@ -16,7 +16,6 @@
 package org.rutebanken.tiamat.model;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import org.locationtech.jts.geom.MultiPolygon;
 
@@ -26,7 +25,7 @@ import java.io.Serializable;
 public class PersistableMultiPolygon implements Serializable {
 
     @Id
-    @GeneratedValue(generator = "sequence_per_table_generator")
+    @PerTableSequence
     protected Long id;
 
     private MultiPolygon multiPolygon;

--- a/src/main/java/org/rutebanken/tiamat/model/PersistablePolygon.java
+++ b/src/main/java/org/rutebanken/tiamat/model/PersistablePolygon.java
@@ -17,7 +17,6 @@ package org.rutebanken.tiamat.model;
 
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import org.locationtech.jts.geom.Polygon;
 
@@ -27,7 +26,7 @@ import java.io.Serializable;
 public class PersistablePolygon implements Serializable {
 
     @Id
-    @GeneratedValue(generator = "sequence_per_table_generator")
+    @PerTableSequence
     protected Long id;
 
     private Polygon polygon;

--- a/src/main/java/org/rutebanken/tiamat/model/RelationshipStructure.java
+++ b/src/main/java/org/rutebanken/tiamat/model/RelationshipStructure.java
@@ -15,7 +15,6 @@
 
 package org.rutebanken.tiamat.model;
 
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 
@@ -24,7 +23,7 @@ import jakarta.persistence.MappedSuperclass;
 public class RelationshipStructure {
 
     @Id
-    @GeneratedValue(generator = "sequence_per_table_generator")
+    @PerTableSequence
     protected String id;
 
     public String getId() {

--- a/src/main/java/org/rutebanken/tiamat/model/SanitaryEquipment_VersionStructure.java
+++ b/src/main/java/org/rutebanken/tiamat/model/SanitaryEquipment_VersionStructure.java
@@ -18,10 +18,9 @@ package org.rutebanken.tiamat.model;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Transient;
-import org.hibernate.annotations.LazyCollection;
-import org.hibernate.annotations.LazyCollectionOption;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -35,8 +34,7 @@ public class SanitaryEquipment_VersionStructure
     protected GenderLimitationEnumeration gender;
     protected BigInteger numberOfToilets;
 
-    @ElementCollection(targetClass = SanitaryFacilityEnumeration.class)
-    @LazyCollection(LazyCollectionOption.FALSE)
+    @ElementCollection(targetClass = SanitaryFacilityEnumeration.class, fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     protected List<SanitaryFacilityEnumeration> sanitaryFacilityList;
 

--- a/src/main/java/org/rutebanken/tiamat/model/Value.java
+++ b/src/main/java/org/rutebanken/tiamat/model/Value.java
@@ -19,7 +19,6 @@ import com.google.common.base.MoreObjects;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import org.hibernate.annotations.Cache;
@@ -36,7 +35,7 @@ import java.util.Set;
 public class Value implements Serializable {
 
     @Id
-    @GeneratedValue(generator = "sequence_per_table_generator")
+    @PerTableSequence
     private long id;
 
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)

--- a/src/main/java/org/rutebanken/tiamat/model/Value.java
+++ b/src/main/java/org/rutebanken/tiamat/model/Value.java
@@ -20,7 +20,6 @@ import jakarta.persistence.CollectionTable;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import org.hibernate.annotations.Cache;
@@ -37,7 +36,7 @@ import java.util.Set;
 public class Value implements Serializable {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequence_per_table_generator")
+    @GeneratedValue(generator = "sequence_per_table_generator")
     private long id;
 
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)

--- a/src/main/java/org/rutebanken/tiamat/model/identification/IdentifiedEntity.java
+++ b/src/main/java/org/rutebanken/tiamat/model/identification/IdentifiedEntity.java
@@ -17,9 +17,9 @@ package org.rutebanken.tiamat.model.identification;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import org.rutebanken.tiamat.model.PerTableSequence;
 import org.rutebanken.tiamat.repository.listener.IdentifiedEntityListener;
 
 @MappedSuperclass
@@ -27,7 +27,7 @@ import org.rutebanken.tiamat.repository.listener.IdentifiedEntityListener;
 public abstract class IdentifiedEntity {
 
     @Id
-    @GeneratedValue(generator = "sequence_per_table_generator")
+    @PerTableSequence
     protected Long id;
 
     protected String netexId;

--- a/src/main/java/org/rutebanken/tiamat/model/job/ExportJob.java
+++ b/src/main/java/org/rutebanken/tiamat/model/job/ExportJob.java
@@ -18,9 +18,9 @@ package org.rutebanken.tiamat.model.job;
 import com.google.common.base.MoreObjects;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Transient;
+import org.rutebanken.tiamat.model.PerTableSequence;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import org.rutebanken.tiamat.exporter.params.ExportParams;
 
@@ -34,7 +34,7 @@ import static org.rutebanken.tiamat.rest.netex.publicationdelivery.AsyncExportRe
 public class ExportJob {
 
     @Id
-    @GeneratedValue(generator = "sequence_per_table_generator")
+    @PerTableSequence
     @Schema(description = "Unique id for the entity")
     private Long id;
 

--- a/src/main/java/org/rutebanken/tiamat/model/package-info.java
+++ b/src/main/java/org/rutebanken/tiamat/model/package-info.java
@@ -1,4 +1,3 @@
-
 /*
  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
  * the European Commission - subsequent versions of the EUPL (the "Licence");
@@ -14,16 +13,4 @@
  * limitations under the Licence.
  */
 
-@GenericGenerator(
-        name = "sequence_per_table_generator",
-        type = org.hibernate.id.enhanced.SequenceStyleGenerator.class,
-        parameters = {
-                @Parameter(name = SequenceStyleGenerator.CONFIG_SEQUENCE_PER_ENTITY_SUFFIX, value = "_seq"),
-                @Parameter(name = OptimizableGenerator.INCREMENT_PARAM, value = "10")
-        })
 package org.rutebanken.tiamat.model;
-
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-import org.hibernate.id.OptimizableGenerator;
-import org.hibernate.id.enhanced.SequenceStyleGenerator;

--- a/src/main/java/org/rutebanken/tiamat/netex/mapping/converter/LineStringConverter.java
+++ b/src/main/java/org/rutebanken/tiamat/netex/mapping/converter/LineStringConverter.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.List;
 
 @Component
@@ -71,7 +72,7 @@ public class LineStringConverter extends BidirectionalConverter<LineStringType, 
         DirectPositionListType directPositionListType = new DirectPositionListType();
 
         if(lineString.getCoordinates() != null) {
-            logger.debug("Converting coordinates {}", lineString.getCoordinates());
+            logger.debug("Converting coordinates {}", Arrays.toString(lineString.getCoordinates()));
             List<Double> positions = directPositionListType.getValue();
             for(Coordinate coordinate : lineString.getCoordinates()) {
                 positions.add(coordinate.y);

--- a/src/main/java/org/rutebanken/tiamat/repository/QuayRepositoryImpl.java
+++ b/src/main/java/org/rutebanken/tiamat/repository/QuayRepositoryImpl.java
@@ -26,6 +26,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -126,10 +129,13 @@ public class QuayRepositoryImpl implements QuayRepositoryCustom {
     }
 
     private Instant parseInstant(Object timestampObject) {
-        if (timestampObject instanceof Timestamp) {
-            return ((Timestamp)timestampObject).toInstant();
-        }
-        return null;
+        return switch (timestampObject) {
+            case Instant instant -> instant;
+            case OffsetDateTime odt -> odt.toInstant();
+            case LocalDateTime ldt -> ldt.atZone(ZoneId.systemDefault()).toInstant();
+            case Timestamp ts -> ts.toInstant();
+            case null, default -> null;
+        };
     }
 
     @Override

--- a/src/main/java/org/rutebanken/tiamat/repository/StopPlaceRepositoryImpl.java
+++ b/src/main/java/org/rutebanken/tiamat/repository/StopPlaceRepositoryImpl.java
@@ -51,6 +51,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -437,10 +440,13 @@ public class StopPlaceRepositoryImpl implements StopPlaceRepositoryCustom {
 
 
     private Instant parseInstant(Object timestampObject) {
-        if (timestampObject instanceof Timestamp) {
-            return ((Timestamp)timestampObject).toInstant();
-        }
-        return null;
+        return switch (timestampObject) {
+            case Instant instant -> instant;
+            case OffsetDateTime odt -> odt.toInstant();
+            case LocalDateTime ldt -> ldt.atZone(ZoneId.systemDefault()).toInstant();
+            case Timestamp ts -> ts.toInstant();
+            case null, default -> null;
+        };
     }
 
 

--- a/src/main/java/org/rutebanken/tiamat/service/batch/StopPlaceRefUpdaterService.java
+++ b/src/main/java/org/rutebanken/tiamat/service/batch/StopPlaceRefUpdaterService.java
@@ -182,7 +182,7 @@ public class StopPlaceRefUpdaterService {
                             session.evict(stopPlaceToSave);
                         }
 
-                        session.update(stopPlaceToSave);
+                        session.merge(stopPlaceToSave);
 
 
                         logger.trace("Saved stop {}", stopPlaceToSave);

--- a/src/test/java/org/rutebanken/tiamat/TiamatTestApplication.java
+++ b/src/test/java/org/rutebanken/tiamat/TiamatTestApplication.java
@@ -20,10 +20,13 @@ package org.rutebanken.tiamat;
 import org.rutebanken.tiamat.auth.TiamatSecurityConfig;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.actuate.web.servlet.ManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.web.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
@@ -33,7 +36,13 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 /**
  * Run integration tests for the rest interface without security
  */
-@SpringBootApplication(exclude = { SecurityAutoConfiguration.class, ManagementWebSecurityAutoConfiguration.class })
+@SpringBootApplication(exclude = {
+        SecurityAutoConfiguration.class,
+        ManagementWebSecurityAutoConfiguration.class,
+        SecurityFilterAutoConfiguration.class,
+        ServletWebSecurityAutoConfiguration.class,
+        UserDetailsServiceAutoConfiguration.class
+})
 @EnableTransactionManagement
 @EnableCaching
 @EntityScan(basePackageClasses={StopPlace.class, Jsr310JpaConverters.class})

--- a/src/test/java/org/rutebanken/tiamat/rest/dto/DtoResourceIntegrationTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/dto/DtoResourceIntegrationTest.java
@@ -15,7 +15,6 @@
 
 package org.rutebanken.tiamat.rest.dto;
 
-import io.restassured.RestAssured;
 import org.junit.Before;
 import org.junit.Test;
 import org.rutebanken.tiamat.TiamatIntegrationTest;
@@ -24,11 +23,11 @@ import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.StopTypeEnumeration;
 import org.rutebanken.tiamat.versioning.save.StopPlaceVersionedSaverService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.client.RestTestClient;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.rutebanken.tiamat.config.JerseyConfig.SERVICES_ADMIN_PATH;
 import static org.rutebanken.tiamat.config.JerseyConfig.SERVICES_STOP_PLACE_PATH;
@@ -43,10 +42,11 @@ public class DtoResourceIntegrationTest extends TiamatIntegrationTest {
     @Autowired
     StopPlaceVersionedSaverService saverService;
 
+    RestTestClient restTestClient;
+
     @Before
-    public void configureRestAssured() {
-        RestAssured.baseURI = "http://localhost";
-        RestAssured.port = port;
+    public void setUpRestTestClient() {
+        restTestClient = RestTestClient.bindToServer().baseUrl("http://localhost:" + port).build();
     }
 
     @Test
@@ -159,9 +159,7 @@ public class DtoResourceIntegrationTest extends TiamatIntegrationTest {
 
 
     private String getIdMapping(String url) {
-        return given()
-                .port(port)
-                .get(url)
-                .prettyPrint();
+
+        return restTestClient.get().uri(url).exchange().expectBody(String.class).returnResult().getResponseBody();
     }
 }


### PR DESCRIPTION
### Summary

- Bumps superpom 5.6.0→6.4.0 and entur-helpers 5.50.0→7.1.0
- **Upgrades Java 21→25**: `pom.xml` target version, CI workflows (both `ci.yaml` and `entur-push.yml`), and `Dockerfile` base image (`eclipse-temurin:25-noble`)
- Adds explicit `spring-boot-starter-flyway`, `spring-boot-starter-hazelcast`, and `spring-boot-starter-restclient-test` dependencies
- Fixes broken imports across config, auth, and model classes due to Spring Boot 4 package reorganisation
- Replaces deprecated Hibernate `@LazyCollection` with standard JPA `fetch = FetchType.EAGER`
- Updates `session.update` → `session.merge` for Hibernate 7 compatibility
- Handles additional timestamp types (`OffsetDateTime`, `LocalDateTime`) in repository timestamp conversion
- Fixes Jackson 3.x null-for-primitives error in `GroupMembership` record (`boolean` → `Boolean`)
- Fixes `DtoResourceIntegrationTest` — `RestTestClient` cannot be autowired from Spring context with `RANDOM_PORT`; initialise it in `@Before` instead
- Cleans up `TiamatIntegrationTest` — removes a `@TestConfiguration` that attempted to inject `${local.server.port}` during context load (before the port is available)
- Suppresses spurious `[path]` compiler warnings caused by `Class-Path` manifest entries in GeoTools and HK2 JARs (`-Xlint:-path`)

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (dependency upgrades and compatibility fixes for Spring Boot 4 / Hibernate 7 / Java 25)

### Issue

No separate issue — these are all compatibility fixes required for the Spring Boot 4, Hibernate 7, and Java 25 upgrade. The motivation and approach are described fully in the summary above.

### Unit tests

- Existing tests `DtoResourceIntegrationTest` (3 tests) and `TrivoreAuthorizationsTest` (5 tests) were failing before these changes and now pass.
- No new tests added — the fixes restore existing test coverage.
- No manual verification needed beyond the test suite.

### Documentation

No public API or design changes — all changes are compatibility fixes. No Javadoc additions required.