### PR TITLE
Add formatting to Fintraffic's ReadApi xml records

### DIFF
--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficApiControllerTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficApiControllerTest.java
@@ -80,22 +80,22 @@ class FintrafficApiControllerTest {
 
         ReadApiEntityOutRecord scheduledStopPoint = new ReadApiEntityOutRecord(
                 "ScheduledStopPoint",
-                "<ScheduledStopPoint id=\"FSR:ScheduledStopPoint:1\" version=\"1\"/>".getBytes(StandardCharsets.UTF_8)
+                "<ScheduledStopPoint id=\"FSR:ScheduledStopPoint:1\" version=\"1\"/>"
         );
 
         ReadApiEntityOutRecord topographicPlace = new ReadApiEntityOutRecord(
                 "TopographicPlace",
-                "<TopographicPlace id=\"FSR:TopographicPlace:91\" version=\"1\"/>".getBytes(StandardCharsets.UTF_8)
+                "<TopographicPlace id=\"FSR:TopographicPlace:91\" version=\"1\"/>"
         );
 
         ReadApiEntityOutRecord stopPlace = new ReadApiEntityOutRecord(
                 "StopPlace",
-                "<StopPlace id=\"FSR:StopPlace:1\" version=\"1\"/>".getBytes(StandardCharsets.UTF_8)
+                "<StopPlace id=\"FSR:StopPlace:1\" version=\"1\"/>"
         );
 
         ReadApiEntityOutRecord parking = new ReadApiEntityOutRecord(
                 "Parking",
-                "<Parking id=\"FSR:Parking:1\" version=\"1\"/>".getBytes(StandardCharsets.UTF_8)
+                "<Parking id=\"FSR:Parking:1\" version=\"1\"/>"
         );
 
         when(netexRepository.streamStopPlaces(any(ReadApiSearchKey.class)))

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingService.java
@@ -1,5 +1,6 @@
 package org.rutebanken.tiamat.ext.fintraffic.api;
 
+import com.sun.xml.txw2.output.IndentingXMLStreamWriter;
 import jakarta.annotation.PostConstruct;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
@@ -214,9 +215,11 @@ public class ReadApiNetexMarshallingService {
 
         try (StringWriter stringWriter = new StringWriter(512)) {
             XMLStreamWriter xsw = new NoNameSpaceXMLStreamWriter(xof.createXMLStreamWriter(stringWriter));
+            XMLStreamWriter indentedXSW = new IndentingXMLStreamWriter(xsw);
+
             JAXBElement<?> jaxbElement = createJAXBElementForEntity(netexEntity);
             Marshaller marshaller = createMarshaller(netexEntity.getClass());
-            marshaller.marshal(jaxbElement, xsw);
+            marshaller.marshal(jaxbElement, indentedXSW);
             xsw.flush();
             return stringWriter.toString();
         } catch (JAXBException | XMLStreamException | IOException e) {

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryService.java
@@ -38,6 +38,8 @@ public class ReadApiNetexPublicationDeliveryService {
     private static final byte[] END_TAG_STOP_PLACES = "</stopPlaces>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] END_TAG_PARKINGS = "</parkings>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] NEWLINE = "\n".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] COLLECTION_TAG_SPACING = "            ".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] COLLECTION_ITEM_TAG_SPACING = "                ".getBytes(StandardCharsets.UTF_8);
 
     private static final String TIMESTAMP_PLACEHOLDER = "\\{timeStamp}";
     private static final String PREFIX_PLACEHOLDER = "\\{prefix}";
@@ -163,11 +165,13 @@ public class ReadApiNetexPublicationDeliveryService {
             while (netexIterator.hasNext()) {
                 ReadApiEntityOutRecord netexEntityRow = netexIterator.next();
                 String type = netexEntityRow.type();
-                byte[] xmlEntity = netexEntityRow.xml();
+                String xmlEntity = netexEntityRow.xml();
+                String[] xmlEntityByLine = xmlEntity.split("\\n");
 
                 if (!Objects.equals(previousType, type)) {
                     // Close previous collection if needed
                     if (previousType != null) {
+                        outputStream.write(COLLECTION_TAG_SPACING);
                         outputStream.write(getCollectionEndTag(previousType));
                         outputStream.write(NEWLINE);
                     }
@@ -175,6 +179,7 @@ public class ReadApiNetexPublicationDeliveryService {
                     // Type has changed, need to move to the correct collection
                     while ((line = xmlReader.readLine()) != null) {
                         if (line.trim().equals(getCollectionTag(type))) {
+                            outputStream.write(COLLECTION_TAG_SPACING);
                             outputStream.write(getCollectionStartTag(type));
                             outputStream.write(NEWLINE);
                             break;
@@ -186,13 +191,23 @@ public class ReadApiNetexPublicationDeliveryService {
                     previousType = type;
                 }
 
-                outputStream.write(xmlEntity);
+                int i = 0;
+                for (String xmlEntityLine : xmlEntityByLine) {
+                    outputStream.write(COLLECTION_ITEM_TAG_SPACING);
+                    outputStream.write(xmlEntityLine.getBytes(StandardCharsets.UTF_8));
+                    i ++;
+                    if (i != xmlEntityByLine.length) {
+                        outputStream.write(NEWLINE);
+                    }
+                }
+
                 outputStream.write(NEWLINE);
                 entities++;
             }
 
             if (previousType != null) {
                 // Close last collection
+                outputStream.write(COLLECTION_TAG_SPACING);
                 outputStream.write(getCollectionEndTag(previousType));
                 outputStream.write(NEWLINE);
             }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/model/ReadApiEntityOutRecord.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/model/ReadApiEntityOutRecord.java
@@ -5,4 +5,4 @@ package org.rutebanken.tiamat.ext.fintraffic.api.model;
  * @param type Entity type
  * @param xml Entity XML content as byte array
  */
-public record ReadApiEntityOutRecord(String type, byte[] xml) {}
+public record ReadApiEntityOutRecord(String type, String xml) {}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/repository/FintrafficNetexRepository.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/repository/FintrafficNetexRepository.java
@@ -78,7 +78,7 @@ public class FintrafficNetexRepository extends AbstractNetexRepository {
 
         return jdbc.queryForStream(
                 sql.toString(),
-                (rs, rn) -> new ReadApiEntityOutRecord(rs.getString("type"), rs.getBytes("xml")),
+                (rs, rn) -> new ReadApiEntityOutRecord(rs.getString("type"), rs.getString("xml")),
                 params.toArray()
         );
     }


### PR DESCRIPTION
### Summary

This change improves the xml content produced by Fintraffic's ReadApi service, making it properly formatted.

Two sides of the fix:
- Store in db the xml in a formatted way
- Append the right amount of spaces at the time of the actual export to make it fit well into the surrounding xml