### PR TITLE
Add AWS config for Hazelcast

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/config/HazelCastConfig.java
+++ b/src/main/java/org/rutebanken/tiamat/config/HazelCastConfig.java
@@ -41,9 +41,7 @@ public class HazelCastConfig {
         JoinConfig joinConfig = config.getNetworkConfig().getJoin();
         joinConfig.getMulticastConfig().setEnabled(false);
 
-        if (awsEnabled) {
-            joinConfig.getAwsConfig().setEnabled(true);
-        }
+        joinConfig.getAwsConfig().setEnabled(awsEnabled);
 
         joinConfig.getKubernetesConfig().setEnabled(kubernetesEnabled);
         joinConfig.getKubernetesConfig().setProperty("namespace", hazelcastNamespace);

--- a/src/main/java/org/rutebanken/tiamat/config/HazelCastConfig.java
+++ b/src/main/java/org/rutebanken/tiamat/config/HazelCastConfig.java
@@ -21,6 +21,9 @@ public class HazelCastConfig {
     @Value("${tiamat.hazelcast.kubernetes.enabled:false}")
     private boolean kubernetesEnabled;
 
+    @Value("${tiamat.hazelcast.aws.enabled:false}")
+    private boolean awsEnabled;
+
     @Value("${tiamat.hazelcast.cluster.name:tiamat}")
     private String hazelcastClusterName;
 
@@ -35,9 +38,12 @@ public class HazelCastConfig {
         // Configure network settings
         config.getNetworkConfig().setPortAutoIncrement(false);
 
-        // Configure Kubernetes discovery
         JoinConfig joinConfig = config.getNetworkConfig().getJoin();
         joinConfig.getMulticastConfig().setEnabled(false);
+
+        if (awsEnabled) {
+            joinConfig.getAwsConfig().setEnabled(true);
+        }
 
         joinConfig.getKubernetesConfig().setEnabled(kubernetesEnabled);
         joinConfig.getKubernetesConfig().setProperty("namespace", hazelcastNamespace);


### PR DESCRIPTION
### Summary

Add configuration option to enable Hazelcast in AWS. The default is false. The addition is required because Hazelcast is configured using a Java class, not using the default application properties.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

The change is required to make Hazelcast behavior robust during application restarts and deployments in AWS Elastic Container Service.

Closes #45

### Unit tests

There are no unit tests added. The configuration option has been tried out in a running two node cluster.

### Documentation

The option is documented in Hazelcast docs, see https://docs.hazelcast.com/hazelcast/5.7/deploy/deploying-on-aws

---
<!-- Thank you for your contribution to entur/tiamat! -->


