### PR TITLE
Support external versioning and FareFrame-backed GroupOfTariffZones import

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,15 @@ tiamat.locals.language.default=eng
 
 tariffZoneLookupService.resetReferences=true
 
+# External versioning (Tiamat as replica of master register): keep a single version per netexId
+# using the incoming version number, and clean up entities not present in the delivery
+fareZone.externalVersioning=false
+groupOfTariffZones.externalVersioning=false
+
+# TariffZones are deprecated. When enabled, plain TariffZones are skipped on import
+# (FareZones and GroupOfTariffZones are still imported)
+ignoreTariffZoneImport=false
+
 debug=true
 
 # Disable feature detection by this undocumented parameter. Check the org.hibernate.engine.jdbc.internal.JdbcServiceImpl.configure method for more details.
@@ -536,6 +545,35 @@ curl -XPOST -H"Content-Type: application/xml" \
 - `FARE_FRAME` mode returns FareFrame with fareZones only
 
 **Note:** When using `FARE_FRAME` mode, ensure your input XML has the correct NeTEx structure with FrameDefaults before ValidBetween elements.
+
+### Combined SiteFrame and FareFrame deliveries
+
+A publication delivery may contain both a SiteFrame and a FareFrame (Nordic profile: FareZones live in the FareFrame, while the GroupOfTariffZones referencing them lives in the SiteFrame). When both frames are present:
+
+- FareZones in the FareFrame are imported first, so a GroupOfTariffZones in the SiteFrame can reference them within the same delivery.
+- Group members not supplied in the delivery are resolved against already persisted FareZones in the database. The import fails if a referenced zone cannot be resolved either way.
+
+### External versioning for GroupOfTariffZones
+
+When Tiamat acts as a replica of a master register, version numbers can be managed externally:
+
+```properties
+groupOfTariffZones.externalVersioning=false
+```
+
+When enabled:
+- Only a single version is kept per netexId, updated in place using the incoming version number.
+- After import, groups not present in the delivery are deleted (full replace semantics).
+
+The equivalent property for FareZones is `fareZone.externalVersioning`. When enabled, FareZones not present in an incoming FareFrame delivery are pruned after import.
+
+### Ignoring deprecated TariffZones on import
+
+Plain TariffZones are deprecated in favour of FareZones. To skip them during import while still importing FareZones and GroupOfTariffZones:
+
+```properties
+ignoreTariffZoneImport=false
+```
 
 ## GraphQL
 GraphQL endpoint is available on

--- a/src/main/java/org/rutebanken/tiamat/config/GroupOfTariffZonesConfig.java
+++ b/src/main/java/org/rutebanken/tiamat/config/GroupOfTariffZonesConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GroupOfTariffZonesConfig {
+
+    @Value("${groupOfTariffZones.externalVersioning:false}")
+    private boolean externalVersioning;
+
+    public boolean isExternalVersioning() {
+        return externalVersioning;
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/config/TariffZoneConfig.java
+++ b/src/main/java/org/rutebanken/tiamat/config/TariffZoneConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TariffZoneConfig {
+
+    /**
+     * TariffZones are deprecated. When enabled, plain TariffZones are skipped on import
+     * (FareZones and GroupOfTariffZones are still imported).
+     */
+    @Value("${ignoreTariffZoneImport:false}")
+    private boolean ignoreImport;
+
+    public boolean isIgnoreImport() {
+        return ignoreImport;
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/importer/GroupOfTariffZonesImportResult.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/GroupOfTariffZonesImportResult.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.importer;
+
+import org.rutebanken.netex.model.GroupOfTariffZones;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Result of GroupOfTariffZones import operation.
+ * Contains the imported groups and their netexIds for cleanup tracking.
+ */
+public record GroupOfTariffZonesImportResult(List<GroupOfTariffZones> importedGroupsOfTariffZones, Set<String> importedNetexIds) {
+
+}

--- a/src/main/java/org/rutebanken/tiamat/importer/GroupOfTariffZonesImporter.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/GroupOfTariffZonesImporter.java
@@ -16,6 +16,7 @@
 package org.rutebanken.tiamat.importer;
 
 import org.rutebanken.netex.model.GroupOfTariffZones;
+import org.rutebanken.tiamat.config.GroupOfTariffZonesConfig;
 import org.rutebanken.tiamat.netex.mapping.NetexMapper;
 import org.rutebanken.tiamat.versioning.save.GroupOffTariffZonesSaverService;
 import org.slf4j.Logger;
@@ -23,9 +24,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-
-import static java.util.stream.Collectors.toList;
+import java.util.Set;
 
 @Transactional
 @Component
@@ -35,22 +37,37 @@ public class GroupOfTariffZonesImporter {
 
     private final NetexMapper netexMapper;
     private final GroupOffTariffZonesSaverService groupOffTariffZonesSaverService;
+    private final GroupOfTariffZonesConfig groupOfTariffZonesConfig;
 
     public GroupOfTariffZonesImporter(NetexMapper netexMapper,
-                                      GroupOffTariffZonesSaverService groupOffTariffZonesSaverService) {
+                                      GroupOffTariffZonesSaverService groupOffTariffZonesSaverService,
+                                      GroupOfTariffZonesConfig groupOfTariffZonesConfig) {
         this.netexMapper = netexMapper;
         this.groupOffTariffZonesSaverService = groupOffTariffZonesSaverService;
+        this.groupOfTariffZonesConfig = groupOfTariffZonesConfig;
     }
 
-    public List<GroupOfTariffZones> importGroupOfTariffZones(List<org.rutebanken.tiamat.model.GroupOfTariffZones> groupOfTariffZones) {
+    public GroupOfTariffZonesImportResult importGroupOfTariffZones(List<org.rutebanken.tiamat.model.GroupOfTariffZones> groupOfTariffZones) {
 
-        return groupOfTariffZones
-                .stream()
-                .peek(incomingGoTZ -> logger.info("Importing group of tariff zone {}, version {}",
-                        incomingGoTZ.getNetexId(), incomingGoTZ.getVersion()))
-                .map(groupOffTariffZonesSaverService::saveNewVersion)
-                .map(savedGoTZ -> netexMapper.getFacade().map(savedGoTZ, GroupOfTariffZones.class))
-                .collect(toList());
+        boolean externalVersioning = groupOfTariffZonesConfig.isExternalVersioning();
+        Set<String> importedNetexIds = new HashSet<>();
+        List<GroupOfTariffZones> importedGroups = new ArrayList<>();
+
+        for (org.rutebanken.tiamat.model.GroupOfTariffZones incomingGroup : groupOfTariffZones) {
+            logger.info("Importing group of tariff zone {}, version {} (external versioning: {})",
+                    incomingGroup.getNetexId(), incomingGroup.getVersion(), externalVersioning);
+
+            org.rutebanken.tiamat.model.GroupOfTariffZones saved = externalVersioning
+                    ? groupOffTariffZonesSaverService.saveWithExternalVersioning(incomingGroup)
+                    : groupOffTariffZonesSaverService.saveNewVersion(incomingGroup);
+
+            if (saved != null && saved.getNetexId() != null) {
+                importedNetexIds.add(saved.getNetexId());
+            }
+            importedGroups.add(netexMapper.getFacade().map(saved, GroupOfTariffZones.class));
+        }
+
+        return new GroupOfTariffZonesImportResult(importedGroups, importedNetexIds);
     }
 
 }

--- a/src/main/java/org/rutebanken/tiamat/importer/GroupOfTariffZonesImporter.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/GroupOfTariffZonesImporter.java
@@ -61,9 +61,7 @@ public class GroupOfTariffZonesImporter {
                     ? groupOffTariffZonesSaverService.saveWithExternalVersioning(incomingGroup)
                     : groupOffTariffZonesSaverService.saveNewVersion(incomingGroup);
 
-            if (saved != null && saved.getNetexId() != null) {
-                importedNetexIds.add(saved.getNetexId());
-            }
+            importedNetexIds.add(saved.getNetexId());
             importedGroups.add(netexMapper.getFacade().map(saved, GroupOfTariffZones.class));
         }
 

--- a/src/main/java/org/rutebanken/tiamat/importer/PublicationDeliveryImporter.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/PublicationDeliveryImporter.java
@@ -40,6 +40,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.Collections;
 import java.util.Set;
@@ -68,6 +70,7 @@ public class PublicationDeliveryImporter {
     private final AuthorizationService authorizationService;
     private final FareZoneConfig fareZoneConfig;
     private final FareZoneSaverService fareZoneSaverService;
+    private final TransactionTemplate transactionTemplate;
     private final boolean authorizationEnabled;
 
     @Autowired
@@ -83,6 +86,7 @@ public class PublicationDeliveryImporter {
                                        AuthorizationService authorizationService,
                                        FareZoneConfig fareZoneConfig,
                                        FareZoneSaverService fareZoneSaverService,
+                                       PlatformTransactionManager transactionManager,
                                        @Value("${authorization.enabled:true}") boolean authorizationEnabled) {
         this.publicationDeliveryHelper = publicationDeliveryHelper;
         this.parkingsImportHandler = parkingsImportHandler;
@@ -96,6 +100,7 @@ public class PublicationDeliveryImporter {
         this.authorizationService = authorizationService;
         this.fareZoneConfig = fareZoneConfig;
         this.fareZoneSaverService = fareZoneSaverService;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
         this.authorizationEnabled = authorizationEnabled;
     }
 
@@ -104,7 +109,6 @@ public class PublicationDeliveryImporter {
         return importPublicationDelivery(incomingPublicationDelivery, null);
     }
 
-    @SuppressWarnings("unchecked")
     public PublicationDeliveryStructure importPublicationDelivery(PublicationDeliveryStructure incomingPublicationDelivery, ImportParams importParams) {
         if(authorizationEnabled && !authorizationService.canEditAllEntities()){
                 throw new AccessDeniedException("Insufficient privileges for operation");
@@ -159,19 +163,27 @@ public class PublicationDeliveryImporter {
 
             // Import fare zones carried in an accompanying FareFrame, so that a GroupOfTariffZones
             // in the SiteFrame can reference them within the same delivery.
-            Set<String> fareFrameZoneIds = Collections.emptySet();
+            final Set<String> fareFrameZoneIds;
             if (netexFareFrame != null) {
                 FareFrame responseFareFrame = new FareFrame().withId(requestId + "-fareframe-response").withVersion("1");
                 fareFrameZoneIds = tariffZoneImportHandler.handleFareZonesFromFareFrame(netexFareFrame, importParams, tariffZoneCounter, responseFareFrame);
+                } else {
+                fareFrameZoneIds = Collections.emptySet();
+            }
 
+            // Run the external versioning FareZone cleanup and the GroupOfTariffZones import in a single
+            // transaction, so that a failed group member validation rolls back the deletes instead of
+            // leaving FareZones permanently removed by a rejected import.
+            final ImportParams finalImportParams = importParams;
+            transactionTemplate.executeWithoutResult(transactionStatus -> {
                 // With external versioning the import is a full replace: prune FareZones not present in this delivery.
                 if (fareZoneConfig.isExternalVersioning() && !fareFrameZoneIds.isEmpty()) {
                     int deletedCount = fareZoneSaverService.deleteAllExcept(fareFrameZoneIds);
                     logger.info("External versioning cleanup: deleted {} orphaned FareZones", deletedCount);
                 }
-            }
 
-            groupOfTariffZonesImportHandler.handleGroupOfTariffZones(netexSiteFrame, importParams, responseSiteFrame, fareFrameZoneIds);
+                groupOfTariffZonesImportHandler.handleGroupOfTariffZones(netexSiteFrame, finalImportParams, responseSiteFrame, fareFrameZoneIds);
+            });
             stopPlaceImportHandler.handleStops(netexSiteFrame, importParams, stopPlaceCounter, responseSiteFrame);
             parkingsImportHandler.handleParkings(netexSiteFrame, importParams, parkingCounter, responseSiteFrame);
             pathLinkImportHandler.handlePathLinks(netexSiteFrame, importParams, pathLinkCounter, responseSiteFrame);

--- a/src/main/java/org/rutebanken/tiamat/importer/PublicationDeliveryImporter.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/PublicationDeliveryImporter.java
@@ -15,9 +15,11 @@
 
 package org.rutebanken.tiamat.importer;
 
+import org.rutebanken.netex.model.FareFrame;
 import org.rutebanken.netex.model.PublicationDeliveryStructure;
 import org.rutebanken.netex.model.SiteFrame;
 import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.config.FareZoneConfig;
 import org.rutebanken.tiamat.exporter.PublicationDeliveryCreator;
 import org.rutebanken.tiamat.importer.handler.GroupOfTariffZonesImportHandler;
 import org.rutebanken.tiamat.importer.handler.ParkingsImportHandler;
@@ -30,6 +32,7 @@ import org.rutebanken.tiamat.importer.log.ImportLoggerTask;
 import org.rutebanken.tiamat.netex.mapping.NetexMapper;
 import org.rutebanken.tiamat.netex.mapping.PublicationDeliveryHelper;
 import org.rutebanken.tiamat.service.batch.BackgroundJobs;
+import org.rutebanken.tiamat.versioning.save.FareZoneSaverService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -38,6 +41,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.Timer;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -61,6 +66,8 @@ public class PublicationDeliveryImporter {
     private final TopographicPlaceImportHandler topographicPlaceImportHandler;
     private final BackgroundJobs backgroundJobs;
     private final AuthorizationService authorizationService;
+    private final FareZoneConfig fareZoneConfig;
+    private final FareZoneSaverService fareZoneSaverService;
     private final boolean authorizationEnabled;
 
     @Autowired
@@ -74,6 +81,8 @@ public class PublicationDeliveryImporter {
                                        ParkingsImportHandler parkingsImportHandler,
                                        BackgroundJobs backgroundJobs,
                                        AuthorizationService authorizationService,
+                                       FareZoneConfig fareZoneConfig,
+                                       FareZoneSaverService fareZoneSaverService,
                                        @Value("${authorization.enabled:true}") boolean authorizationEnabled) {
         this.publicationDeliveryHelper = publicationDeliveryHelper;
         this.parkingsImportHandler = parkingsImportHandler;
@@ -85,6 +94,8 @@ public class PublicationDeliveryImporter {
         this.stopPlaceImportHandler = stopPlaceImportHandler;
         this.backgroundJobs = backgroundJobs;
         this.authorizationService = authorizationService;
+        this.fareZoneConfig = fareZoneConfig;
+        this.fareZoneSaverService = fareZoneSaverService;
         this.authorizationEnabled = authorizationEnabled;
     }
 
@@ -125,6 +136,10 @@ public class PublicationDeliveryImporter {
         // Currently only supporting one site frame per publication delivery
         SiteFrame netexSiteFrame = publicationDeliveryHelper.findSiteFrame(incomingPublicationDelivery);
 
+        // A FareFrame may accompany the SiteFrame (Nordic profile: FareZones live in the FareFrame,
+        // while the GroupOfTariffZones referencing them lives in the SiteFrame).
+        FareFrame netexFareFrame = publicationDeliveryHelper.findFareFrame(incomingPublicationDelivery);
+
         String requestId = netexSiteFrame.getId();
 
         updateMappingContext(netexSiteFrame);
@@ -141,7 +156,22 @@ public class PublicationDeliveryImporter {
 
             topographicPlaceImportHandler.handleTopographicPlaces(netexSiteFrame, importParams, topographicPlaceCounter ,responseSiteFrame);
             tariffZoneImportHandler.handleTariffZones(netexSiteFrame, importParams, tariffZoneCounter, responseSiteFrame);
-            groupOfTariffZonesImportHandler.handleGroupOfTariffZones(netexSiteFrame,importParams,responseSiteFrame);
+
+            // Import fare zones carried in an accompanying FareFrame, so that a GroupOfTariffZones
+            // in the SiteFrame can reference them within the same delivery.
+            Set<String> fareFrameZoneIds = Collections.emptySet();
+            if (netexFareFrame != null) {
+                FareFrame responseFareFrame = new FareFrame().withId(requestId + "-fareframe-response").withVersion("1");
+                fareFrameZoneIds = tariffZoneImportHandler.handleFareZonesFromFareFrame(netexFareFrame, importParams, tariffZoneCounter, responseFareFrame);
+
+                // With external versioning the import is a full replace: prune FareZones not present in this delivery.
+                if (fareZoneConfig.isExternalVersioning() && !fareFrameZoneIds.isEmpty()) {
+                    int deletedCount = fareZoneSaverService.deleteAllExcept(fareFrameZoneIds);
+                    logger.info("External versioning cleanup: deleted {} orphaned FareZones", deletedCount);
+                }
+            }
+
+            groupOfTariffZonesImportHandler.handleGroupOfTariffZones(netexSiteFrame, importParams, responseSiteFrame, fareFrameZoneIds);
             stopPlaceImportHandler.handleStops(netexSiteFrame, importParams, stopPlaceCounter, responseSiteFrame);
             parkingsImportHandler.handleParkings(netexSiteFrame, importParams, parkingCounter, responseSiteFrame);
             pathLinkImportHandler.handlePathLinks(netexSiteFrame, importParams, pathLinkCounter, responseSiteFrame);

--- a/src/main/java/org/rutebanken/tiamat/importer/PublicationDeliveryImporter.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/PublicationDeliveryImporter.java
@@ -188,7 +188,9 @@ public class PublicationDeliveryImporter {
             parkingsImportHandler.handleParkings(netexSiteFrame, importParams, parkingCounter, responseSiteFrame);
             pathLinkImportHandler.handlePathLinks(netexSiteFrame, importParams, pathLinkCounter, responseSiteFrame);
 
-            if(responseSiteFrame.getTariffZones() != null || responseSiteFrame.getTopographicPlaces() != null) {
+            if(responseSiteFrame.getTariffZones() != null
+                    || responseSiteFrame.getTopographicPlaces() != null
+                    || !fareFrameZoneIds.isEmpty()) {
                 backgroundJobs.triggerStopPlaceUpdate();
             }
             return publicationDeliveryCreator.createPublicationDelivery(responseSiteFrame);

--- a/src/main/java/org/rutebanken/tiamat/importer/PublicationDeliveryTariffZoneImporter.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/PublicationDeliveryTariffZoneImporter.java
@@ -101,7 +101,7 @@ public class PublicationDeliveryTariffZoneImporter {
             responseSiteFrame.withId(requestId + "-response").withVersion("1");
 
             tariffZoneImportHandler.handleTariffZones(netexSiteFrame, importParams, tariffZoneCounter, responseSiteFrame);
-            groupOfTariffZonesImportHandler.handleGroupOfTariffZones(netexSiteFrame,importParams,responseSiteFrame);
+            groupOfTariffZonesImportHandler.handleGroupOfTariffZones(netexSiteFrame, importParams, responseSiteFrame, java.util.Collections.emptySet());
 
             if(responseSiteFrame.getTariffZones() != null || responseSiteFrame.getTopographicPlaces() != null) {
                 backgroundJobs.triggerStopPlaceUpdate();

--- a/src/main/java/org/rutebanken/tiamat/importer/handler/GroupOfTariffZonesImportHandler.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/handler/GroupOfTariffZonesImportHandler.java
@@ -46,20 +46,28 @@
 package org.rutebanken.tiamat.importer.handler;
 
 import com.google.api.client.util.Preconditions;
-import org.rutebanken.netex.model.FareZone;
 import org.rutebanken.netex.model.GroupOfTariffZones;
 import org.rutebanken.netex.model.GroupsOfTariffZonesInFrame_RelStructure;
 import org.rutebanken.netex.model.SiteFrame;
+import org.rutebanken.netex.model.Zone_VersionStructure;
+import org.rutebanken.tiamat.config.GroupOfTariffZonesConfig;
 import org.rutebanken.tiamat.importer.GroupOfTariffZonesImporter;
+import org.rutebanken.tiamat.importer.GroupOfTariffZonesImportResult;
 import org.rutebanken.tiamat.importer.ImportParams;
 import org.rutebanken.tiamat.importer.ImportType;
+import org.rutebanken.tiamat.model.TariffZoneRef;
 import org.rutebanken.tiamat.netex.mapping.NetexMapper;
 import org.rutebanken.tiamat.netex.mapping.PublicationDeliveryHelper;
+import org.rutebanken.tiamat.repository.FareZoneRepository;
+import org.rutebanken.tiamat.versioning.save.GroupOffTariffZonesSaverService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
@@ -72,48 +80,86 @@ public class GroupOfTariffZonesImportHandler {
     private final NetexMapper netexMapper;
 
     private final GroupOfTariffZonesImporter groupOfTariffZonesImporter;
-    
+
+    private final FareZoneRepository fareZoneRepository;
+
+    private final GroupOfTariffZonesConfig groupOfTariffZonesConfig;
+
+    private final GroupOffTariffZonesSaverService groupOffTariffZonesSaverService;
+
 
     public GroupOfTariffZonesImportHandler(PublicationDeliveryHelper publicationDeliveryHelper,
                                            NetexMapper netexMapper,
-                                           GroupOfTariffZonesImporter groupOfTariffZonesImporter) {
+                                           GroupOfTariffZonesImporter groupOfTariffZonesImporter,
+                                           FareZoneRepository fareZoneRepository,
+                                           GroupOfTariffZonesConfig groupOfTariffZonesConfig,
+                                           GroupOffTariffZonesSaverService groupOffTariffZonesSaverService) {
         this.publicationDeliveryHelper = publicationDeliveryHelper;
         this.netexMapper = netexMapper;
         this.groupOfTariffZonesImporter = groupOfTariffZonesImporter;
+        this.fareZoneRepository = fareZoneRepository;
+        this.groupOfTariffZonesConfig = groupOfTariffZonesConfig;
+        this.groupOffTariffZonesSaverService = groupOffTariffZonesSaverService;
     }
 
 
-    public void handleGroupOfTariffZones(SiteFrame netexSiteFrame, ImportParams importParams, SiteFrame responseSiteframe) {
+    public void handleGroupOfTariffZones(SiteFrame netexSiteFrame, ImportParams importParams, SiteFrame responseSiteframe, Set<String> additionalZoneIds) {
 
+        if (!publicationDeliveryHelper.hasGroupOfTariffZones(netexSiteFrame) || importParams.importType == ImportType.ID_MATCH) {
+            return;
+        }
 
-        if (publicationDeliveryHelper.hasTariffZones(netexSiteFrame) && publicationDeliveryHelper.hasGroupOfTariffZones(netexSiteFrame) && importParams.importType != ImportType.ID_MATCH) {
-            List<String> tariffZoneIds = netexSiteFrame.getTariffZones().getTariffZone().stream()
-                    .map(jaxbElement -> (FareZone) jaxbElement.getValue())
-                    .map(tz -> tz.getId())
-                    .collect(Collectors.toList());
+        // Zones declared in this SiteFrame (either TariffZone or FareZone instances share the Zone_VersionStructure supertype).
+        Set<String> knownZoneIds = new HashSet<>();
+        if (publicationDeliveryHelper.hasTariffZones(netexSiteFrame)) {
+            netexSiteFrame.getTariffZones().getTariffZone().stream()
+                    .map(jaxbElement -> (Zone_VersionStructure) jaxbElement.getValue())
+                    .map(Zone_VersionStructure::getId)
+                    .forEach(knownZoneIds::add);
+        }
 
-            List<org.rutebanken.tiamat.model.GroupOfTariffZones> tiamatGroupOfTariffZones = netexSiteFrame.getGroupsOfTariffZones().getGroupOfTariffZones().stream()
-                    .map(netexMapper::mapToTiamatModel)
-                    .collect(Collectors.toList());
+        // Zones imported from an accompanying FareFrame in the same delivery.
+        if (additionalZoneIds != null) {
+            knownZoneIds.addAll(additionalZoneIds);
+        }
 
-            //Checks if netex import file contains all the fare zones
-            validateMembers(tiamatGroupOfTariffZones,tariffZoneIds);
+        List<org.rutebanken.tiamat.model.GroupOfTariffZones> tiamatGroupOfTariffZones = netexSiteFrame.getGroupsOfTariffZones().getGroupOfTariffZones().stream()
+                .map(netexMapper::mapToTiamatModel)
+                .collect(Collectors.toList());
 
-            logger.debug("Mapped {} group tariff zones from netex to internal model", tiamatGroupOfTariffZones.size());
-            final List<GroupOfTariffZones> importedGroupOfTariffZones = groupOfTariffZonesImporter.importGroupOfTariffZones(tiamatGroupOfTariffZones);
-            
-            logger.debug("Got {} imported group of tariffZones ", importedGroupOfTariffZones.size());
+        // Members not supplied in this delivery may already be persisted (e.g. FareZones imported earlier). Resolve them from the database.
+        Set<String> unresolvedRefs = tiamatGroupOfTariffZones.stream()
+                .flatMap(group -> group.getMembers().stream())
+                .map(TariffZoneRef::getRef)
+                .filter(ref -> !knownZoneIds.contains(ref))
+                .collect(Collectors.toSet());
+        if (!unresolvedRefs.isEmpty()) {
+            fareZoneRepository.findValidFareZones(new ArrayList<>(unresolvedRefs))
+                    .forEach(fareZone -> knownZoneIds.add(fareZone.getNetexId()));
+        }
 
-            if (!importedGroupOfTariffZones.isEmpty()) {
-                responseSiteframe.withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure().withGroupOfTariffZones(importedGroupOfTariffZones));
+        // Checks that every referenced zone is resolvable (in this delivery or already persisted).
+        validateMembers(tiamatGroupOfTariffZones, knownZoneIds);
 
-            }
+        logger.debug("Mapped {} group tariff zones from netex to internal model", tiamatGroupOfTariffZones.size());
+        final GroupOfTariffZonesImportResult importResult = groupOfTariffZonesImporter.importGroupOfTariffZones(tiamatGroupOfTariffZones);
+        final List<GroupOfTariffZones> importedGroupOfTariffZones = importResult.importedGroupsOfTariffZones();
 
+        logger.debug("Got {} imported group of tariffZones ", importedGroupOfTariffZones.size());
+
+        // With external versioning the import is a full replace: prune groups not present in this delivery.
+        if (groupOfTariffZonesConfig.isExternalVersioning() && !importResult.importedNetexIds().isEmpty()) {
+            int deletedCount = groupOffTariffZonesSaverService.deleteAllExcept(importResult.importedNetexIds());
+            logger.info("External versioning cleanup: deleted {} orphaned GroupOfTariffZones", deletedCount);
+        }
+
+        if (!importedGroupOfTariffZones.isEmpty()) {
+            responseSiteframe.withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure().withGroupOfTariffZones(importedGroupOfTariffZones));
         }
     }
 
 
-    private void validateMembers(List<org.rutebanken.tiamat.model.GroupOfTariffZones>  groupOfTariffZones, List<String> tariffZoneRefs) {
+    private void validateMembers(List<org.rutebanken.tiamat.model.GroupOfTariffZones>  groupOfTariffZones, Set<String> tariffZoneRefs) {
         groupOfTariffZones.forEach(groupOfTariffZone -> groupOfTariffZone.getMembers().forEach(member ->
                 Preconditions.checkArgument(tariffZoneRefs.contains(member.getRef()),
                 "Member with reference " + member.getRef() + " does not exist when importing group of tariff zones " + groupOfTariffZones)));

--- a/src/main/java/org/rutebanken/tiamat/importer/handler/TariffZoneImportHandler.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/handler/TariffZoneImportHandler.java
@@ -54,6 +54,7 @@ import org.rutebanken.netex.model.SiteFrame;
 import org.rutebanken.netex.model.TariffZone;
 import org.rutebanken.netex.model.TariffZonesInFrame_RelStructure;
 import org.rutebanken.netex.model.Zone_VersionStructure;
+import org.rutebanken.tiamat.config.TariffZoneConfig;
 import org.rutebanken.tiamat.importer.FareZoneImporter;
 import org.rutebanken.tiamat.importer.ImportParams;
 import org.rutebanken.tiamat.importer.ImportType;
@@ -64,6 +65,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -81,14 +83,18 @@ public class TariffZoneImportHandler {
 
     private final FareZoneImporter fareZoneImporter;
 
+    private final TariffZoneConfig tariffZoneConfig;
+
     public TariffZoneImportHandler(PublicationDeliveryHelper publicationDeliveryHelper,
                                    NetexMapper netexMapper,
                                    TariffZoneImporter tariffZoneImporter,
-                                   FareZoneImporter fareZoneImporter) {
+                                   FareZoneImporter fareZoneImporter,
+                                   TariffZoneConfig tariffZoneConfig) {
         this.publicationDeliveryHelper = publicationDeliveryHelper;
         this.netexMapper = netexMapper;
         this.tariffZoneImporter = tariffZoneImporter;
         this.fareZoneImporter = fareZoneImporter;
+        this.tariffZoneConfig = tariffZoneConfig;
     }
 
 
@@ -96,11 +102,20 @@ public class TariffZoneImportHandler {
 
 
         if (publicationDeliveryHelper.hasTariffZones(netexSiteFrame) && importParams.importType != ImportType.ID_MATCH) {
-            List<org.rutebanken.tiamat.model.TariffZone> tiamatTariffZones = netexSiteFrame.getTariffZones().getTariffZone().stream()
-                    .filter(this::isTariffZone)
-                    .map(jaxbElement -> (TariffZone) jaxbElement.getValue())
-                    .map(netexMapper::mapToTiamatModel)
-                    .collect(Collectors.toList());
+            List<org.rutebanken.tiamat.model.TariffZone> tiamatTariffZones;
+            if (tariffZoneConfig.isIgnoreImport()) {
+                long ignored = netexSiteFrame.getTariffZones().getTariffZone().stream().filter(this::isTariffZone).count();
+                if (ignored > 0) {
+                    logger.info("Ignoring {} deprecated TariffZones on import (ignoreTariffZoneImport=true)", ignored);
+                }
+                tiamatTariffZones = Collections.emptyList();
+            } else {
+                tiamatTariffZones = netexSiteFrame.getTariffZones().getTariffZone().stream()
+                        .filter(this::isTariffZone)
+                        .map(jaxbElement -> (TariffZone) jaxbElement.getValue())
+                        .map(netexMapper::mapToTiamatModel)
+                        .collect(Collectors.toList());
+            }
 
             List<org.rutebanken.tiamat.model.FareZone> tiamatFareZones = netexSiteFrame.getTariffZones().getTariffZone().stream()
                     .filter(this::isFareZone)

--- a/src/main/java/org/rutebanken/tiamat/netex/id/ValidPrefixList.java
+++ b/src/main/java/org/rutebanken/tiamat/netex/id/ValidPrefixList.java
@@ -37,7 +37,7 @@ public class ValidPrefixList {
 
     @Autowired
     public ValidPrefixList(@Value("${netex.validPrefix:NSR}") String validNetexPrefix,
-                           @Value("#{${netex.id.valid.prefix.list:{TopographicPlace:{'KVE','WOF','OSM', 'ENT'},TariffZone:{'*'},FareZone:{'*'}}}}") Map<String, List<String>> validPrefixesPerType) {
+                           @Value("#{${netex.id.valid.prefix.list:{TopographicPlace:{'KVE','WOF','OSM', 'ENT'},TariffZone:{'*'},FareZone:{'*'},GroupOfTariffZones:{'*'}}}}") Map<String, List<String>> validPrefixesPerType) {
         for (String type : validPrefixesPerType.keySet()) {
             List<String> validPrefixesForType = validPrefixesPerType.get(type);
             logger.info("Loaded valid prefixes for {}: {} ", type, validPrefixesForType);

--- a/src/main/java/org/rutebanken/tiamat/repository/FareZoneRepositoryImpl.java
+++ b/src/main/java/org/rutebanken/tiamat/repository/FareZoneRepositoryImpl.java
@@ -266,8 +266,10 @@ public class FareZoneRepositoryImpl implements FareZoneRepositoryCustom {
         final Query explicitStopsQuery = entityManager.createNativeQuery(generateSqlQuery(true));
         final Query implicitStopsQuery = entityManager.createNativeQuery(generateSqlQuery(false));
 
-        explicitStopsQuery.executeUpdate();
-        implicitStopsQuery.executeUpdate();
+        final int executeUpdateExplictStops = explicitStopsQuery.executeUpdate();
+        logger.info("Updated {} explicit stop place tariff zone references(Farezone)", executeUpdateExplictStops);
+        final int executeUpdateImpilict = implicitStopsQuery.executeUpdate();
+        logger.info("Updated {} implicit stop place tariff zone references(Farezone)", executeUpdateImpilict);
     }
 
     private String generateSqlQuery(boolean explicitStops) {

--- a/src/main/java/org/rutebanken/tiamat/versioning/save/GroupOffTariffZonesSaverService.java
+++ b/src/main/java/org/rutebanken/tiamat/versioning/save/GroupOffTariffZonesSaverService.java
@@ -16,26 +16,44 @@
 package org.rutebanken.tiamat.versioning.save;
 
 
+import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.auth.UsernameFetcher;
 import org.rutebanken.tiamat.model.GroupOfTariffZones;
 import org.rutebanken.tiamat.repository.GroupOfTariffZonesRepository;
 import org.rutebanken.tiamat.versioning.validate.VersionValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class GroupOffTariffZonesSaverService {
 
+    private static final Logger logger = LoggerFactory.getLogger(GroupOffTariffZonesSaverService.class);
+
     private final GroupOfTariffZonesRepository groupOfTariffZonesRepository;
     private final DefaultVersionedSaverService defaultVersionedSaverService;
     private final VersionValidator versionValidator;
+    private final UsernameFetcher usernameFetcher;
+    private final AuthorizationService authorizationService;
 
     @Autowired
     public GroupOffTariffZonesSaverService(GroupOfTariffZonesRepository groupOfTariffZonesRepository,
                                            DefaultVersionedSaverService defaultVersionedSaverService,
-                                           VersionValidator versionValidator) {
+                                           VersionValidator versionValidator,
+                                           UsernameFetcher usernameFetcher,
+                                           AuthorizationService authorizationService) {
         this.groupOfTariffZonesRepository = groupOfTariffZonesRepository;
         this.defaultVersionedSaverService = defaultVersionedSaverService;
         this.versionValidator = versionValidator;
+        this.usernameFetcher = usernameFetcher;
+        this.authorizationService = authorizationService;
     }
 
     public GroupOfTariffZones saveNewVersion(GroupOfTariffZones newVersion) {
@@ -45,14 +63,106 @@ public class GroupOffTariffZonesSaverService {
         } else {
             existingGroupOfTariffZone = null;
         }
-        GroupOfTariffZones  saved = defaultVersionedSaverService.saveNewVersion(existingGroupOfTariffZone, newVersion, groupOfTariffZonesRepository);
-        return saved;
+        return defaultVersionedSaverService.saveNewVersion(existingGroupOfTariffZone, newVersion, groupOfTariffZonesRepository);
     }
 
     public GroupOfTariffZones saveNewVersion(GroupOfTariffZones existingVersion, GroupOfTariffZones newVersion) {
         versionValidator.validate(existingVersion, newVersion);
-        GroupOfTariffZones  saved = defaultVersionedSaverService.saveNewVersion(existingVersion, newVersion, groupOfTariffZonesRepository);
+        return defaultVersionedSaverService.saveNewVersion(existingVersion, newVersion, groupOfTariffZonesRepository);
+    }
+
+    /**
+     * Save GroupOfTariffZones with external versioning - versions are managed externally.
+     * Updates the existing GroupOfTariffZones by netexId (regardless of version) in place, or creates a
+     * new one if not found. Only a single version per netexId is kept, and the version number is taken
+     * from the incoming data. Used when Tiamat acts as a replica of a master register.
+     *
+     * @param incomingGroupOfTariffZones the group to save/update
+     * @return the saved group
+     */
+    public GroupOfTariffZones saveWithExternalVersioning(GroupOfTariffZones incomingGroupOfTariffZones) {
+        GroupOfTariffZones existingGroupOfTariffZones = null;
+
+        if (incomingGroupOfTariffZones.getNetexId() != null) {
+            existingGroupOfTariffZones = groupOfTariffZonesRepository.findFirstByNetexIdOrderByVersionDesc(incomingGroupOfTariffZones.getNetexId());
+        }
+
+        authorizationService.verifyCanEditEntities(Arrays.asList(existingGroupOfTariffZones, incomingGroupOfTariffZones));
+
+        String username = usernameFetcher.getUserNameForAuthenticatedUser();
+        Instant now = Instant.now();
+
+        GroupOfTariffZones groupToSave;
+
+        if (existingGroupOfTariffZones != null) {
+            logger.info("Updating existing GroupOfTariffZones {} from version {} to version {} with external versioning",
+                    incomingGroupOfTariffZones.getNetexId(), existingGroupOfTariffZones.getVersion(), incomingGroupOfTariffZones.getVersion());
+
+            copyFields(incomingGroupOfTariffZones, existingGroupOfTariffZones);
+            existingGroupOfTariffZones.setChanged(now);
+            existingGroupOfTariffZones.setChangedBy(username);
+            groupToSave = existingGroupOfTariffZones;
+        } else {
+            logger.info("Creating new GroupOfTariffZones {} version {} with external versioning",
+                    incomingGroupOfTariffZones.getNetexId(), incomingGroupOfTariffZones.getVersion());
+
+            incomingGroupOfTariffZones.setCreated(now);
+            incomingGroupOfTariffZones.setChangedBy(username);
+            groupToSave = incomingGroupOfTariffZones;
+        }
+
+        GroupOfTariffZones saved = groupOfTariffZonesRepository.save(groupToSave);
+
+        logger.info("Saved GroupOfTariffZones {} version {} with external versioning by user {}",
+                saved.getNetexId(), saved.getVersion(), username);
+
         return saved;
+    }
+
+    /**
+     * Copy all relevant fields from source to target GroupOfTariffZones, preserving the target's database ID.
+     */
+    private void copyFields(GroupOfTariffZones source, GroupOfTariffZones target) {
+        target.setNetexId(source.getNetexId());
+        target.setVersion(source.getVersion());
+        target.setName(source.getName());
+        target.setValidBetween(source.getValidBetween());
+
+        target.getMembers().clear();
+        target.getMembers().addAll(source.getMembers());
+    }
+
+    /**
+     * Delete all GroupOfTariffZones NOT in the provided set of netexIds.
+     * Used for cleanup after an external versioning import to remove orphaned groups.
+     * Respects user permissions and logs all deleted netexIds.
+     *
+     * @param netexIdsToKeep set of netexIds to preserve
+     * @return number of groups deleted
+     */
+    public int deleteAllExcept(Set<String> netexIdsToKeep) {
+        List<GroupOfTariffZones> allGroups = groupOfTariffZonesRepository.findAll();
+
+        List<GroupOfTariffZones> toDelete = allGroups.stream()
+                .filter(group -> !netexIdsToKeep.contains(group.getNetexId()))
+                .toList();
+
+        if (toDelete.isEmpty()) {
+            logger.info("No orphaned GroupOfTariffZones to delete");
+            return 0;
+        }
+
+        authorizationService.verifyCanEditEntities(toDelete);
+
+        String deletedIds = toDelete.stream()
+                .map(GroupOfTariffZones::getNetexId)
+                .collect(Collectors.joining(", "));
+
+        logger.info("Deleting {} orphaned GroupOfTariffZones: {}", toDelete.size(), deletedIds);
+
+        groupOfTariffZonesRepository.deleteAll(toDelete);
+
+        return toDelete.size();
     }
 
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -51,6 +51,13 @@ tariffZoneLookupService.resetReferences=true
 # When enabled, Tiamat will update existing FareZones by netexId and cleanup orphaned zones
 fareZone.externalVersioning=false
 
+# External versioning for GroupOfTariffZones (Tiamat as replica of master register)
+# When enabled, Tiamat keeps a single version per netexId using the incoming version number and cleans up orphaned groups
+groupOfTariffZones.externalVersioning=false
+
+# TariffZones are deprecated. When enabled, plain TariffZones are skipped on import (FareZones and GroupOfTariffZones are still imported)
+ignoreTariffZoneImport=false
+
 debug=true
 
 # Disable feature detection by this undocumented parameter. Check the org.hibernate.engine.jdbc.internal.JdbcServiceImpl.configure method for more details.

--- a/src/test/java/org/rutebanken/tiamat/importer/GroupOfTariffZonesFareFrameImportTest.java
+++ b/src/test/java/org/rutebanken/tiamat/importer/GroupOfTariffZonesFareFrameImportTest.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.importer;
+
+import org.junit.Test;
+import org.rutebanken.netex.model.FareFrame;
+import org.rutebanken.netex.model.FareZone;
+import org.rutebanken.netex.model.FareZonesInFrame_RelStructure;
+import org.rutebanken.netex.model.GroupsOfTariffZonesInFrame_RelStructure;
+import org.rutebanken.netex.model.MultilingualString;
+import org.rutebanken.netex.model.ObjectFactory;
+import org.rutebanken.netex.model.PublicationDeliveryStructure;
+import org.rutebanken.netex.model.SiteFrame;
+import org.rutebanken.netex.model.TariffZone;
+import org.rutebanken.netex.model.TariffZoneRef;
+import org.rutebanken.netex.model.TariffZoneRefs_RelStructure;
+import org.rutebanken.netex.model.TariffZonesInFrame_RelStructure;
+import org.rutebanken.netex.model.ValidBetween;
+import org.rutebanken.tiamat.TiamatIntegrationTest;
+import org.rutebanken.tiamat.config.FareZoneConfig;
+import org.rutebanken.tiamat.config.GroupOfTariffZonesConfig;
+import org.rutebanken.tiamat.config.TariffZoneConfig;
+import org.rutebanken.tiamat.model.GroupOfTariffZones;
+import org.rutebanken.tiamat.rest.netex.publicationdelivery.PublicationDeliveryTestHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Integration tests for the Nordic NeTEx profile layout where FareZones are delivered in a FareFrame
+ * while the GroupOfTariffZones referencing them lives in the SiteFrame of the same publication delivery.
+ *
+ * @see <a href="https://github.com/entur/profile-examples/blob/master/netex/fares-sales/FareZones.xml">Entur profile example</a>
+ */
+@Transactional
+public class GroupOfTariffZonesFareFrameImportTest extends TiamatIntegrationTest {
+
+    @Autowired
+    private PublicationDeliveryTestHelper publicationDeliveryTestHelper;
+
+    @Autowired
+    private PublicationDeliveryImporter publicationDeliveryImporter;
+
+    @Autowired
+    private FareZoneConfig fareZoneConfig;
+
+    @Autowired
+    private GroupOfTariffZonesConfig groupOfTariffZonesConfig;
+
+    @Autowired
+    private TariffZoneConfig tariffZoneConfig;
+
+    private final ObjectFactory objectFactory = new ObjectFactory();
+
+    @Test
+    public void importGroupOfTariffZonesReferencingFareZonesInFareFrame() {
+        // GIVEN: a delivery where the FareFrame holds the FareZones and the SiteFrame holds a group referencing them
+        FareFrame fareFrame = fareFrameWithFareZones("OST:FareZone:1", "OST:FareZone:2");
+
+        SiteFrame siteFrame = publicationDeliveryTestHelper.siteFrame();
+        siteFrame.withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure()
+                .withGroupOfTariffZones(groupOfTariffZones("OST:GroupOfTariffZones:1", "OST:FareZone:1", "OST:FareZone:2")));
+
+        PublicationDeliveryStructure delivery = publicationDeliveryTestHelper.publicationDelivery(siteFrame, fareFrame);
+
+        ImportParams importParams = new ImportParams();
+        importParams.importType = ImportType.INITIAL;
+
+        // WHEN: imported through the default (SiteFrame) importer
+        PublicationDeliveryStructure response = publicationDeliveryImporter.importPublicationDelivery(delivery, importParams);
+
+        // THEN: both fare zones and the group with its resolved members are persisted
+        assertThat(response).isNotNull();
+        assertThat(fareZoneRepository.findByNetexId("OST:FareZone:1")).isNotEmpty();
+        assertThat(fareZoneRepository.findByNetexId("OST:FareZone:2")).isNotEmpty();
+
+        List<GroupOfTariffZones> groups = groupOfTariffZonesRepository.findAll();
+        assertThat(groups).as("Imported group of tariff zones").hasSize(1);
+        assertThat(groups.getFirst().getMembers())
+                .extracting(member -> member.getRef())
+                .containsExactlyInAnyOrder("OST:FareZone:1", "OST:FareZone:2");
+    }
+
+    @Test
+    public void importGroupResolvesMemberAgainstPreviouslyPersistedFareZone() {
+        // GIVEN: a first delivery that persists a FareZone (FareFrame alongside an empty SiteFrame)
+        PublicationDeliveryStructure firstDelivery = publicationDeliveryTestHelper.publicationDelivery(
+                publicationDeliveryTestHelper.siteFrame(),
+                fareFrameWithFareZones("OST:FareZone:99"));
+
+        ImportParams importParams = new ImportParams();
+        importParams.importType = ImportType.INITIAL;
+        publicationDeliveryImporter.importPublicationDelivery(firstDelivery, importParams);
+
+        // WHEN: a later delivery contains only the group (no FareFrame), referencing the persisted zone
+        SiteFrame siteFrame = publicationDeliveryTestHelper.siteFrame();
+        siteFrame.withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure()
+                .withGroupOfTariffZones(groupOfTariffZones("OST:GroupOfTariffZones:2", "OST:FareZone:99")));
+
+        publicationDeliveryImporter.importPublicationDelivery(publicationDeliveryTestHelper.publicationDelivery(siteFrame), importParams);
+
+        // THEN: the member is resolved from the database and the group is persisted
+        List<GroupOfTariffZones> groups = groupOfTariffZonesRepository.findAll();
+        assertThat(groups).hasSize(1);
+        assertThat(groups.getFirst().getMembers())
+                .extracting(member -> member.getRef())
+                .containsExactly("OST:FareZone:99");
+    }
+
+    @Test
+    public void importGroupFailsWhenMemberZoneIsUnknown() {
+        // GIVEN: a group referencing a zone that is neither in the delivery nor persisted
+        SiteFrame siteFrame = publicationDeliveryTestHelper.siteFrame();
+        siteFrame.withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure()
+                .withGroupOfTariffZones(groupOfTariffZones("OST:GroupOfTariffZones:3", "OST:FareZone:doesNotExist")));
+
+        PublicationDeliveryStructure delivery = publicationDeliveryTestHelper.publicationDelivery(siteFrame, fareFrameWithFareZones("OST:FareZone:1"));
+
+        ImportParams importParams = new ImportParams();
+        importParams.importType = ImportType.INITIAL;
+
+        // WHEN / THEN: import is rejected with a clear message
+        assertThatThrownBy(() -> publicationDeliveryImporter.importPublicationDelivery(delivery, importParams))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("OST:FareZone:doesNotExist");
+    }
+
+    @Test
+    public void externalVersioningPrunesOrphanedFareZonesInCombinedPath() {
+        ImportParams importParams = new ImportParams();
+        importParams.importType = ImportType.INITIAL;
+
+        // GIVEN: a first delivery persists two fare zones
+        publicationDeliveryImporter.importPublicationDelivery(
+                publicationDeliveryTestHelper.publicationDelivery(publicationDeliveryTestHelper.siteFrame(),
+                        fareFrameWithFareZones("OST:FareZone:keep", "OST:FareZone:orphan")),
+                importParams);
+
+        ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", true);
+        try {
+            // WHEN: a later combined delivery only contains one of them, plus a group referencing it
+            SiteFrame siteFrame = publicationDeliveryTestHelper.siteFrame();
+            siteFrame.withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure()
+                    .withGroupOfTariffZones(groupOfTariffZones("OST:GroupOfTariffZones:10", "OST:FareZone:keep")));
+
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(siteFrame, fareFrameWithFareZones("OST:FareZone:keep")),
+                    importParams);
+
+            // THEN: the orphaned zone is removed, the referenced zone survives, and the group is imported
+            assertThat(fareZoneRepository.findByNetexId("OST:FareZone:keep")).isNotEmpty();
+            assertThat(fareZoneRepository.findByNetexId("OST:FareZone:orphan")).isEmpty();
+            assertThat(groupOfTariffZonesRepository.findAll()).hasSize(1);
+        } finally {
+            ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
+        }
+    }
+
+    @Test
+    public void externalVersioningKeepsSingleVersionUsingIncomingVersionNumber() {
+        ImportParams importParams = new ImportParams();
+        importParams.importType = ImportType.INITIAL;
+
+        ReflectionTestUtils.setField(groupOfTariffZonesConfig, "externalVersioning", true);
+        try {
+            // GIVEN: group version 1 imported
+            importCombined(importParams, "OST:FareZone:1",
+                    groupVersioned("OST:GroupOfTariffZones:1", "3", "OST:FareZone:1"));
+
+            // WHEN: the same group is re-imported with the externally supplied version 7
+            importCombined(importParams, "OST:FareZone:1",
+                    groupVersioned("OST:GroupOfTariffZones:1", "7", "OST:FareZone:1"));
+
+            // THEN: only one version is kept and its version number is the incoming one
+            List<GroupOfTariffZones> groups = groupOfTariffZonesRepository.findByNetexId("OST:GroupOfTariffZones:1");
+            assertThat(groups).hasSize(1);
+            assertThat(groups.getFirst().getVersion()).isEqualTo(7L);
+            assertThat(groupOfTariffZonesRepository.findAll()).hasSize(1);
+        } finally {
+            ReflectionTestUtils.setField(groupOfTariffZonesConfig, "externalVersioning", false);
+        }
+    }
+
+    @Test
+    public void externalVersioningPrunesOrphanedGroups() {
+        ImportParams importParams = new ImportParams();
+        importParams.importType = ImportType.INITIAL;
+
+        ReflectionTestUtils.setField(groupOfTariffZonesConfig, "externalVersioning", true);
+        try {
+            // GIVEN: two groups imported
+            SiteFrame first = publicationDeliveryTestHelper.siteFrame();
+            first.withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure().withGroupOfTariffZones(
+                    groupOfTariffZones("OST:GroupOfTariffZones:1", "OST:FareZone:1"),
+                    groupOfTariffZones("OST:GroupOfTariffZones:2", "OST:FareZone:2")));
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(first, fareFrameWithFareZones("OST:FareZone:1", "OST:FareZone:2")), importParams);
+            assertThat(groupOfTariffZonesRepository.findAll()).hasSize(2);
+
+            // WHEN: a later delivery only contains the first group
+            SiteFrame second = publicationDeliveryTestHelper.siteFrame();
+            second.withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure().withGroupOfTariffZones(
+                    groupOfTariffZones("OST:GroupOfTariffZones:1", "OST:FareZone:1")));
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(second, fareFrameWithFareZones("OST:FareZone:1")), importParams);
+
+            // THEN: the orphaned group is removed, the present one survives
+            List<GroupOfTariffZones> groups = groupOfTariffZonesRepository.findAll();
+            assertThat(groups).hasSize(1);
+            assertThat(groups.getFirst().getMembers())
+                    .extracting(member -> member.getRef())
+                    .containsExactly("OST:FareZone:1");
+        } finally {
+            ReflectionTestUtils.setField(groupOfTariffZonesConfig, "externalVersioning", false);
+        }
+    }
+
+    @Test
+    public void ignoreTariffZoneImportSkipsTariffZonesButKeepsFareZonesAndGroups() {
+        ImportParams importParams = new ImportParams();
+        importParams.importType = ImportType.INITIAL;
+
+        ReflectionTestUtils.setField(tariffZoneConfig, "ignoreImport", true);
+        try {
+            // GIVEN: a SiteFrame with a deprecated TariffZone + a group referencing a FareZone, and a FareFrame with that FareZone
+            SiteFrame siteFrame = publicationDeliveryTestHelper.siteFrame();
+            siteFrame.withTariffZones(new TariffZonesInFrame_RelStructure()
+                    .withTariffZone(objectFactory.createTariffZone(new TariffZone()
+                            .withId("OST:TariffZone:1")
+                            .withVersion("1")
+                            .withName(new MultilingualString().withValue("Deprecated zone")))));
+            siteFrame.withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure()
+                    .withGroupOfTariffZones(groupOfTariffZones("OST:GroupOfTariffZones:1", "OST:FareZone:1")));
+
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(siteFrame, fareFrameWithFareZones("OST:FareZone:1")), importParams);
+
+            // THEN: the TariffZone is ignored, but the FareZone and the group are imported
+            assertThat(tariffZoneRepository.findByNetexId("OST:TariffZone:1")).isEmpty();
+            assertThat(fareZoneRepository.findByNetexId("OST:FareZone:1")).isNotEmpty();
+            assertThat(groupOfTariffZonesRepository.findAll()).hasSize(1);
+        } finally {
+            ReflectionTestUtils.setField(tariffZoneConfig, "ignoreImport", false);
+        }
+    }
+
+    private void importCombined(ImportParams importParams, String fareZoneId, org.rutebanken.netex.model.GroupOfTariffZones group) {
+        SiteFrame siteFrame = publicationDeliveryTestHelper.siteFrame();
+        siteFrame.withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure().withGroupOfTariffZones(group));
+        publicationDeliveryImporter.importPublicationDelivery(
+                publicationDeliveryTestHelper.publicationDelivery(siteFrame, fareFrameWithFareZones(fareZoneId)), importParams);
+    }
+
+    private org.rutebanken.netex.model.GroupOfTariffZones groupVersioned(String groupId, String version, String... memberRefs) {
+        return groupOfTariffZones(groupId, memberRefs).withVersion(version);
+    }
+
+    private FareFrame fareFrameWithFareZones(String... fareZoneIds) {
+        LocalDateTime validFrom = LocalDateTime.now().minusDays(3);
+        FareFrame fareFrame = publicationDeliveryTestHelper.fareFrame();
+        fareFrame.setFareZones(new FareZonesInFrame_RelStructure());
+        for (String id : fareZoneIds) {
+            fareFrame.getFareZones().getFareZone().add(new FareZone()
+                    .withId(id)
+                    .withVersion("1")
+                    .withName(new MultilingualString().withValue(id))
+                    .withValidBetween(new ValidBetween().withFromDate(validFrom)));
+        }
+        return fareFrame;
+    }
+
+    private org.rutebanken.netex.model.GroupOfTariffZones groupOfTariffZones(String groupId, String... memberRefs) {
+        TariffZoneRefs_RelStructure members = new TariffZoneRefs_RelStructure();
+        for (String ref : memberRefs) {
+            members.getTariffZoneRef_().add(objectFactory.createTariffZoneRef(new TariffZoneRef().withRef(ref)));
+        }
+        return new org.rutebanken.netex.model.GroupOfTariffZones()
+                .withId(groupId)
+                .withVersion("1")
+                .withName(new MultilingualString().withValue(groupId))
+                .withMembers(members);
+    }
+}

--- a/src/test/java/org/rutebanken/tiamat/importer/GroupOfTariffZonesImporterTest.java
+++ b/src/test/java/org/rutebanken/tiamat/importer/GroupOfTariffZonesImporterTest.java
@@ -31,9 +31,9 @@ public class GroupOfTariffZonesImporterTest extends TiamatIntegrationTest {
         groupOfTariffZones.getMembers().addAll(members);
 
 
-        final List<org.rutebanken.netex.model.GroupOfTariffZones> imported = groupOfTariffZonesImporter.importGroupOfTariffZones(List.of(groupOfTariffZones));
+        final GroupOfTariffZonesImportResult importResult = groupOfTariffZonesImporter.importGroupOfTariffZones(List.of(groupOfTariffZones));
 
-        assertThat(imported).isNotNull().hasSize(1);
+        assertThat(importResult.importedGroupsOfTariffZones()).isNotNull().hasSize(1);
 
 
         final List<GroupOfTariffZones> result = groupOfTariffZonesRepository.findByNetexId(groupOfTariffZones.getNetexId());

--- a/src/test/java/org/rutebanken/tiamat/rest/netex/publicationdelivery/FareZoneExternalVersioningTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/netex/publicationdelivery/FareZoneExternalVersioningTest.java
@@ -19,14 +19,21 @@ import org.junit.Test;
 import org.rutebanken.netex.model.FareFrame;
 import org.rutebanken.netex.model.FareZone;
 import org.rutebanken.netex.model.FareZonesInFrame_RelStructure;
+import org.rutebanken.netex.model.GroupOfTariffZones;
+import org.rutebanken.netex.model.GroupsOfTariffZonesInFrame_RelStructure;
 import org.rutebanken.netex.model.MultilingualString;
+import org.rutebanken.netex.model.ObjectFactory;
 import org.rutebanken.netex.model.PublicationDeliveryStructure;
+import org.rutebanken.netex.model.SiteFrame;
+import org.rutebanken.netex.model.TariffZoneRef;
+import org.rutebanken.netex.model.TariffZoneRefs_RelStructure;
 import org.rutebanken.netex.model.ValidBetween;
 import org.rutebanken.tiamat.TiamatIntegrationTest;
 import org.rutebanken.tiamat.config.FareZoneConfig;
 import org.rutebanken.tiamat.importer.FareZoneFrameSource;
 import org.rutebanken.tiamat.importer.ImportParams;
 import org.rutebanken.tiamat.importer.ImportType;
+import org.rutebanken.tiamat.importer.PublicationDeliveryImporter;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -36,6 +43,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Integration tests for FareZone external versioning feature.
@@ -47,7 +55,12 @@ public class FareZoneExternalVersioningTest extends TiamatIntegrationTest {
     private PublicationDeliveryTestHelper publicationDeliveryTestHelper;
 
     @Autowired
+    private PublicationDeliveryImporter publicationDeliveryImporter;
+
+    @Autowired
     private FareZoneConfig fareZoneConfig;
+
+    private final ObjectFactory objectFactory = new ObjectFactory();
 
     /**
      * Test that external versioning creates new FareZones on first import
@@ -643,6 +656,75 @@ public class FareZoneExternalVersioningTest extends TiamatIntegrationTest {
         } finally {
             ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
         }
+    }
+
+    /**
+     * Regression test: a failed GroupOfTariffZones member validation must not leave the external
+     * versioning FareZone cleanup committed. The cleanup and the group import run in a single
+     * transaction, so a rejected import rolls back the deletes instead of permanently losing FareZones.
+     */
+    @Test
+    public void externalVersioning_failedGroupValidationRollsBackFareZoneCleanup() {
+        ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", true);
+
+        try {
+            ImportParams importParams = new ImportParams();
+            importParams.importType = ImportType.INITIAL;
+
+            // GIVEN: two FareZones persisted by a first delivery
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(
+                            publicationDeliveryTestHelper.siteFrame(),
+                            fareFrameWithFareZones("NSR:FareZone:901", "NSR:FareZone:902")),
+                    importParams);
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:902")).isNotEmpty();
+
+            // WHEN: a later delivery keeps only one zone, while its group still references the now-orphaned zone.
+            // The cleanup deletes the orphan before member validation, so validation fails.
+            SiteFrame siteFrame = publicationDeliveryTestHelper.siteFrame();
+            siteFrame.withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure()
+                    .withGroupOfTariffZones(groupOfTariffZones("NSR:GroupOfTariffZones:901", "NSR:FareZone:902")));
+
+            PublicationDeliveryStructure delivery = publicationDeliveryTestHelper.publicationDelivery(
+                    siteFrame, fareFrameWithFareZones("NSR:FareZone:901"));
+
+            assertThatThrownBy(() -> publicationDeliveryImporter.importPublicationDelivery(delivery, importParams))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("NSR:FareZone:902");
+
+            // THEN: the cleanup is rolled back together with the rejected group import - no data loss
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:901")).isNotEmpty();
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:902")).isNotEmpty();
+            assertThat(groupOfTariffZonesRepository.findAll()).isEmpty();
+        } finally {
+            ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
+        }
+    }
+
+    private FareFrame fareFrameWithFareZones(String... fareZoneIds) {
+        LocalDateTime validFrom = LocalDateTime.now().minusDays(3);
+        FareFrame fareFrame = publicationDeliveryTestHelper.fareFrame();
+        fareFrame.setFareZones(new FareZonesInFrame_RelStructure());
+        for (String id : fareZoneIds) {
+            fareFrame.getFareZones().getFareZone().add(new FareZone()
+                    .withId(id)
+                    .withVersion("1")
+                    .withName(new MultilingualString().withValue(id))
+                    .withValidBetween(new ValidBetween().withFromDate(validFrom)));
+        }
+        return fareFrame;
+    }
+
+    private GroupOfTariffZones groupOfTariffZones(String groupId, String... memberRefs) {
+        TariffZoneRefs_RelStructure members = new TariffZoneRefs_RelStructure();
+        for (String ref : memberRefs) {
+            members.getTariffZoneRef_().add(objectFactory.createTariffZoneRef(new TariffZoneRef().withRef(ref)));
+        }
+        return new GroupOfTariffZones()
+                .withId(groupId)
+                .withVersion("1")
+                .withName(new MultilingualString().withValue(groupId))
+                .withMembers(members);
     }
 
 }

--- a/src/test/java/org/rutebanken/tiamat/rest/netex/publicationdelivery/FareZoneExternalVersioningTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/netex/publicationdelivery/FareZoneExternalVersioningTest.java
@@ -695,7 +695,7 @@ public class FareZoneExternalVersioningTest extends TiamatIntegrationTest {
             // THEN: the cleanup is rolled back together with the rejected group import - no data loss
             assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:901")).isNotEmpty();
             assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:902")).isNotEmpty();
-            assertThat(groupOfTariffZonesRepository.findAll()).isEmpty();
+            assertThat(groupOfTariffZonesRepository.findByNetexId("NSR:GroupOfTariffZones:901")).isEmpty();
         } finally {
             ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
         }

--- a/src/test/java/org/rutebanken/tiamat/rest/netex/publicationdelivery/PublicationDeliveryTestHelper.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/netex/publicationdelivery/PublicationDeliveryTestHelper.java
@@ -112,6 +112,19 @@ public class PublicationDeliveryTestHelper {
                 .withCompositeFrameOrCommonFrame(new ObjectFactory().createFareFrame(fareFrame)));
     }
 
+    @SuppressWarnings("unchecked")
+    public PublicationDeliveryStructure publicationDelivery(SiteFrame siteFrame, FareFrame fareFrame) {
+        ObjectFactory objectFactory = new ObjectFactory();
+        return new PublicationDeliveryStructure()
+                .withPublicationTimestamp(LocalDateTime.now())
+                .withVersion("1")
+                .withParticipantRef("test")
+                .withDataObjects(new PublicationDeliveryStructure.DataObjects()
+                        .withCompositeFrameOrCommonFrame(
+                                objectFactory.createSiteFrame(siteFrame),
+                                objectFactory.createFareFrame(fareFrame)));
+    }
+
     public SiteFrame siteFrame() {
         SiteFrame siteFrame = new SiteFrame();
         siteFrame.setVersion("1");


### PR DESCRIPTION
### Summary

This PR improves NeTEx fare zone imports for registries that maintain their fare zone data in an external master register and use Tiamat as a replica (Nordic profile usage):

- **Combined SiteFrame + FareFrame deliveries**: A publication delivery may now carry FareZones in a FareFrame while the GroupOfTariffZones referencing them lives in the SiteFrame. FareZones from the FareFrame are imported first so the group's member references resolve within the same delivery. Members not supplied in the delivery are resolved against already persisted FareZones in the database; the import fails if a referenced zone cannot be resolved either way.
- **External versioning for GroupOfTariffZones** (`groupOfTariffZones.externalVersioning`, default `false`): when enabled, Tiamat keeps a single version per netexId, updates it in place using the externally supplied version number, and deletes groups not present in the delivery (full-replace semantics). This mirrors the existing `fareZone.externalVersioning` behaviour.
- **FareZone orphan cleanup for FareFrame imports**: when `fareZone.externalVersioning` is enabled, FareZones not present in an incoming FareFrame delivery are pruned after import.
- **Skip deprecated TariffZones** (`ignoreTariffZoneImport`, default `false`): plain TariffZones are deprecated in favour of FareZones; when enabled they are skipped on import while FareZones and GroupOfTariffZones are still imported.
- `GroupOfTariffZones` added to the default `netex.id.valid.prefix.list`, allowing externally generated group IDs with any prefix.

**Motivation**: In our deployment the fare zone register is mastered outside Tiamat. Deliveries arrive as FareFrame (FareZones) plus SiteFrame (GroupOfTariffZones), with version numbers managed by the master system. Previously, a GroupOfTariffZones could only reference zones declared as `tariffZones` in the same SiteFrame, version numbers were always reassigned by Tiamat, and stale groups/zones accumulated after upstream deletions.

**Technical approach**: New `@Configuration` classes (`GroupOfTariffZonesConfig`, `TariffZoneConfig`) expose the feature flags; both default to `false` so existing behaviour is unchanged. `GroupOffTariffZonesSaverService` gains `saveWithExternalVersioning` (in-place update by netexId, preserving the incoming version) and `deleteAllExcept` (orphan cleanup); both go through `AuthorizationService.verifyCanEditEntities` and log changed/deleted entities with the acting username. `GroupOfTariffZonesImportHandler` collects known zone IDs from the SiteFrame, the accompanying FareFrame, and the database before validating group members.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Unit tests

- Integration tests added in `GroupOfTariffZonesFareFrameImportTest` (Testcontainers/PostGIS) covering:
  - importing a group whose members are declared in an accompanying FareFrame
  - resolving group members against previously persisted FareZones
  - failing the import when a member reference cannot be resolved
  - external versioning keeping a single version per netexId with the incoming version number
  - external versioning pruning orphaned groups and orphaned FareZones
  - `ignoreTariffZoneImport` skipping plain TariffZones while keeping FareZones and groups
- `GroupOfTariffZonesImporterTest` updated for the new `GroupOfTariffZonesImportResult` return type.
- All new/updated tests pass locally (`mvn test -Dtest='GroupOfTariffZonesFareFrameImportTest,GroupOfTariffZonesImporterTest'`).
- All feature flags default to `false`, so default import behaviour is covered by the existing test suite.

### Documentation

- README updated: new properties documented in the sample configuration, plus sections on combined SiteFrame/FareFrame deliveries, external versioning semantics, and ignoring deprecated TariffZones.
- Javadoc added on `saveWithExternalVersioning`, `deleteAllExcept`, and the new configuration classes.
