### PR TITLE
Fix FareZone import: strip "S" prefix from ScheduledStopPoint member refs

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/netex/mapping/mapper/FareZoneMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/netex/mapping/mapper/FareZoneMapper.java
@@ -106,7 +106,11 @@ public class FareZoneMapper extends CustomMapper<FareZone, org.rutebanken.tiamat
             if (Objects.equals(refType, "StopPlace")) {
                 return netexId;
             } else if (Objects.equals(refType, "ScheduledStopPoint")) {
-                return String.format("%s:StopPlace:%s", idParts[0], idParts[2]);
+                var id = idParts[2];
+                if (id.startsWith("S")) {
+                    id = id.substring(1);
+                }
+                return String.format("%s:StopPlace:%s", idParts[0], id);
             }
         }
         return null;

--- a/src/test/java/org/rutebanken/tiamat/netex/mapping/NetexMapperTest.java
+++ b/src/test/java/org/rutebanken/tiamat/netex/mapping/NetexMapperTest.java
@@ -33,6 +33,7 @@ import org.rutebanken.tiamat.model.AddressablePlaceRefStructure;
 import org.rutebanken.tiamat.model.AlternativeName;
 import org.rutebanken.tiamat.model.CountryRef;
 import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
+import org.rutebanken.tiamat.model.FareZone;
 import org.rutebanken.tiamat.model.GroupOfStopPlaces;
 import org.rutebanken.tiamat.model.IanaCountryTldEnumeration;
 import org.rutebanken.tiamat.model.LightingEnumeration;
@@ -41,6 +42,7 @@ import org.rutebanken.tiamat.model.NameTypeEnumeration;
 import org.rutebanken.tiamat.model.PathLink;
 import org.rutebanken.tiamat.model.PathLinkEnd;
 import org.rutebanken.tiamat.model.Quay;
+import org.rutebanken.tiamat.model.ScopingMethodEnumeration;
 import org.rutebanken.tiamat.model.SiteFrame;
 import org.rutebanken.tiamat.model.SiteRefStructure;
 import org.rutebanken.tiamat.model.StopPlace;
@@ -48,10 +50,12 @@ import org.rutebanken.tiamat.model.StopPlaceReference;
 import org.rutebanken.tiamat.model.StopPlacesInFrame_RelStructure;
 import org.rutebanken.tiamat.model.TopographicPlace;
 import org.rutebanken.tiamat.model.TopographicPlaceRefStructure;
+import org.rutebanken.tiamat.model.ValidBetween;
 import org.rutebanken.tiamat.model.Value;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -612,5 +616,49 @@ public class NetexMapperTest extends TiamatIntegrationTest {
         assertThat(
                 firstSiteRef.getRef())
                 .isEqualTo("NSR:StopPlace:1");
+    }
+
+    /**
+     * A FareZone with EXPLICIT_STOPS scoping stores its members as StopPlace references.
+     * On export each member is rewritten to a ScheduledStopPoint ref with an "S" prefix,
+     * so the import must strip that prefix to restore the original StopPlace ref.
+     * This verifies the export -> import round-trip is stable.
+     */
+    @Test
+    public void fareZoneExplicitStopsMembersSurviveNetexRoundTrip() {
+        NetexMappingContext mappingContext = new NetexMappingContext();
+        mappingContext.defaultTimeZone = ZoneId.of("Europe/Oslo");
+        NetexMappingContextThreadLocal.set(mappingContext);
+        try {
+            FareZone tiamatFareZone = new FareZone();
+            tiamatFareZone.setNetexId("NSR:FareZone:1");
+            tiamatFareZone.setVersion(1L);
+            tiamatFareZone.setName(new EmbeddableMultilingualString("Round trip zone"));
+            tiamatFareZone.setValidBetween(new ValidBetween(Instant.now().minusSeconds(3600)));
+            tiamatFareZone.setScopingMethod(ScopingMethodEnumeration.EXPLICIT_STOPS);
+            tiamatFareZone.getFareZoneMembers().add(new StopPlaceReference("NSR:StopPlace:123"));
+
+            // Export: StopPlace ref -> ScheduledStopPoint ref with "S" prefix added.
+            org.rutebanken.netex.model.FareZone netexFareZone = netexMapper.mapToNetexModel(tiamatFareZone);
+
+            assertThat(netexFareZone.getScopingMethod())
+                    .as("scoping method preserved on export")
+                    .isEqualTo(org.rutebanken.netex.model.ScopingMethodEnumeration.EXPLICIT_STOPS);
+            assertThat(netexFareZone.getMembers()).as("members").isNotNull();
+            assertThat(netexFareZone.getMembers().getPointRef())
+                    .as("exported member point refs")
+                    .extracting(pointRef -> pointRef.getValue().getRef())
+                    .containsExactly("NSR:ScheduledStopPoint:S123");
+
+            // Import: ScheduledStopPoint ref -> StopPlace ref, "S" prefix stripped.
+            FareZone roundTripped = netexMapper.mapToTiamatModel(netexFareZone);
+
+            assertThat(roundTripped.getFareZoneMembers())
+                    .as("round-tripped fare zone members")
+                    .extracting(StopPlaceReference::getRef)
+                    .containsExactly("NSR:StopPlace:123");
+        } finally {
+            NetexMappingContextThreadLocal.set(null);
+        }
     }
 }


### PR DESCRIPTION
### Summary

Fixes FareZone member references being corrupted on import.

When a FareZone uses `EXPLICIT_STOPS` scoping, its members are stored as StopPlace references (e.g. `NSR:StopPlace:123`). On **export**, `FareZoneMapper` rewrites each member into a `ScheduledStopPoint` reference and prefixes the numeric part with `S` (`NSR:StopPlace:123` → `NSR:ScheduledStopPoint:S123`). On **import**, however, the reverse conversion did not strip that `S` prefix, so a re-imported member was stored as `NSR:StopPlace:S123`.

That malformed ref breaks the `fare_zone_members.ref` ↔ `stop_place.netex_id` join used by `TariffZonesLookupService` / `FareZoneRepositoryImpl`, so stop places silently stopped matching their fare zone after an export → import round-trip.

This PR strips the leading `S` in `convertScheduledStopPointRefToStopPlaceRef`, making the import the exact inverse of the export. A `startsWith("S")` guard keeps it safe for refs that don't carry the prefix.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Issue

Motivation: an exported FareZone could not be re-imported without corrupting its explicit-stops members.

How it works: the export side (`convertStopPlaceRefToScheduledStopPointRef`) adds an `S` prefix to the stop id when turning a StopPlace ref into a ScheduledStopPoint ref. The import side now performs the inverse — stripping a leading `S` — so the original `NSR:StopPlace:<id>` value is restored and written to `fare_zone_members`.

### Unit tests

- Added `NetexMapperTest#fareZoneExplicitStopsMembersSurviveNetexRoundTrip`, which builds an `EXPLICIT_STOPS` FareZone with member `NSR:StopPlace:123`, maps it to NeTEx (asserting `NSR:ScheduledStopPoint:S123`), then maps it back (asserting the member is restored to `NSR:StopPlace:123`).
- Verified the test **fails without** the fix (member comes back as `NSR:StopPlace:S123`) and **passes with** it, confirming the test guards the change.
