### PR TITLE
Ext Fintraffic - Add support for Fare Zones to Read API

### DIFF
--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyServiceTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyServiceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.FintrafficReadApiSearchKey;
+import org.rutebanken.tiamat.model.FareZone;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.VehicleModeEnumeration;
 import org.rutebanken.tiamat.repository.StopPlaceRepository;
@@ -148,6 +149,19 @@ class FintrafficSearchKeyServiceTest {
         String json = service.generateSearchKeyJSON(parentStopPlace);
 
         assertThat(json).contains("\"transportModes\":[]");
+    }
+
+    @Test
+    void generateSearchKeyJSON_fareZone_returnsEmptySearchKey() {
+        FareZone fareZone = new FareZone();
+        fareZone.setNetexId("TKL:FareZone:A");
+        fareZone.setVersion(1L);
+
+        FintrafficReadApiSearchKey searchKey = parseSearchKey(service.generateSearchKeyJSON(fareZone));
+
+        assertThat(searchKey.transportModes()).isEmpty();
+        assertThat(searchKey.areaCodes()).isEmpty();
+        assertThat(searchKey.municipalityCodes()).isEmpty();
     }
 
     private FintrafficReadApiSearchKey parseSearchKey(String json) {

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingServiceTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingServiceTest.java
@@ -7,6 +7,7 @@ import org.rutebanken.tiamat.exporter.ServiceFrameElementCreator;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiEntityInRecord;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiEntityStatus;
 import org.rutebanken.tiamat.ext.fintraffic.api.repository.NetexRepository;
+import org.rutebanken.tiamat.model.FareZone;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.SiteRefStructure;
 import org.rutebanken.tiamat.model.StopPlace;
@@ -210,6 +211,51 @@ class ReadApiNetexMarshallingServiceTest {
 
         ReadApiEntityInRecord record = records.iterator().next();
         assertThat(record.status(), equalTo(ReadApiEntityStatus.DELETED));
+    }
+
+    @Test
+    void createEntityRecordsForFareZone() {
+        FareZone fareZone = new FareZone();
+        fareZone.setNetexId("TKL:FareZone:A");
+        fareZone.setVersion(1L);
+        fareZone.setChanged(Instant.now());
+
+        org.rutebanken.netex.model.FareZone netexFareZone = new org.rutebanken.netex.model.FareZone();
+        netexFareZone.setId(fareZone.getNetexId());
+        netexFareZone.setVersion(String.valueOf(fareZone.getVersion()));
+
+        when(netexMapper.mapToNetexModel(fareZone)).thenReturn(netexFareZone);
+        when(searchKeyService.generateSearchKeyJSON(fareZone)).thenReturn("{}");
+
+        Collection<ReadApiEntityInRecord> records = marshallingService.createEntityRecords(fareZone, ReadApiEntityStatus.CURRENT);
+
+        assertThat(records, notNullValue());
+        assertThat(records.size(), equalTo(1));
+
+        ReadApiEntityInRecord record = records.iterator().next();
+        assertThat(record.id(), equalTo("TKL:FareZone:A"));
+        assertThat(record.type(), equalTo("FareZone"));
+        assertThat(record.status(), equalTo(ReadApiEntityStatus.CURRENT));
+    }
+
+    @Test
+    void marshallToXMLForFareZoneProducesValidXML() {
+        FareZone fareZone = new FareZone();
+        fareZone.setNetexId("TKL:FareZone:A");
+        fareZone.setVersion(1L);
+        fareZone.setChanged(Instant.now());
+
+        org.rutebanken.netex.model.FareZone netexFareZone = new org.rutebanken.netex.model.FareZone();
+        netexFareZone.setId(fareZone.getNetexId());
+        netexFareZone.setVersion(String.valueOf(fareZone.getVersion()));
+
+        when(netexMapper.mapToNetexModel(fareZone)).thenReturn(netexFareZone);
+
+        String xml = marshallingService.marshallToXML(fareZone);
+
+        assertThat(xml, notNullValue());
+        assertThat(xml, containsString("FareZone"));
+        assertThat(xml, containsString("TKL:FareZone:A"));
     }
 }
 

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryServiceTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryServiceTest.java
@@ -1,0 +1,95 @@
+package org.rutebanken.tiamat.ext.fintraffic.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiEntityOutRecord;
+import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiSearchKey;
+import org.rutebanken.tiamat.ext.fintraffic.api.repository.NetexRepository;
+import org.rutebanken.tiamat.netex.id.ValidPrefixList;
+import org.rutebanken.tiamat.time.ExportTimeZone;
+
+import java.io.ByteArrayOutputStream;
+import java.time.ZoneId;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ReadApiNetexPublicationDeliveryServiceTest {
+
+    private NetexRepository netexRepository;
+    private ReadApiNetexPublicationDeliveryService service;
+
+    @BeforeEach
+    void setUp() {
+        netexRepository = mock(NetexRepository.class);
+
+        ValidPrefixList prefixList = mock(ValidPrefixList.class);
+        when(prefixList.getValidNetexPrefix()).thenReturn("FSR");
+
+        ExportTimeZone exportTimeZone = mock(ExportTimeZone.class);
+        when(exportTimeZone.getDefaultTimeZoneId()).thenReturn(ZoneId.of("Europe/Helsinki"));
+
+        service = new ReadApiNetexPublicationDeliveryService(
+                netexRepository,
+                prefixList,
+                exportTimeZone,
+                "fin",
+                "1.12:NO-NeTEx-stops:1.4"
+        );
+    }
+
+    @Test
+    void streamPublicationDelivery_withNoEntities_producesValidPublicationDelivery() throws Exception {
+        when(netexRepository.streamStopPlaces(any(ReadApiSearchKey.class))).thenReturn(Stream.of());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        service.streamPublicationDelivery(mock(ReadApiSearchKey.class), out);
+        String xml = out.toString();
+
+        assertThat(xml).contains("<PublicationDelivery");
+        assertThat(xml).contains("<ServiceFrame");
+        assertThat(xml).contains("<SiteFrame");
+        // Empty collection placeholders are suppressed — no collection open/close tags expected
+        assertThat(xml).doesNotContain("<tariffZones>");
+        assertThat(xml).doesNotContain("<stopPlaces>");
+    }
+
+    @Test
+    void streamPublicationDelivery_withFareZone_includesTariffZonesCollection() throws Exception {
+        String fareZoneXml = "<FareZone id=\"TKL:FareZone:A\" version=\"1\"><Name>Zone A</Name></FareZone>";
+        ReadApiEntityOutRecord fareZoneRecord = new ReadApiEntityOutRecord("FareZone", fareZoneXml.getBytes());
+
+        when(netexRepository.streamStopPlaces(any(ReadApiSearchKey.class)))
+                .thenReturn(Stream.of(fareZoneRecord));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        service.streamPublicationDelivery(mock(ReadApiSearchKey.class), out);
+        String xml = out.toString();
+
+        assertThat(xml).contains("<tariffZones>");
+        assertThat(xml).contains("TKL:FareZone:A");
+        assertThat(xml).contains("</tariffZones>");
+    }
+
+    @Test
+    void streamPublicationDelivery_fareZoneAppearsBeforeStopPlaces() throws Exception {
+        String fareZoneXml = "<FareZone id=\"TKL:FareZone:A\" version=\"1\"/>";
+        String stopPlaceXml = "<StopPlace id=\"FSR:StopPlace:1\" version=\"1\"/>";
+        ReadApiEntityOutRecord fareZoneRecord = new ReadApiEntityOutRecord("FareZone", fareZoneXml.getBytes());
+        ReadApiEntityOutRecord stopPlaceRecord = new ReadApiEntityOutRecord("StopPlace", stopPlaceXml.getBytes());
+
+        when(netexRepository.streamStopPlaces(any(ReadApiSearchKey.class)))
+                .thenReturn(Stream.of(fareZoneRecord, stopPlaceRecord));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        service.streamPublicationDelivery(mock(ReadApiSearchKey.class), out);
+        String xml = out.toString();
+
+        assertThat(xml.indexOf("<tariffZones>")).isLessThan(xml.indexOf("<stopPlaces>"));
+        assertThat(xml).contains("TKL:FareZone:A");
+        assertThat(xml).contains("FSR:StopPlace:1");
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficSearchKeyService.java
@@ -109,8 +109,6 @@ public class FintrafficSearchKeyService implements SearchKeyService {
         } else if (entity instanceof Parking) {
             // For Parking, use parent StopPlace search key if available
             return searchKeyFromParent.orElse(FintrafficReadApiSearchKey.empty());
-        } else if (entity instanceof TopographicPlace) {
-            return FintrafficReadApiSearchKey.empty();
         } else {
             return FintrafficReadApiSearchKey.empty();
         }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingService.java
@@ -13,6 +13,7 @@ import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiEntityStatus;
 import org.rutebanken.tiamat.ext.fintraffic.api.repository.NetexRepository;
 import org.rutebanken.tiamat.ext.fintraffic.xml.NoNameSpaceXMLStreamWriter;
 import org.rutebanken.tiamat.model.EntityInVersionStructure;
+import org.rutebanken.tiamat.model.FareZone;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.TopographicPlace;
@@ -47,6 +48,7 @@ public class ReadApiNetexMarshallingService {
             org.rutebanken.netex.model.StopPlace.class, e -> objectFactory.createStopPlace((org.rutebanken.netex.model.StopPlace) e),
             org.rutebanken.netex.model.Parking.class, e -> objectFactory.createParking((org.rutebanken.netex.model.Parking) e),
             org.rutebanken.netex.model.TopographicPlace.class, e -> objectFactory.createTopographicPlace((org.rutebanken.netex.model.TopographicPlace) e),
+            org.rutebanken.netex.model.FareZone.class, e -> objectFactory.createFareZone((org.rutebanken.netex.model.FareZone) e),
             org.rutebanken.netex.model.ScheduledStopPoint.class, e -> objectFactory.createScheduledStopPoint((org.rutebanken.netex.model.ScheduledStopPoint) e),
             org.rutebanken.netex.model.PassengerStopAssignment.class, e -> objectFactory.createPassengerStopAssignment((org.rutebanken.netex.model.PassengerStopAssignment) e)
     );
@@ -75,6 +77,7 @@ public class ReadApiNetexMarshallingService {
                     org.rutebanken.netex.model.StopPlace.class,
                     org.rutebanken.netex.model.Parking.class,
                     org.rutebanken.netex.model.TopographicPlace.class,
+                    org.rutebanken.netex.model.FareZone.class,
                     org.rutebanken.netex.model.ScheduledStopPoint.class,
                     org.rutebanken.netex.model.PassengerStopAssignment.class
             );
@@ -190,6 +193,7 @@ public class ReadApiNetexMarshallingService {
             case StopPlace stopPlace -> netexMapper.mapToNetexModel(stopPlace);
             case Parking parking -> netexMapper.mapToNetexModel(parking);
             case TopographicPlace topographicPlace -> netexMapper.mapToNetexModel(topographicPlace);
+            case FareZone fareZone -> netexMapper.mapToNetexModel(fareZone);
             default ->
                     throw new IllegalArgumentException("Unsupported entity type for NeTEx mapping: " + entity.getClass().getName());
         };

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryService.java
@@ -25,16 +25,19 @@ public class ReadApiNetexPublicationDeliveryService {
     private static final String COLLECTION_TAG_SCHEDULED_STOP_POINTS = "<scheduledStopPoints/>";
     private static final String COLLECTION_TAG_STOP_ASSIGNMENTS = "<stopAssignments/>";
     private static final String COLLECTION_TAG_TOPOGRAPHIC_PLACES = "<topographicPlaces/>";
+    private static final String COLLECTION_TAG_TARIFF_ZONES = "<tariffZones/>";
     private static final String COLLECTION_TAG_STOP_PLACES = "<stopPlaces/>";
     private static final String COLLECTION_TAG_PARKINGS = "<parkings/>";
     private static final byte[] START_TAG_SCHEDULED_STOP_POINTS = "<scheduledStopPoints>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] START_TAG_STOP_ASSIGNMENTS = "<stopAssignments>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] START_TAG_TOPOGRAPHIC_PLACES = "<topographicPlaces>".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] START_TAG_TARIFF_ZONES = "<tariffZones>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] START_TAG_STOP_PLACES = "<stopPlaces>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] START_TAG_PARKINGS = "<parkings>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] END_TAG_SCHEDULED_STOP_POINTS = "</scheduledStopPoints>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] END_TAG_STOP_ASSIGNMENTS = "</stopAssignments>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] END_TAG_TOPOGRAPHIC_PLACES = "</topographicPlaces>".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] END_TAG_TARIFF_ZONES = "</tariffZones>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] END_TAG_STOP_PLACES = "</stopPlaces>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] END_TAG_PARKINGS = "</parkings>".getBytes(StandardCharsets.UTF_8);
     private static final byte[] NEWLINE = "\n".getBytes(StandardCharsets.UTF_8);
@@ -64,6 +67,7 @@ public class ReadApiNetexPublicationDeliveryService {
                             </DefaultLocale>
                         </FrameDefaults>
                         <topographicPlaces/>
+                        <tariffZones/>
                         <stopPlaces/>
                         <parkings/>
                     </SiteFrame>
@@ -108,6 +112,7 @@ public class ReadApiNetexPublicationDeliveryService {
             case "ScheduledStopPoint" -> COLLECTION_TAG_SCHEDULED_STOP_POINTS;
             case "PassengerStopAssignment" -> COLLECTION_TAG_STOP_ASSIGNMENTS;
             case "TopographicPlace" -> COLLECTION_TAG_TOPOGRAPHIC_PLACES;
+            case "FareZone" -> COLLECTION_TAG_TARIFF_ZONES;
             case "StopPlace" -> COLLECTION_TAG_STOP_PLACES;
             case "Parking" -> COLLECTION_TAG_PARKINGS;
             default -> throw new IllegalArgumentException("Unsupported type for collection tag: " + type);
@@ -119,6 +124,7 @@ public class ReadApiNetexPublicationDeliveryService {
             case "ScheduledStopPoint" -> START_TAG_SCHEDULED_STOP_POINTS;
             case "PassengerStopAssignment" -> START_TAG_STOP_ASSIGNMENTS;
             case "TopographicPlace" -> START_TAG_TOPOGRAPHIC_PLACES;
+            case "FareZone" -> START_TAG_TARIFF_ZONES;
             case "StopPlace" -> START_TAG_STOP_PLACES;
             case "Parking" -> START_TAG_PARKINGS;
             default -> throw new IllegalArgumentException("Unsupported type for collection start tag: " + type);
@@ -130,6 +136,7 @@ public class ReadApiNetexPublicationDeliveryService {
             case "ScheduledStopPoint" -> END_TAG_SCHEDULED_STOP_POINTS;
             case "PassengerStopAssignment" -> END_TAG_STOP_ASSIGNMENTS;
             case "TopographicPlace" -> END_TAG_TOPOGRAPHIC_PLACES;
+            case "FareZone" -> END_TAG_TARIFF_ZONES;
             case "StopPlace" -> END_TAG_STOP_PLACES;
             case "Parking" -> END_TAG_PARKINGS;
             default -> throw new IllegalArgumentException("Unsupported type for collection end tag: " + type);
@@ -141,6 +148,7 @@ public class ReadApiNetexPublicationDeliveryService {
         if (trimmed.equals(COLLECTION_TAG_SCHEDULED_STOP_POINTS)
                 || trimmed.equals(COLLECTION_TAG_STOP_ASSIGNMENTS)
                 || trimmed.equals(COLLECTION_TAG_TOPOGRAPHIC_PLACES)
+                || trimmed.equals(COLLECTION_TAG_TARIFF_ZONES)
                 || trimmed.equals(COLLECTION_TAG_STOP_PLACES)
                 || trimmed.equals(COLLECTION_TAG_PARKINGS)) {
             return new byte[]{};

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/batch/ReadApiBatchConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/batch/ReadApiBatchConfig.java
@@ -2,6 +2,7 @@ package org.rutebanken.tiamat.ext.fintraffic.api.batch;
 
 import org.rutebanken.tiamat.ext.fintraffic.api.ReadApiNetexMarshallingService;
 import org.rutebanken.tiamat.ext.fintraffic.api.repository.NetexRepository;
+import org.rutebanken.tiamat.repository.FareZoneRepository;
 import org.rutebanken.tiamat.repository.ParkingRepository;
 import org.rutebanken.tiamat.repository.StopPlaceRepository;
 import org.rutebanken.tiamat.repository.TopographicPlaceRepository;
@@ -18,13 +19,15 @@ public class ReadApiBatchConfig {
             ReadApiNetexMarshallingService marshallingService,
             StopPlaceRepository stopPlaceRepository,
             ParkingRepository parkingRepository,
-            TopographicPlaceRepository topographicPlaceRepository
+            TopographicPlaceRepository topographicPlaceRepository,
+            FareZoneRepository fareZoneRepository
     ) {
         return new ReadApiBatchUpdateService(
                 marshallingService,
                 stopPlaceRepository,
                 parkingRepository,
-                topographicPlaceRepository
+                topographicPlaceRepository,
+                fareZoneRepository
         );
     }
 

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/batch/ReadApiBatchUpdateService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/batch/ReadApiBatchUpdateService.java
@@ -8,10 +8,12 @@ import org.rutebanken.tiamat.ext.fintraffic.api.ReadApiNetexMarshallingService;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiEntityInRecord;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiEntityStatus;
 import org.rutebanken.tiamat.model.EntityInVersionStructure;
+import org.rutebanken.tiamat.model.FareZone;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.TopographicPlace;
 import org.rutebanken.tiamat.model.TopographicPlaceTypeEnumeration;
+import org.rutebanken.tiamat.repository.FareZoneRepository;
 import org.rutebanken.tiamat.repository.ParkingRepository;
 import org.rutebanken.tiamat.repository.StopPlaceRepository;
 import org.rutebanken.tiamat.repository.TopographicPlaceRepository;
@@ -34,16 +36,19 @@ public class ReadApiBatchUpdateService {
     private final StopPlaceRepository stopPlaceRepository;
     private final ParkingRepository parkingRepository;
     private final TopographicPlaceRepository topographicPlaceRepository;
+    private final FareZoneRepository fareZoneRepository;
 
     public ReadApiBatchUpdateService(
             ReadApiNetexMarshallingService marshallingService,
             StopPlaceRepository stopPlaceRepository,
             ParkingRepository parkingRepository,
-            TopographicPlaceRepository topographicPlaceRepository) {
+            TopographicPlaceRepository topographicPlaceRepository,
+            FareZoneRepository fareZoneRepository) {
         this.marshallingService = marshallingService;
         this.stopPlaceRepository = stopPlaceRepository;
         this.parkingRepository = parkingRepository;
         this.topographicPlaceRepository = topographicPlaceRepository;
+        this.fareZoneRepository = fareZoneRepository;
     }
 
     /**
@@ -112,6 +117,21 @@ public class ReadApiBatchUpdateService {
 
         Iterator<TopographicPlace> municipalityIterator = municipalities.iterator();
         return processEntitiesInBatches(municipalityIterator, batchSize, batchConsumer, "TopographicPlace");
+    }
+
+    /**
+     * Process FareZones in batches.
+     *
+     * FareZones are very few in number (typically 3 per authority area), so they are loaded as a list.
+     *
+     * @param batchSize Number of entities to process before flushing to database
+     * @param batchConsumer Consumer that handles each batch (typically database upsert)
+     * @return Statistics about the processing
+     */
+    @Transactional(readOnly = true)
+    public ProcessingStats processFareZonesInBatches(int batchSize, Consumer<List<ReadApiEntityInRecord>> batchConsumer) {
+        List<FareZone> fareZones = fareZoneRepository.findAllValidFareZones();
+        return processEntitiesInBatches(fareZones.iterator(), batchSize, batchConsumer, "FareZone");
     }
 
     /**

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/batch/ReadApiBatchUpdateTask.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/batch/ReadApiBatchUpdateTask.java
@@ -53,12 +53,12 @@ public class ReadApiBatchUpdateTask implements ApplicationRunner {
 
         try {
             // Step 1: Mark all rows as STALE
-            logger.info("Step 1/5: Marking all entities as STALE");
+            logger.info("Step 1/6: Marking all entities as STALE");
             int markedStale = netexRepository.markAllEntitiesAsStale();
             logger.info("Marked {} entities as STALE", markedStale);
 
             // Step 2: Process TopographicPlaces (municipalities only)
-            logger.info("Step 2/5: Processing TopographicPlaces");
+            logger.info("Step 2/6: Processing TopographicPlaces");
             ReadApiBatchUpdateService.ProcessingStats topographicPlaceStats =
                 readApiBatchUpdateService.processTopographicPlacesInBatches(DEFAULT_BATCH_SIZE, batch -> {
                     readApiBatchWriteService.upsertBatch(batch);
@@ -75,8 +75,26 @@ public class ReadApiBatchUpdateTask implements ApplicationRunner {
                 topographicPlaceStats.entitiesFailed(),
                 formatDuration(topographicPlaceStats.duration()));
 
-            // Step 3: Process StopPlaces in batches (streaming)
-            logger.info("Step 3/5: Processing StopPlaces (this may take 1-2 hours)");
+            // Step 3: Process FareZones
+            logger.info("Step 3/6: Processing FareZones");
+            ReadApiBatchUpdateService.ProcessingStats fareZoneStats =
+                readApiBatchUpdateService.processFareZonesInBatches(DEFAULT_BATCH_SIZE, batch -> {
+                    readApiBatchWriteService.upsertBatch(batch);
+                    logger.debug("Upserted batch of {} FareZone records", batch.size());
+                });
+
+            totalEntitiesProcessed += fareZoneStats.entitiesProcessed();
+            totalRecordsGenerated += fareZoneStats.recordsGenerated();
+            totalEntitiesFailed += fareZoneStats.entitiesFailed();
+
+            logger.info("FareZone processing completed: {} entities → {} records ({} failed) in {}",
+                fareZoneStats.entitiesProcessed(),
+                fareZoneStats.recordsGenerated(),
+                fareZoneStats.entitiesFailed(),
+                formatDuration(fareZoneStats.duration()));
+
+            // Step 4: Process StopPlaces in batches (streaming)
+            logger.info("Step 4/6: Processing StopPlaces (this may take 1-2 hours)");
             ReadApiBatchUpdateService.ProcessingStats stopPlaceStats =
                 readApiBatchUpdateService.processStopPlacesInBatches(DEFAULT_BATCH_SIZE, batch -> {
                     readApiBatchWriteService.upsertBatch(batch);
@@ -93,8 +111,8 @@ public class ReadApiBatchUpdateTask implements ApplicationRunner {
                 stopPlaceStats.entitiesFailed(),
                 formatDuration(stopPlaceStats.duration()));
 
-            // Step 4: Process Parkings in batches (streaming)
-            logger.info("Step 4/5: Processing Parkings");
+            // Step 5: Process Parkings in batches (streaming)
+            logger.info("Step 5/6: Processing Parkings");
             ReadApiBatchUpdateService.ProcessingStats parkingStats =
                 readApiBatchUpdateService.processParkingsInBatches(DEFAULT_BATCH_SIZE, batch -> {
                     readApiBatchWriteService.upsertBatch(batch);
@@ -111,8 +129,8 @@ public class ReadApiBatchUpdateTask implements ApplicationRunner {
                 parkingStats.entitiesFailed(),
                 formatDuration(parkingStats.duration()));
 
-            // Step 5: Clean up deleted entities
-            logger.info("Step 5/5: Cleaning up stale entities");
+            // Step 6: Clean up deleted entities
+            logger.info("Step 6/6: Cleaning up stale entities");
             int deletedCount = -1;
             if (totalEntitiesFailed > 0) {
                 logger.warn("There were {} failed entities during processing. " +

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/repository/FintrafficNetexRepository.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/repository/FintrafficNetexRepository.java
@@ -29,6 +29,7 @@ public class FintrafficNetexRepository extends AbstractNetexRepository {
                 'ScheduledStopPoint',
                 'PassengerStopAssignment',
                 'TopographicPlace',
+                'FareZone',
                 'StopPlace',
                 'Parking'
             )
@@ -55,9 +56,9 @@ public class FintrafficNetexRepository extends AbstractNetexRepository {
             }
 
             if (!filters.isEmpty()) {
-                // TopographicPlace is always included regardless of search filters because it provides geographic
-                // context needed for all stop place data
-                sql.append(" AND (type = 'TopographicPlace' OR (");
+                // TopographicPlace and FareZone are always included regardless of search filters
+                // because they provide reference data needed for all stop place data
+                sql.append(" AND (type IN ('TopographicPlace', 'FareZone') OR (");
                 sql.append(String.join(" AND ", filters));
                 sql.append("))");
             }
@@ -69,9 +70,10 @@ public class FintrafficNetexRepository extends AbstractNetexRepository {
                 WHEN 'ScheduledStopPoint' THEN 1
                 WHEN 'PassengerStopAssignment' THEN 2
                 WHEN 'TopographicPlace' THEN 3
-                WHEN 'StopPlace' THEN 4
-                WHEN 'Parking' THEN 5
-                ELSE 6
+                WHEN 'FareZone' THEN 4
+                WHEN 'StopPlace' THEN 5
+                WHEN 'Parking' THEN 6
+                ELSE 7
             END
         """);
 


### PR DESCRIPTION
### Summary

- Adds FareZone support to the PETI Read API (`GET /fintraffic/v1/stops`)
- FareZones are now included in the NeTEx output under `<tariffZones>` in the SiteFrame
- Related ticket: DPO-4620

The Read API uses a two-phase approach: a batch task pre-renders entities to a cache table, and the streaming endpoint serves directly from that cache. This PR extends both phases to include FareZones:

1. **Batch update** (`ReadApiBatchUpdateService`, `ReadApiBatchUpdateTask`, `ReadApiBatchConfig`) — FareZones are loaded via `FareZoneRepository.findAllValidFareZones()` and marshalled into the cache as step 3 of 6.
2. **Streaming output** (`ReadApiNetexPublicationDeliveryService`, `FintrafficNetexRepository`) — FareZones are streamed from the cache and placed in a `<tariffZones>` collection in the SiteFrame template. The SQL ORDER BY position (4) matches the template placeholder order, which is required by the streaming algorithm.
3. **Marshalling** (`ReadApiNetexMarshallingService`) — FareZone added to the JAXB factory map and `mapToNetexModel` switch.
4. **Search keys** (`FintrafficSearchKeyService`) — FareZones fall through to the `else` branch (empty search key), which is correct — filtering is handled at the SQL level via the always-include bypass for `FareZone` and `TopographicPlace`.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Unit tests

- Unit tests added for all changed services in `src/ext-test/`
- `ReadApiNetexPublicationDeliveryServiceTest` — 3 tests: empty output, FareZone appears in `<tariffZones>`, FareZone ordered before stop places
- `ReadApiNetexMarshallingServiceTest` — 2 new tests: entity record creation and XML marshalling for FareZone
- `FintrafficSearchKeyServiceTest` — 1 new test: FareZone returns empty search key
- All 36 ext-test tests pass

### Documentation

- Code comments explain the streaming order constraint and why FareZones use list load (small number, ~3 per authority area)