### PR TITLE
Fix/fintraffic authorization invalid centroid

### DIFF
--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficAuthorizationServiceTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficAuthorizationServiceTest.java
@@ -11,6 +11,7 @@ import org.rutebanken.tiamat.exporter.params.TopographicPlaceSearch;
 import org.rutebanken.tiamat.model.GroupOfStopPlaces;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.Quay;
+import org.rutebanken.tiamat.model.SiteRefStructure;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.TopographicPlace;
 import org.rutebanken.tiamat.model.TopographicPlaceTypeEnumeration;
@@ -302,6 +303,25 @@ class FintrafficAuthorizationServiceTest {
         // Both disabled — all geographic edits denied
         assertThat(authorizationService.canEditEntity(getPoint(new Coordinate(0.5, 0.5))), equalTo(false));
         assertThat(authorizationService.canEditEntity(getPoint(new Coordinate(2.5, 2.5))), equalTo(false));
+    }
+
+    @Test
+    public void testCanEditEntityWithNullCentroidAndParentSiteRef() {
+        // Parking without centroid but with parentSiteRef — parent was already geographically authorized
+        Parking parkingWithoutGeometry = getParking("FSR:Parking:99", null);
+        parkingWithoutGeometry.setParentSiteRef(new SiteRefStructure("FSR:StopPlace:50"));
+
+        FintrafficAuthorizationService authorizationService = getAuthorizationService();
+        assertThat(authorizationService.canEditEntity(parkingWithoutGeometry), equalTo(true));
+    }
+
+    @Test
+    public void testCanEditEntityWithNullCentroidAndNoParent() {
+        // Entity without centroid and without parent — editing is denied
+        Parking parkingWithoutGeometry = getParking("FSR:Parking:99", null);
+
+        FintrafficAuthorizationService authorizationService = getAuthorizationService();
+        assertThat(authorizationService.canEditEntity(parkingWithoutGeometry), equalTo(false));
     }
 
     @Test

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficAuthorizationService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficAuthorizationService.java
@@ -10,6 +10,7 @@ import org.rutebanken.tiamat.exporter.params.ExportParams;
 import org.rutebanken.tiamat.exporter.params.TopographicPlaceSearch;
 import org.rutebanken.tiamat.model.EntityStructure;
 import org.rutebanken.tiamat.model.FareZone;
+import org.rutebanken.tiamat.model.Site_VersionStructure;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.StopTypeEnumeration;
 import org.rutebanken.tiamat.model.TopographicPlace;
@@ -167,7 +168,20 @@ public class FintrafficAuthorizationService implements AuthorizationService {
         }
 
         if (entity instanceof Zone_VersionStructure zone) {
-            return canEditEntity(zone.getCentroid(), logAuthorizationCheck);
+            Point centroid = zone.getCentroid();
+            if (centroid == null && entity instanceof Site_VersionStructure site && site.getParentSiteRef() != null) {
+                // Parent entity was already geographically authorized — skip geographic check for this child
+                return true;
+            }
+            if (centroid == null) {
+                // Allow administrators to edit entities with missing centroid
+                if (trivoreAuthorizations.hasAccess(ENTITY_TYPE_ALL, TRANSPORT_MODE_ALL, ADMINISTER)) {
+                    return true;
+                }
+                logger.warn("Entity {} has no centroid and no parent site ref — denying edit.", entity.getNetexId());
+                return false;
+            }
+            return canEditEntity(centroid, logAuthorizationCheck);
         }
         return true;
     }


### PR DESCRIPTION
### Summary

This change fixes a null pointer exception that was encountered when a Parking entity had a null centroid in the database. The logic for authorization in this case is 
- if a parent entity has been authorized -> allow
- if the user has administrator rights -> allow
- otherwise -> deny

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

Closes #45

### Unit tests

Two new unit tests were added for the null centroid case.

### Documentation

Inline comments have been added to explain the logic.
