### PR TITLE
Read API: Replace polygon-based area code lookup with config-driven municipality mapping

### DIFF
--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/AreaCodeMappingConfigTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/AreaCodeMappingConfigTest.java
@@ -1,0 +1,94 @@
+package org.rutebanken.tiamat.ext.fintraffic.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AreaCodeMappingConfigTest {
+
+    private AreaCodeMappingConfig buildConfig(Map<String, String> areaCodes) {
+        return buildConfig(areaCodes, Map.of());
+    }
+
+    private AreaCodeMappingConfig buildConfig(Map<String, String> areaCodes, Map<String, String> displayNames) {
+        AreaCodeMappingConfig config = new AreaCodeMappingConfig();
+        config.setAreaCodes(areaCodes);
+        config.setAreaCodeDisplayNames(displayNames);
+        config.buildReverseIndex();
+        return config;
+    }
+
+    @Test
+    void getAreaCodesForMunicipalityCode_knownCode_returnsUppercaseTvvCode() {
+        AreaCodeMappingConfig config = buildConfig(Map.of("lft", "499,905"));
+
+        assertThat(config.getAreaCodesForMunicipalityCode("499")).containsExactly("LFT");
+        assertThat(config.getAreaCodesForMunicipalityCode("905")).containsExactly("LFT");
+    }
+
+    @Test
+    void getAreaCodesForMunicipalityCode_unknownCode_returnsEmptySet() {
+        AreaCodeMappingConfig config = buildConfig(Map.of("lft", "499,905"));
+
+        assertThat(config.getAreaCodesForMunicipalityCode("123")).isEmpty();
+    }
+
+    @Test
+    void getAreaCodesForMunicipalityCode_emptyConfig_returnsEmptySet() {
+        AreaCodeMappingConfig config = buildConfig(Map.of());
+
+        assertThat(config.getAreaCodesForMunicipalityCode("499")).isEmpty();
+    }
+
+    @Test
+    void getAreaCodesForMunicipalityCode_municipalityInMultipleTvvAreas_returnsAllMatchingCodes() {
+        AreaCodeMappingConfig config = buildConfig(Map.of(
+                "lft", "499,905",
+                "tfc", "049,091,499,753"
+        ));
+
+        assertThat(config.getAreaCodesForMunicipalityCode("499")).containsExactlyInAnyOrder("LFT", "TFC");
+    }
+
+    @Test
+    void getAreaCodesForMunicipalityCode_tvvKeyIsUppercased() {
+        AreaCodeMappingConfig config = buildConfig(Map.of("hsl", "091,092,235"));
+
+        assertThat(config.getAreaCodesForMunicipalityCode("091")).containsExactly("HSL");
+    }
+
+    @Test
+    void getAreaCodesForMunicipalityCode_handlesWhitespaceAroundMunicipalityCodes() {
+        AreaCodeMappingConfig config = buildConfig(Map.of("lft", " 499 , 905 "));
+
+        assertThat(config.getAreaCodesForMunicipalityCode("499")).containsExactly("LFT");
+        assertThat(config.getAreaCodesForMunicipalityCode("905")).containsExactly("LFT");
+    }
+
+    @Test
+    void getAreaCodesForMunicipalityCode_nordicCharacterKeys_areValid() {
+        AreaCodeMappingConfig config = buildConfig(
+                Map.of("atk", "035,043"),
+                Map.of("atk", "ÅTK")
+        );
+
+        assertThat(config.getAreaCodesForMunicipalityCode("035")).containsExactly("ÅTK");
+    }
+
+    @Test
+    void buildReverseIndex_invalidAreaCodeKey_throwsException() {
+        assertThatThrownBy(() -> buildConfig(Map.of("ab", "499")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid TVV area code key");
+    }
+
+    @Test
+    void buildReverseIndex_invalidMunicipalityCode_throwsException() {
+        assertThatThrownBy(() -> buildConfig(Map.of("lft", "499,abc")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid municipality code");
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyServiceTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyServiceTest.java
@@ -4,20 +4,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.FintrafficReadApiSearchKey;
+import org.rutebanken.tiamat.model.PrivateCodeStructure;
 import org.rutebanken.tiamat.model.StopPlace;
+import org.rutebanken.tiamat.model.TopographicPlace;
 import org.rutebanken.tiamat.model.VehicleModeEnumeration;
 import org.rutebanken.tiamat.repository.StopPlaceRepository;
-import org.rutebanken.tiamat.repository.TopographicPlaceRepository;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class FintrafficSearchKeyServiceTest {
 
@@ -25,13 +24,18 @@ class FintrafficSearchKeyServiceTest {
 
     @BeforeEach
     void setUp() {
-        TopographicPlaceRepository topographicPlaceRepositoryMock = mock(TopographicPlaceRepository.class);
         StopPlaceRepository stopPlaceRepositoryMock = mock(StopPlaceRepository.class);
-        when(topographicPlaceRepositoryMock.findTopographicPlace(any())).thenReturn(List.of());
+
+        AreaCodeMappingConfig areaCodeMappingConfig = new AreaCodeMappingConfig();
+        areaCodeMappingConfig.setAreaCodes(Map.of(
+                "lft", "499,905",
+                "hsl", "049,091,092,235,245,257,753,755,858"
+        ));
+        areaCodeMappingConfig.buildReverseIndex();
 
         service = new FintrafficSearchKeyService(
                 new ObjectMapper(),
-                topographicPlaceRepositoryMock,
+                areaCodeMappingConfig,
                 stopPlaceRepositoryMock
         );
     }
@@ -45,6 +49,16 @@ class FintrafficSearchKeyServiceTest {
         stopPlace.setNetexId(netexId);
         stopPlace.setTransportMode(transportMode);
         stopPlace.setVersion(version);
+        return stopPlace;
+    }
+
+    private StopPlace createStopPlaceWithMunicipality(String netexId, VehicleModeEnumeration transportMode, String municipalityCode) {
+        StopPlace stopPlace = createStopPlace(netexId, transportMode);
+        TopographicPlace topographicPlace = new TopographicPlace();
+        PrivateCodeStructure privateCode = new PrivateCodeStructure();
+        privateCode.setValue(municipalityCode);
+        topographicPlace.setPrivateCode(privateCode);
+        stopPlace.setTopographicPlace(topographicPlace);
         return stopPlace;
     }
 
@@ -156,5 +170,44 @@ class FintrafficSearchKeyServiceTest {
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse search key JSON: " + json, e);
         }
+    }
+
+    @Test
+    void generateSearchKeyJSON_stopPlaceWithMunicipality_containsAreaCode() {
+        StopPlace stopPlace = createStopPlaceWithMunicipality("FSR:StopPlace:100", VehicleModeEnumeration.BUS, "499");
+
+        FintrafficReadApiSearchKey searchKey = parseSearchKey(service.generateSearchKeyJSON(stopPlace));
+
+        assertThat(searchKey.areaCodes()).containsExactly("LFT");
+        assertThat(searchKey.municipalityCodes()).containsExactly("499");
+    }
+
+    @Test
+    void generateSearchKeyJSON_stopPlaceWithNoTopographicPlace_emptyAreaCodes() {
+        StopPlace stopPlace = createStopPlace("FSR:StopPlace:101", VehicleModeEnumeration.BUS);
+
+        FintrafficReadApiSearchKey searchKey = parseSearchKey(service.generateSearchKeyJSON(stopPlace));
+
+        assertThat(searchKey.areaCodes()).isEmpty();
+        assertThat(searchKey.municipalityCodes()).isEmpty();
+    }
+
+    @Test
+    void generateSearchKeyJSON_stopPlaceWithUnknownMunicipalityCode_emptyAreaCodes() {
+        StopPlace stopPlace = createStopPlaceWithMunicipality("FSR:StopPlace:102", VehicleModeEnumeration.BUS, "999");
+
+        FintrafficReadApiSearchKey searchKey = parseSearchKey(service.generateSearchKeyJSON(stopPlace));
+
+        assertThat(searchKey.areaCodes()).isEmpty();
+        assertThat(searchKey.municipalityCodes()).containsExactly("999");
+    }
+
+    @Test
+    void generateSearchKeyJSON_stopPlaceWithMunicipality_areaCodeIsUppercase() {
+        StopPlace stopPlace = createStopPlaceWithMunicipality("FSR:StopPlace:103", VehicleModeEnumeration.BUS, "091");
+
+        FintrafficReadApiSearchKey searchKey = parseSearchKey(service.generateSearchKeyJSON(stopPlace));
+
+        assertThat(searchKey.areaCodes()).containsExactly("HSL");
     }
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/AreaCodeMappingConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/AreaCodeMappingConfig.java
@@ -1,0 +1,79 @@
+package org.rutebanken.tiamat.ext.fintraffic.api;
+
+import jakarta.annotation.PostConstruct;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@ConfigurationProperties(prefix = "ext.fintraffic")
+public class AreaCodeMappingConfig {
+
+    private static final Logger logger = LoggerFactory.getLogger(AreaCodeMappingConfig.class);
+
+    private Map<String, String> areaCodes = new HashMap<>();
+
+    // Spring Boot relaxed binding strips non-ASCII chars from @ConfigurationProperties map keys,
+    // so Nordic TVV codes must use ASCII keys in properties with display-name overrides here.
+    private Map<String, String> areaCodeDisplayNames = new HashMap<>();
+
+    // Built at startup: "499" → {"LFT"}, "091" → {"HSL", "TFC"}, etc.
+    private Map<String, Set<String>> reverseIndex = Collections.emptyMap();
+
+    @PostConstruct
+    void buildReverseIndex() {
+        if (areaCodes.isEmpty()) {
+            logger.warn("No ext.fintraffic.areaCodes mappings configured — all area code lookups will return empty results");
+        }
+        Map<String, Set<String>> index = new HashMap<>();
+        areaCodes.forEach((tvvCode, codesStr) -> {
+            String uppercaseTvvCode = areaCodeDisplayNames.getOrDefault(tvvCode, tvvCode.toUpperCase());
+            if (!FintrafficConstants.isValidAreaCode(uppercaseTvvCode)) {
+                throw new IllegalArgumentException(
+                        "Invalid TVV area code key in ext.fintraffic.area-codes: '" + tvvCode
+                                + "' (resolved to '" + uppercaseTvvCode + "')"
+                );
+            }
+            for (String municipalityCode : codesStr.split(",")) {
+                String trimmed = municipalityCode.trim();
+                if (!trimmed.isEmpty()) {
+                    if (!FintrafficConstants.isValidMunicipalityCode(trimmed)) {
+                        throw new IllegalArgumentException(
+                                "Invalid municipality code in ext.fintraffic.areaCodes." + tvvCode + ": '" + trimmed + "'"
+                        );
+                    }
+                    index.computeIfAbsent(trimmed, k -> new HashSet<>()).add(uppercaseTvvCode);
+                }
+            }
+        });
+        // Make value sets immutable to prevent external modification
+        index.replaceAll((k, v) -> Set.copyOf(v));
+        this.reverseIndex = Collections.unmodifiableMap(index);
+    }
+
+    public Set<String> getAreaCodesForMunicipalityCode(String municipalityCode) {
+        return reverseIndex.getOrDefault(municipalityCode, Set.of());
+    }
+
+    public void setAreaCodes(Map<String, String> areaCodes) {
+        this.areaCodes = areaCodes;
+    }
+
+    public Map<String, String> getAreaCodes() {
+        return areaCodes;
+    }
+
+    public void setAreaCodeDisplayNames(Map<String, String> areaCodeDisplayNames) {
+        this.areaCodeDisplayNames = areaCodeDisplayNames;
+    }
+
+    public Map<String, String> getAreaCodeDisplayNames() {
+        return areaCodeDisplayNames;
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/AreaCodeMappingConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/AreaCodeMappingConfig.java
@@ -5,6 +5,7 @@ import org.rutebanken.tiamat.ext.fintraffic.FintrafficConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Profile;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -12,6 +13,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+@Profile("fintraffic-read-api")
 @ConfigurationProperties(prefix = "ext.fintraffic")
 public class AreaCodeMappingConfig {
 

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficReadApiConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficReadApiConfig.java
@@ -8,9 +8,9 @@ import org.rutebanken.tiamat.ext.fintraffic.api.repository.NetexRepository;
 import org.rutebanken.tiamat.netex.id.ValidPrefixList;
 import org.rutebanken.tiamat.netex.mapping.NetexMapper;
 import org.rutebanken.tiamat.repository.StopPlaceRepository;
-import org.rutebanken.tiamat.repository.TopographicPlaceRepository;
 import org.rutebanken.tiamat.time.ExportTimeZone;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -18,6 +18,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 @Profile("fintraffic-read-api")
 @Configuration
+@EnableConfigurationProperties(AreaCodeMappingConfig.class)
 public class FintrafficReadApiConfig {
     @Bean
     public NetexRepository netexRepository(
@@ -47,12 +48,12 @@ public class FintrafficReadApiConfig {
     @Bean
     public SearchKeyService searchKeyService(
             ObjectMapper objectMapper,
-            TopographicPlaceRepository topographicPlaceRepository,
+            AreaCodeMappingConfig areaCodeMappingConfig,
             StopPlaceRepository stopPlaceRepository
     ) {
         return new FintrafficSearchKeyService(
                 objectMapper,
-                topographicPlaceRepository,
+                areaCodeMappingConfig,
                 stopPlaceRepository
         );
     }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyService.java
@@ -2,15 +2,7 @@ package org.rutebanken.tiamat.ext.fintraffic.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import jakarta.annotation.Nonnull;
 import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.geom.Polygonal;
-import org.locationtech.jts.geom.prep.PreparedPolygon;
-import org.rutebanken.tiamat.exporter.params.ExportParams;
-import org.rutebanken.tiamat.exporter.params.TopographicPlaceSearch;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.FintrafficReadApiSearchKey;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiSearchKey;
 import org.rutebanken.tiamat.model.EntityInVersionStructure;
@@ -19,18 +11,12 @@ import org.rutebanken.tiamat.model.PrivateCodeStructure;
 import org.rutebanken.tiamat.model.SiteRefStructure;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.TopographicPlace;
-import org.rutebanken.tiamat.model.TopographicPlaceTypeEnumeration;
 import org.rutebanken.tiamat.model.VehicleModeEnumeration;
 import org.rutebanken.tiamat.repository.StopPlaceRepository;
-import org.rutebanken.tiamat.repository.TopographicPlaceRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -41,44 +27,25 @@ import java.util.stream.Stream;
 public class FintrafficSearchKeyService implements SearchKeyService {
     private final Logger logger = LoggerFactory.getLogger(FintrafficSearchKeyService.class);
     private final ObjectMapper objectMapper;
-    private final TopographicPlaceRepository topographicPlaceRepository;
+    private final AreaCodeMappingConfig areaCodeMappingConfig;
     private final StopPlaceRepository stopPlaceRepository;
-    private static final String CODESPACE_KEY = "codespace";
-    private final LoadingCache<String, List<PolygonAndAreaCodes>> administrativeZoneGeometryIndex;
-
-    private record PolygonAndAreaCodes(PreparedPolygon polygon, Set<String> areaCodes) {
-    }
 
     public FintrafficSearchKeyService(
             ObjectMapper objectMapper,
-            TopographicPlaceRepository topographicPlaceRepository,
+            AreaCodeMappingConfig areaCodeMappingConfig,
             StopPlaceRepository stopPlaceRepository
     ) {
         this.objectMapper = objectMapper;
-        this.topographicPlaceRepository = topographicPlaceRepository;
+        this.areaCodeMappingConfig = areaCodeMappingConfig;
         this.stopPlaceRepository = stopPlaceRepository;
-
-        // Use a loading cache to store administrative zone geometries for efficient spatial queries
-        this.administrativeZoneGeometryIndex = CacheBuilder.newBuilder()
-                .maximumSize(1)
-                .expireAfterWrite(Duration.ofMinutes(5))
-                .build(new CacheLoader<>() {
-                    @Override
-                    @Nonnull
-                    public List<PolygonAndAreaCodes> load(@Nonnull String ignoredKey) {
-                        return loadPolygonsAndAreaCodes();
-                    }
-                });
     }
 
-    @Nonnull
     @Override
     public String generateSearchKeyJSON(EntityInVersionStructure entity) {
         FintrafficReadApiSearchKey searchKey = this.extractSearchKey(entity);
         return createJSONString(searchKey);
     }
 
-    @Nonnull
     private FintrafficReadApiSearchKey extractSearchKey(EntityInVersionStructure entity) {
         Optional<StopPlace> parentStopPlace = fetchParentStopPlace(entity);
         Optional<FintrafficReadApiSearchKey> searchKeyFromParent = parentStopPlace.map(this::extractSearchKey);
@@ -166,16 +133,22 @@ public class FintrafficSearchKeyService implements SearchKeyService {
                     .toArray(String[]::new);
         }
 
-        Optional<Point> stopPlaceCentroid = Optional.ofNullable(stopPlace.getCentroid());
-        Optional<String[]> areaCodes = stopPlaceCentroid.map(this::getAdministrativeZonesForPoint);
+        String[] areaCodes = getMunicipalityCode(stopPlace)
+                .map(areaCodeMappingConfig::getAreaCodesForMunicipalityCode)
+                .map(codes -> codes.toArray(String[]::new))
+                .orElse(new String[]{});
 
-        String[] municipalityCodes = Optional.ofNullable(stopPlace.getTopographicPlace())
-                .map(TopographicPlace::getPrivateCode)
-                .map(PrivateCodeStructure::getValue)
+        String[] municipalityCodes = getMunicipalityCode(stopPlace)
                 .map(code -> new String[]{code})
                 .orElse(new String[]{});
 
-        return new FintrafficReadApiSearchKey(transportModes, areaCodes.orElse(new String[]{}), municipalityCodes);
+        return new FintrafficReadApiSearchKey(transportModes, areaCodes, municipalityCodes);
+    }
+
+    private Optional<String> getMunicipalityCode(StopPlace stopPlace) {
+        return Optional.ofNullable(stopPlace.getTopographicPlace())
+                .map(TopographicPlace::getPrivateCode)
+                .map(PrivateCodeStructure::getValue);
     }
 
     private String createJSONString(ReadApiSearchKey searchKey) {
@@ -185,42 +158,5 @@ public class FintrafficSearchKeyService implements SearchKeyService {
             throw new RuntimeException("Failed to convert search key to JSON", e);
         }
     }
-
-    private String[] getAdministrativeZonesForPoint(Point point) {
-        try {
-            List<PolygonAndAreaCodes> polygons = administrativeZoneGeometryIndex.get("ALL_ZONES");
-            return new ArrayList<>(polygons).stream()
-                    .filter(p -> p.polygon().contains(point))
-                    .map(p -> p.areaCodes)
-                    .filter(Objects::nonNull)
-                    .flatMap(Collection::stream)
-                    .toArray(String[]::new);
-        } catch (Exception e) {
-            logger.error("Error retrieving administrative zones for point: {}", point, e);
-            throw new RuntimeException("Error retrieving administrative zones for point: " + point, e);
-        }
-    }
-
-    private List<PolygonAndAreaCodes> loadPolygonsAndAreaCodes() {
-        Instant start = Instant.now();
-        TopographicPlaceSearch search = TopographicPlaceSearch.newTopographicPlaceSearchBuilder()
-                .versionValidity(ExportParams.VersionValidity.CURRENT).build();
-
-        List<TopographicPlace> topographicPlaces = topographicPlaceRepository.findTopographicPlace(search);
-        List<PolygonAndAreaCodes> polygonAndAreaCodes = topographicPlaces.stream()
-                .filter(tp -> tp.getTopographicPlaceType().equals(TopographicPlaceTypeEnumeration.REGION))
-                .filter(tp -> tp.getKeyValues().containsKey(CODESPACE_KEY))
-                .filter(tp -> tp.getPolygon() != null)
-                .map(tp -> new PolygonAndAreaCodes(
-                        // Create prepared polygon for efficient spatial queries
-                        new PreparedPolygon((Polygonal) tp.getPolygon().copy()),
-                        // Create a copy to ensure immutability
-                        Set.copyOf(tp.getKeyValues().get(CODESPACE_KEY).getItems())
-                ))
-                .toList();
-        Instant end = Instant.now();
-        long duration = Duration.between(start, end).toMillis();
-        logger.info("Prepared {} zone geometries for spatial queries in {} ms", polygonAndAreaCodes.size(), duration);
-        return polygonAndAreaCodes;
-    }
 }
+

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyService.java
@@ -2,7 +2,6 @@ package org.rutebanken.tiamat.ext.fintraffic.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.locationtech.jts.geom.Point;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.FintrafficReadApiSearchKey;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiSearchKey;
 import org.rutebanken.tiamat.model.EntityInVersionStructure;
@@ -17,10 +16,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 @Transactional(readOnly = true)

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/repository/FintrafficNetexRepository.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/repository/FintrafficNetexRepository.java
@@ -72,7 +72,8 @@ public class FintrafficNetexRepository extends AbstractNetexRepository {
                 WHEN 'StopPlace' THEN 4
                 WHEN 'Parking' THEN 5
                 ELSE 6
-            END
+            END,
+            id
         """);
 
         return jdbc.queryForStream(


### PR DESCRIPTION
Maintaining TVV TopographicPlace polygons in the database is error-prone and unnecessary — the mapping from municipalities to TVV areas is stable administrative data that rarely changes. Moving it to `application.properties` makes updates trivial and eliminates the dependency on REGION TopographicPlace entities with polygon geometries.

### What changed

- **`AreaCodeMappingConfig`** — New `@ConfigurationProperties` bean (active on `fintraffic-read-api` profile only) that reads `ext.fintraffic.area-codes.*` from `application.properties`, validates entries at startup, and builds an immutable reverse index (municipality code → TVV codes). Handles Nordic keys (`ÅTK`, `FÖL`) via display-name overrides.

- **`FintrafficSearchKeyService`** — Replaced `TopographicPlaceRepository` polygon queries and the Guava `LoadingCache` with a simple lookup through `AreaCodeMappingConfig.getAreaCodesForMunicipalityCode()`. Area codes are now derived from the StopPlace's TopographicPlace PrivateCode (municipality code) instead of centroid-in-polygon spatial queries.

- **`FintrafficNetexRepository`** — Added secondary `ORDER BY id` to the Read API query for deterministic response ordering within each entity type.

### Configuration example

```properties
### Regional TVVs — each key maps to the municipality codes the TVV covers
ext.fintraffic.area-codes.hsl=049,091,092,235,245,257,753,755,858
ext.fintraffic.area-codes.lft=499,905

### Nordic key display-name overrides (Spring strips non-ASCII from map keys)
ext.fintraffic.area-code-display-names.atk=ÅTK
ext.fintraffic.area-code-display-names.fol=FÖL
```

### Post-deploy action

A **batch rebuild** of all search keys is required after deployment to re-derive area codes from the new config mapping.