### PR TITLE
Make it clear in the README that a Hazelcast cluster must be configur…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ A frontend for Tiamat is available. It's name is Abzu.
 See https://github.com/entur/abzu
 
 ### Supports running multiple instances
-Tiamat uses Hazelcast memory grid to communicate with other instances in kubernetes.
-This means that you can run multiple instances.
+Tiamat uses a Hazelcast memory grid to communicate with other instances in Kubernetes or AWS Fargate.
+This means that you can run multiple instances. If multiple instances are running, the Hazelcast cluster **must** be 
+configured correctly. The application instances **must** be able to accept incoming connections to the configured 
+service port `tiamat.hazelcast.service-port`. Additionally, one of the properties `tiamat.hazelcast.kubernetes.enabled` 
+or `tiamat.hazelcast.aws.enabled` **must** be set to true.
 
 ### Mapping of IDs
 After import stop places and assigning new IDs to stop places, tiamat keeps olds IDs in a mapping table.


### PR DESCRIPTION
Make it clear in the README that a Hazelcast cluster must be configured when running multiple instances. Document properties for Kubernets and AWS.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

Documentation for AWS was missing.

Closes #45

### Unit tests

N/A

### Documentation

Readme updated
---


