### PR TITLE
feature/ext-fintraffic Add user id to each log event using MDC + clean up configs

### DIFF
--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficSecurityConfigTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficSecurityConfigTest.java
@@ -1,12 +1,9 @@
 package org.rutebanken.tiamat.ext.fintraffic.auth;
 
-import jakarta.servlet.Filter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.rutebanken.helper.organisation.user.UserInfoExtractor;
 import org.rutebanken.tiamat.auth.UsernameFetcher;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -51,57 +48,5 @@ public class FintrafficSecurityConfigTest {
 
         mockAuthentication(null);
         Assertions.assertEquals("<unknown user>", usernameFetcher.getUserNameForAuthenticatedUser());
-    }
-
-    @Test
-    public void testAwsTraceIdFilterWithHeader() {
-        // 1. Create new HTTP request to simulate incoming request with AWS trace ID header
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        request.addHeader("X-Amz-Cf-Id", "test-cf-id");
-        request.addHeader("X-Amzn-Trace-Id", "test-trace-id");
-
-        // 2. Create the filter and invoke it
-        FintrafficSecurityConfig config = new FintrafficSecurityConfig();
-        Filter filter = config.awsTraceIdFilterRegistrationBean().getFilter();
-        try {
-            filter.doFilter(request, response, (req, res) -> {
-                // 3. Inside the filter chain, check that the AWS trace ID is set in the MDC
-                String cfIdInMDC = org.slf4j.MDC.get("awsCfId");
-                String traceIdInMDC = org.slf4j.MDC.get("awsAmznTraceId");
-                Assertions.assertEquals("test-cf-id", cfIdInMDC);
-                Assertions.assertEquals("test-trace-id", traceIdInMDC);
-            });
-        } catch (Exception e) {
-            Assertions.fail("Filter threw an exception: " + e.getMessage());
-        } finally {
-            // 4. After the filter, check that the AWS trace ID is removed from the MDC
-            String cfIdInMDC = org.slf4j.MDC.get("awsCfId");
-            String traceIdInMDC = org.slf4j.MDC.get("awsAmznTraceId");
-            Assertions.assertNull(cfIdInMDC, "awsCfId should be removed from MDC after filter execution");
-            Assertions.assertNull(traceIdInMDC, "awsAmznTraceId should be removed from MDC after filter execution");
-        }
-    }
-
-    @Test
-    public void testAwsTraceIdFilterWithoutHeader() {
-        // 1. Create new HTTP request without AWS trace ID headers
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        // 2. Create the filter and invoke it
-        FintrafficSecurityConfig config = new FintrafficSecurityConfig();
-        Filter filter = config.awsTraceIdFilterRegistrationBean().getFilter();
-        try {
-            filter.doFilter(request, response, (req, res) -> {
-                // 3. Inside the filter chain, check that the AWS trace ID is not set in the MDC
-                String cfIdInMDC = org.slf4j.MDC.get("awsCfId");
-                String traceIdInMDC = org.slf4j.MDC.get("awsAmznTraceId");
-                Assertions.assertNull(cfIdInMDC, "AWS CF ID should not be set in MDC when header is missing");
-                Assertions.assertNull(traceIdInMDC, "AWS trace ID should not be set in MDC when header is missing");
-            });
-        } catch (Exception e) {
-            Assertions.fail("Filter threw an exception: " + e.getMessage());
-        }
     }
 }

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/filter/FintrafficMdcFilterConfigTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/filter/FintrafficMdcFilterConfigTest.java
@@ -1,0 +1,95 @@
+package org.rutebanken.tiamat.ext.fintraffic.filter;
+
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+public class FintrafficMdcFilterConfigTest {
+
+    @AfterEach
+    public void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private Filter filter() {
+        return new FintrafficMdcFilterConfig().mdcFilterRegistrationBean().getFilter();
+    }
+
+    @Test
+    public void testUserIdSetFromJwt() throws Exception {
+        Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject("test-subject").build();
+        JwtAuthenticationToken auth = new JwtAuthenticationToken(jwt);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter().doFilter(request, response, (req, res) ->
+                Assertions.assertEquals("test-subject", MDC.get("userId"))
+        );
+        Assertions.assertNull(MDC.get("userId"), "userId should be removed from MDC after filter");
+    }
+
+    @Test
+    public void testUserIdFallsBackToUnknownWhenUnauthenticated() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter().doFilter(request, response, (req, res) ->
+                Assertions.assertEquals("<unknown user>", MDC.get("userId"))
+        );
+        Assertions.assertNull(MDC.get("userId"), "userId should be removed from MDC after filter");
+    }
+
+    @Test
+    public void testAwsHeadersSetInMdc() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Amz-Cf-Id", "test-cf-id");
+        request.addHeader("X-Amzn-Trace-Id", "test-trace-id");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter().doFilter(request, response, (req, res) -> {
+            Assertions.assertEquals("test-cf-id", MDC.get("awsCfId"));
+            Assertions.assertEquals("test-trace-id", MDC.get("awsAmznTraceId"));
+        });
+        Assertions.assertNull(MDC.get("awsCfId"), "awsCfId should be removed from MDC after filter");
+        Assertions.assertNull(MDC.get("awsAmznTraceId"), "awsAmznTraceId should be removed from MDC after filter");
+    }
+
+    @Test
+    public void testAwsHeadersAbsentWhenNotProvided() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter().doFilter(request, response, (req, res) -> {
+            Assertions.assertNull(MDC.get("awsCfId"), "awsCfId should not be set when header is absent");
+            Assertions.assertNull(MDC.get("awsAmznTraceId"), "awsAmznTraceId should not be set when header is absent");
+        });
+    }
+
+    @Test
+    public void testMdcIsCleanedUpEvenWhenFilterChainThrows() {
+        Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject("throwing-subject").build();
+        JwtAuthenticationToken auth = new JwtAuthenticationToken(jwt);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Amz-Cf-Id", "cf-id");
+        request.addHeader("X-Amzn-Trace-Id", "trace-id");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        Assertions.assertThrows(RuntimeException.class, () ->
+                filter().doFilter(request, response, (req, res) -> { throw new RuntimeException("simulated failure"); })
+        );
+        Assertions.assertNull(MDC.get("userId"));
+        Assertions.assertNull(MDC.get("awsCfId"));
+        Assertions.assertNull(MDC.get("awsAmznTraceId"));
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficSecurityConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/auth/FintrafficSecurityConfig.java
@@ -1,28 +1,19 @@
 package org.rutebanken.tiamat.ext.fintraffic.auth;
 
-import jakarta.servlet.Filter;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.rutebanken.helper.organisation.user.UserInfoExtractor;
 import org.rutebanken.tiamat.auth.AuthorizationService;
 import org.rutebanken.tiamat.auth.UsernameFetcher;
 import org.rutebanken.tiamat.repository.TopographicPlaceRepository;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Optional;
 
 @Configuration
 @Profile("fintraffic")
@@ -56,63 +47,14 @@ public class FintrafficSecurityConfig {
                 .build();
     }
 
-    private Optional<String> getSubject() {
-        if (SecurityContextHolder.getContext().getAuthentication() instanceof JwtAuthenticationToken token
-                && (token.getPrincipal() instanceof Jwt jwt)) {
-            return Optional.of(jwt.getSubject());
-        }
-        return Optional.empty();
-    }
-
     @Bean
     @Primary
     public UsernameFetcher usernameFetcher(UserInfoExtractor userInfoExtractor) {
         return new UsernameFetcher(userInfoExtractor) {
             @Override
             public String getUserNameForAuthenticatedUser() {
-                return getSubject().orElse("<unknown user>");
+                return TrivoreAuthorizations.getCurrentSubject();
             }
         };
-    }
-
-    private Filter awsTraceIdFilter() {
-        final String AWS_REQ_CF_ID = "X-Amz-Cf-Id";
-        final String AWS_REQ_ALB_ID = "X-Amzn-Trace-Id";
-        final String MDC_AWS_REQ_CF_ID = "awsCfId";
-        final String MDC_AWS_REQ_ALB_ID = "awsAmznTraceId";
-
-        return (req, res, filterChain) -> {
-            if (!(req instanceof HttpServletRequest httpRequest) || !(res instanceof HttpServletResponse)) {
-                filterChain.doFilter(req, res);
-                return;
-            }
-
-            String cfId = httpRequest.getHeader(AWS_REQ_CF_ID);
-            String albId = httpRequest.getHeader(AWS_REQ_ALB_ID);
-
-            if (cfId != null) {
-                MDC.put(MDC_AWS_REQ_CF_ID, cfId);
-            }
-            if (albId != null) {
-                MDC.put(MDC_AWS_REQ_ALB_ID, albId);
-            }
-
-            try {
-                filterChain.doFilter(req, res);
-            } finally {
-                MDC.remove(MDC_AWS_REQ_CF_ID);
-                MDC.remove(MDC_AWS_REQ_ALB_ID);
-            }
-        };
-    }
-
-    @Bean
-    public FilterRegistrationBean<Filter> awsTraceIdFilterRegistrationBean() {
-        FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>();
-        registration.setFilter(awsTraceIdFilter());
-        registration.addUrlPatterns("/*");
-        registration.setName("awsTraceIdFilter");
-        registration.setOrder(-1); // Ensure this runs before other filters
-        return registration;
     }
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/filter/FintrafficMdcFilterConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/filter/FintrafficMdcFilterConfig.java
@@ -1,0 +1,66 @@
+package org.rutebanken.tiamat.ext.fintraffic.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.http.HttpServletRequest;
+import org.rutebanken.tiamat.ext.fintraffic.auth.TrivoreAuthorizations;
+import org.slf4j.MDC;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Populates Logback MDC fields for each request to enable structured log correlation:
+ * <ul>
+ *   <li>{@code userId} — the {@code sub} claim from the JWT, identifying the authenticated Trivore user.
+ *       Falls back to {@code "<unknown user>"} for unauthenticated requests.</li>
+ *   <li>{@code awsCfId} — the CloudFront request ID ({@code X-Amz-Cf-Id} header), useful for
+ *       correlating logs with CloudFront access logs.</li>
+ *   <li>{@code awsAmznTraceId} — the ALB/X-Ray trace ID ({@code X-Amzn-Trace-Id} header), useful for
+ *       distributed tracing across AWS services.</li>
+ * </ul>
+ */
+@Configuration
+@Profile("fintraffic")
+public class FintrafficMdcFilterConfig {
+
+    private static final String MDC_USER_ID = "userId";
+    private static final String MDC_AWS_CF_ID = "awsCfId";
+    private static final String MDC_AWS_ALB_ID = "awsAmznTraceId";
+
+    private static final String HEADER_AWS_CF_ID = "X-Amz-Cf-Id";
+    private static final String HEADER_AWS_ALB_ID = "X-Amzn-Trace-Id";
+
+    private Filter mdcFilter() {
+        return (req, res, filterChain) -> {
+            MDC.put(MDC_USER_ID, TrivoreAuthorizations.getCurrentSubject());
+            if (req instanceof HttpServletRequest httpRequest) {
+                String cfId = httpRequest.getHeader(HEADER_AWS_CF_ID);
+                String albId = httpRequest.getHeader(HEADER_AWS_ALB_ID);
+                if (cfId != null) {
+                    MDC.put(MDC_AWS_CF_ID, cfId);
+                }
+                if (albId != null) {
+                    MDC.put(MDC_AWS_ALB_ID, albId);
+                }
+            }
+            try {
+                filterChain.doFilter(req, res);
+            } finally {
+                MDC.remove(MDC_USER_ID);
+                MDC.remove(MDC_AWS_CF_ID);
+                MDC.remove(MDC_AWS_ALB_ID);
+            }
+        };
+    }
+
+    @Bean
+    public FilterRegistrationBean<Filter> mdcFilterRegistrationBean() {
+        FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(mdcFilter());
+        registration.addUrlPatterns("/*");
+        registration.setName("mdcFilter");
+        registration.setOrder(1); // Run after Spring Security populates the SecurityContext
+        return registration;
+    }
+}


### PR DESCRIPTION
### Summary

This PR contains ext Fintraffic specific changes, only.

Add Trivore user identifer to log context to trace log events related to a single user. Also, clean up Fintraffic security config class by moving logging related filters to another config file. And remove some duplicate code for access the subject from the JWT token.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

It's hard to follow what effects users actions have if the user identifier is not included in the log event. This change allows the user identifier be logged for each log event.

Closes #45

### Unit tests

N/A

### Documentation

Javadoc for the new Config class has been added.



