### PR TITLE
Fix PolygonFetcher returning null for FareZones with multiSurface geometry

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/PolygonFetcher.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/PolygonFetcher.java
@@ -27,7 +27,7 @@ public class PolygonFetcher implements DataFetcher {
     @Override
     public Object get(DataFetchingEnvironment environment) {
         if(environment.getSource() instanceof Zone_VersionStructure zoneVersionStructure) {
-            return zoneVersionStructure.getPolygon();
+            return zoneVersionStructure.getGeometry();
         }
         return null;
     }

--- a/src/test/java/org/rutebanken/tiamat/rest/graphql/fetchers/PolygonFetcherTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/graphql/fetchers/PolygonFetcherTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.rest.graphql.fetchers;
+
+import graphql.schema.DataFetchingEnvironment;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Polygon;
+import org.rutebanken.tiamat.model.FareZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PolygonFetcherTest {
+
+    private final GeometryFactory geometryFactory = new GeometryFactory();
+    private final PolygonFetcher fetcher = new PolygonFetcher();
+
+    @Test
+    public void returnsNullWhenSourceIsNotAZone() {
+        DataFetchingEnvironment env = mock(DataFetchingEnvironment.class);
+        when(env.getSource()).thenReturn("not a zone");
+
+        assertThat(fetcher.get(env)).isNull();
+    }
+
+    @Test
+    public void returnsPolygonWhenOnlyPolygonIsSet() {
+        Polygon polygon = geometryFactory.createPolygon(new Coordinate[]{
+                new Coordinate(0, 0), new Coordinate(1, 0),
+                new Coordinate(1, 1), new Coordinate(0, 0)
+        });
+
+        FareZone fareZone = new FareZone();
+        fareZone.setPolygon(polygon);
+
+        DataFetchingEnvironment env = mock(DataFetchingEnvironment.class);
+        when(env.getSource()).thenReturn(fareZone);
+
+        assertThat(fetcher.get(env)).isEqualTo(polygon);
+    }
+
+    @Test
+    public void returnsMultiPolygonWhenOnlyMultiSurfaceIsSet() {
+        Polygon polygon = geometryFactory.createPolygon(new Coordinate[]{
+                new Coordinate(0, 0), new Coordinate(1, 0),
+                new Coordinate(1, 1), new Coordinate(0, 0)
+        });
+        MultiPolygon multiPolygon = geometryFactory.createMultiPolygon(new Polygon[]{polygon});
+
+        FareZone fareZone = new FareZone();
+        fareZone.setMultiSurface(multiPolygon);
+
+        DataFetchingEnvironment env = mock(DataFetchingEnvironment.class);
+        when(env.getSource()).thenReturn(fareZone);
+
+        assertThat(fetcher.get(env)).isEqualTo(multiPolygon);
+    }
+
+    @Test
+    public void prefersMultiSurfaceOverPolygonWhenBothAreSet() {
+        Polygon polygon = geometryFactory.createPolygon(new Coordinate[]{
+                new Coordinate(0, 0), new Coordinate(1, 0),
+                new Coordinate(1, 1), new Coordinate(0, 0)
+        });
+        MultiPolygon multiPolygon = geometryFactory.createMultiPolygon(new Polygon[]{polygon});
+
+        FareZone fareZone = new FareZone();
+        fareZone.setPolygon(polygon);
+        fareZone.setMultiSurface(multiPolygon);
+
+        DataFetchingEnvironment env = mock(DataFetchingEnvironment.class);
+        when(env.getSource()).thenReturn(fareZone);
+
+        assertThat(fetcher.get(env)).isEqualTo(multiPolygon);
+    }
+
+    @Test
+    public void returnsNullWhenNeitherPolygonNorMultiSurfaceIsSet() {
+        FareZone fareZone = new FareZone();
+
+        DataFetchingEnvironment env = mock(DataFetchingEnvironment.class);
+        when(env.getSource()).thenReturn(fareZone);
+
+        assertThat(fetcher.get(env)).isNull();
+    }
+}


### PR DESCRIPTION
### Summary

- Fixes `PolygonFetcher` returning `null` for zones whose geometry is stored as `multiSurface` (e.g. FareZones with holes or multiple disconnected areas)
- Previously, `getPolygon()` was called directly, which returns `null` when only `multiSurface` is populated. Changed to call `getGeometry()`, which already implements the correct fallback: prefers `multiSurface`, falls back to `polygon`.
- This is a one-line fix in production code. The rest of the change is a new unit test class.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Issue

No public GitHub issue. Internally tracked as DPO-4725.

**Background:** When FareZones are imported with multiSurface geometry (zones with holes or multiple disconnected areas), the GraphQL API's `polygon` field returned `null` even though the geometry was correctly stored in the database (`multi_surface_id` column populated). This prevented the Abzu stop place editor from displaying such zones on the map.

**Root cause:** `PolygonFetcher.get()` called `Zone_VersionStructure.getPolygon()` unconditionally. `getPolygon()` only returns the simple polygon geometry. The existing `getGeometry()` method already implements the intended fallback logic (returns multiSurface if present, otherwise polygon), but `PolygonFetcher` was not using it.

**Fix:** Replace the `getPolygon()` call with `getGeometry()` in `PolygonFetcher`.

### Unit tests

A new test class `PolygonFetcherTest` was added covering:
- Returns `null` when source is not a `Zone_VersionStructure`
- Returns the polygon when only a simple polygon is set (regression: existing behaviour preserved)
- Returns the multiPolygon when only multiSurface is set (the bug scenario)
- Returns the multiPolygon when both are set (multiSurface takes precedence, matching `getGeometry()` semantics)

All tests pass locally.

### Documentation

The fix is self-explanatory (a one-line change with a clear method name). No Javadoc changes needed.