### PR TITLE
Fix masked error responses on XML REST endpoints (#403)

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/rest/exception/ErrorResponseEntityMessageBodyWriter.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/exception/ErrorResponseEntityMessageBodyWriter.java
@@ -56,7 +56,9 @@ public class ErrorResponseEntityMessageBodyWriter implements MessageBodyWriter<E
         Optional.ofNullable(errorResponseEntity.errors)
                 .ifPresent(errors -> errors.forEach(error -> {
                     try {
-                        writer.write(error.message);
+                        // Guard against null messages (e.g. a NullPointerException has none):
+                        // PrintWriter.write(String) NPEs on null, which would itself fail the response.
+                        writer.write(error.message != null ? error.message : "");
                         writer.write("\n");
                     } catch (IOException e) {
                         logger.error("Cannot write error message when serializing error response entity", e);

--- a/src/main/java/org/rutebanken/tiamat/rest/exception/GeneralExceptionMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/exception/GeneralExceptionMapper.java
@@ -22,6 +22,7 @@ import jakarta.persistence.OptimisticLockException;
 import jakarta.validation.ValidationException;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
@@ -58,7 +59,12 @@ public class GeneralExceptionMapper implements ExceptionMapper<Exception> {
             status = toStatus(rootCause);
         }
 
+        // Pin the media type to text/plain so ErrorResponseEntityMessageBodyWriter (also text/plain)
+        // can serialize the body. Without this the response inherits the resource's @Produces
+        // (e.g. application/xml on the import endpoint), no writer matches ErrorResponseEntity,
+        // and the real cause is silently replaced by a generic 500.
         return Response.status(status)
+                       .type(MediaType.TEXT_PLAIN_TYPE)
                        .entity(new ErrorResponseEntity(rootCause.getMessage()))
                        .build();
     }

--- a/src/main/java/org/rutebanken/tiamat/rest/exception/GeneralExceptionMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/exception/GeneralExceptionMapper.java
@@ -59,13 +59,17 @@ public class GeneralExceptionMapper implements ExceptionMapper<Exception> {
             status = toStatus(rootCause);
         }
 
+        // Fall back to toString() (class name) when the exception carries no message,
+        // so the client still gets something meaningful (e.g. "java.lang.NullPointerException").
+        String message = rootCause.getMessage() != null ? rootCause.getMessage() : rootCause.toString();
+
         // Pin the media type to text/plain so ErrorResponseEntityMessageBodyWriter (also text/plain)
         // can serialize the body. Without this the response inherits the resource's @Produces
         // (e.g. application/xml on the import endpoint), no writer matches ErrorResponseEntity,
         // and the real cause is silently replaced by a generic 500.
         return Response.status(status)
                        .type(MediaType.TEXT_PLAIN_TYPE)
-                       .entity(new ErrorResponseEntity(rootCause.getMessage()))
+                       .entity(new ErrorResponseEntity(message))
                        .build();
     }
 

--- a/src/main/java/org/rutebanken/tiamat/rest/exception/NoSuchElementMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/exception/NoSuchElementMapper.java
@@ -27,9 +27,11 @@ public class NoSuchElementMapper implements ExceptionMapper<NoSuchElementExcepti
     public Response toResponse(NoSuchElementException ex) {
         // Return a serializable text/plain body. Previously the raw exception was set as the
         // entity with no media type, which had no MessageBodyWriter and collapsed to a generic 500.
+        // Fall back to toString() when the exception carries no message.
+        String message = ex.getMessage() != null ? ex.getMessage() : ex.toString();
         return Response.status(Response.Status.NOT_FOUND)
                 .type(MediaType.TEXT_PLAIN_TYPE)
-                .entity(new ErrorResponseEntity(ex.getMessage()))
+                .entity(new ErrorResponseEntity(message))
                 .build();
     }
 }

--- a/src/test/java/org/rutebanken/tiamat/rest/exception/ErrorResponseEntityMessageBodyWriterTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/exception/ErrorResponseEntityMessageBodyWriterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.rest.exception;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.annotation.Annotation;
+import java.nio.charset.StandardCharsets;
+
+
+public class ErrorResponseEntityMessageBodyWriterTest {
+
+    private String write(ErrorResponseEntity entity) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new ErrorResponseEntityMessageBodyWriter().writeTo(
+                entity, ErrorResponseEntity.class, ErrorResponseEntity.class,
+                new Annotation[0], MediaType.TEXT_PLAIN_TYPE, new MultivaluedHashMap<>(), out);
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void writesMessage() throws Exception {
+        Assert.assertEquals("boom\n", write(new ErrorResponseEntity("boom")));
+    }
+
+    @Test
+    public void nullMessageIsWrittenWithoutThrowing() throws Exception {
+        // A null message (e.g. from a NullPointerException) must not NPE the writer itself.
+        Assert.assertEquals("\n", write(new ErrorResponseEntity((String) null)));
+    }
+}

--- a/src/test/java/org/rutebanken/tiamat/rest/exception/GeneralExceptionMapperTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/exception/GeneralExceptionMapperTest.java
@@ -74,4 +74,13 @@ public class GeneralExceptionMapperTest {
         Assert.assertEquals(MediaType.TEXT_PLAIN_TYPE, rsp.getMediaType());
         Assert.assertEquals("boom", ((ErrorResponseEntity) rsp.getEntity()).errors.getFirst().message);
     }
+
+    @Test
+    public void exceptionWithoutMessageStillYieldsNonNullMessage() {
+        Response rsp = new GeneralExceptionMapper().toResponse(new NullPointerException());
+        Assert.assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), rsp.getStatus());
+        String message = ((ErrorResponseEntity) rsp.getEntity()).errors.getFirst().message;
+        Assert.assertNotNull("message must never be null or the body writer NPEs", message);
+        Assert.assertTrue(message.contains("NullPointerException"));
+    }
 }

--- a/src/test/java/org/rutebanken/tiamat/rest/exception/GeneralExceptionMapperTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/exception/GeneralExceptionMapperTest.java
@@ -17,6 +17,7 @@ package org.rutebanken.tiamat.rest.exception;
 
 import jakarta.validation.ValidationException;
 import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.junit.Assert;
 import org.junit.Test;
@@ -65,5 +66,12 @@ public class GeneralExceptionMapperTest {
     public void rawUnknownExceptionYieldsInternalServerError() {
         Response rsp = new GeneralExceptionMapper().toResponse(new FileNotFoundException());
         Assert.assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), rsp.getStatus());
+    }
+
+    @Test
+    public void errorResponseIsTextPlainSoTheCauseCanBeSerialized() {
+        Response rsp = new GeneralExceptionMapper().toResponse(new TransactionSystemException("", new RuntimeException("boom")));
+        Assert.assertEquals(MediaType.TEXT_PLAIN_TYPE, rsp.getMediaType());
+        Assert.assertEquals("boom", ((ErrorResponseEntity) rsp.getEntity()).errors.getFirst().message);
     }
 }

--- a/src/test/java/org/rutebanken/tiamat/rest/exception/NoSuchElementMapperTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/exception/NoSuchElementMapperTest.java
@@ -17,19 +17,19 @@ package org.rutebanken.tiamat.rest.exception;
 
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.ext.ExceptionMapper;
-import jakarta.ws.rs.ext.Provider;
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.NoSuchElementException;
 
-@Provider
-public class NoSuchElementMapper implements ExceptionMapper<NoSuchElementException> {
-    public Response toResponse(NoSuchElementException ex) {
-        // Return a serializable text/plain body. Previously the raw exception was set as the
-        // entity with no media type, which had no MessageBodyWriter and collapsed to a generic 500.
-        return Response.status(Response.Status.NOT_FOUND)
-                .type(MediaType.TEXT_PLAIN_TYPE)
-                .entity(new ErrorResponseEntity(ex.getMessage()))
-                .build();
+
+public class NoSuchElementMapperTest {
+
+    @Test
+    public void yieldsNotFoundWithSerializableTextPlainBody() {
+        Response rsp = new NoSuchElementMapper().toResponse(new NoSuchElementException("missing"));
+        Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), rsp.getStatus());
+        Assert.assertEquals(MediaType.TEXT_PLAIN_TYPE, rsp.getMediaType());
+        Assert.assertEquals("missing", ((ErrorResponseEntity) rsp.getEntity()).errors.getFirst().message);
     }
 }


### PR DESCRIPTION
### Summary

Fixes masked error responses on XML-producing REST endpoints (#403).

Any exception thrown while handling a request on a `@Produces(application/xml)` endpoint
(e.g. the NeTEx import endpoint `POST /services/stop_places/netex`) was returned to the
client as an opaque, generic `HTTP 500` — the real cause was discarded and only visible in
the server log. This made every import/validation failure look identical and slowed down
diagnosis considerably.

Root cause (two layers):

1. `GeneralExceptionMapper#toResponse` built the response **without setting a media type**, so
   it inherited the resource's `@Produces` (`application/xml`). The only writer for
   `ErrorResponseEntity` is `@Produces("text/plain")`, so no writer matched →
   `MessageBodyProviderNotFoundException` → generic 500, message dropped.
2. Once the response is pinned to `text/plain`, `ErrorResponseEntityMessageBodyWriter` is
   actually invoked — and it then NPE'd for exceptions with no message (e.g. a bare
   `NullPointerException`), because `PrintWriter.write(String)` throws on `null`. So the error
   still failed to serialize, just one level deeper.

Changes:

- `GeneralExceptionMapper` — pin error responses to `text/plain` so the existing writer matches.
- `NoSuchElementMapper` — same fix; also switched from setting the raw (un-writable) exception
  as the entity to a `text/plain` `ErrorResponseEntity`.
- Both mappers — fall back to the exception's `toString()` (class name) when `getMessage()` is
  `null`, so the client gets something meaningful instead of a blank line.
- `ErrorResponseEntityMessageBodyWriter` — null-guard the write so it can never NPE on a null message.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Issue

Closes #403.

- **Motivation:** while importing a third-party NeTEx file, four distinct failures all surfaced
  as the same opaque `{"status":500,"error":"Internal Server Error"}`; the actual causes (schema
  parse error, missing time zone, non-numeric version, non-conforming IDs) were only recoverable
  from `spring.log`.
- **How it works:** JAX-RS selects a `MessageBodyWriter` by the response's media type. By
  explicitly setting `text/plain` (the type `ErrorResponseEntityMessageBodyWriter` already
  produces) the writer is always matched, regardless of the resource's `@Produces`.
- **Design note:** `text/plain` was chosen because it matches the existing writer and keeps the
  Content-Type honest. An alternative (broadening the writer's `@Produces` to `application/xml`/
  `application/json`) would label a plain-text body as XML/JSON, so it was not taken.

### Unit tests

- `GeneralExceptionMapperTest` — added assertions that the response media type is `text/plain`,
  that the cause message is carried through, and that an exception **without** a message still
  yields a non-null message (`NullPointerException` → class name).
- `NoSuchElementMapperTest` (new) — asserts 404 + `text/plain` + serialized message.
- `ErrorResponseEntityMessageBodyWriterTest` (new) — writes a normal message, and reproduces the
  null-message case to prove the writer no longer NPEs.
- All four exception-mapper test classes pass locally on JDK 25 (`mvn test -Dtest=...`, 11 tests, BUILD SUCCESS).

### Documentation

- Added inline comments at each change site explaining why the media type is pinned and why the
  null-guard / `toString()` fallback are needed.