### PR TITLE
Fix: skip proximity merge when incoming parking has a known source ID

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/importer/merging/MergingParkingImporter.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/merging/MergingParkingImporter.java
@@ -35,6 +35,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.util.concurrent.ExecutionException;
 
+import static org.rutebanken.tiamat.netex.mapping.mapper.NetexIdMapper.ORIGINAL_ID_KEY;
+
 @Component
 @Qualifier("mergingParkingImporter")
 @Transactional
@@ -184,6 +186,12 @@ public class MergingParkingImporter {
         final Parking existingParking = parkingFromOriginalIdFinder.find(newParking);
         if (existingParking != null) {
             return existingParking;
+        }
+        // If the parking has a known source ID but was not found by it, it is definitively new.
+        // Skip proximity matching to avoid incorrectly merging distinct facilities that happen to
+        // share a name and are geographically close (e.g., two lots at the same station).
+        if (!newParking.getOrCreateValues(ORIGINAL_ID_KEY).isEmpty()) {
+            return null;
         }
 
         if (newParking.getName() != null) {

--- a/src/test/java/org/rutebanken/tiamat/importer/merging/MergingParkingImporterTest.java
+++ b/src/test/java/org/rutebanken/tiamat/importer/merging/MergingParkingImporterTest.java
@@ -202,6 +202,40 @@ public class MergingParkingImporterTest extends TiamatIntegrationTest {
         assertThat(parking.getParkingType()).isNull();
     }
 
+    /**
+     * Two parkings with the same name and coordinates but different importedIds must be kept as separate parkings.
+     * The proximity-based merge must not fire when the incoming parking has a known source ID.
+     */
+    @Test
+    public void parkingsWithDifferentImportedIdsMustNotBeMergedByProximity() throws ExecutionException, InterruptedException {
+        String name = "Shared Station Parking";
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        double longitude = 24.934288;
+        double latitude = 60.198294;
+
+        Parking firstParking = createParking(name, longitude, latitude, null);
+        firstParking.setParkingType(ParkingTypeEnumeration.PARK_AND_RIDE);
+        firstParking.getOrCreateValues(NetexIdMapper.ORIGINAL_ID_KEY).add("FIN:Parking:liipi-100");
+        firstParking.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+
+        Parking firstResult = mergingParkingImporter.importParkingWithoutNetexMapping(firstParking);
+
+        Parking secondParking = createParking(name, longitude, latitude, null);
+        secondParking.setParkingType(ParkingTypeEnumeration.PARK_AND_RIDE);
+        secondParking.getOrCreateValues(NetexIdMapper.ORIGINAL_ID_KEY).add("FIN:Parking:liipi-200");
+        secondParking.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+
+        Parking secondResult = mergingParkingImporter.importParkingWithoutNetexMapping(secondParking);
+
+        assertThat(secondResult.getNetexId())
+                .as("Two parkings with distinct importedIds must not be merged by proximity")
+                .isNotEqualTo(firstResult.getNetexId());
+        assertThat(secondResult.getVersion()).isEqualTo(1L);
+    }
+
     @Test
     public void testHandleAlreadyExistingParkingUpdatedParkingVehicleTypes() {
 


### PR DESCRIPTION
### Summary

- Fixes a bug in `MergingParkingImporter` where two distinct parking facilities could be incorrectly merged based on proximity alone when they shared a name and nearby coordinates (e.g., two separate lots at the same station).

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Issue

**Motivation:** When importing parkings that carry an `originalId` (i.e., a known source-system ID), the importer first tries to locate an existing parking by that ID. If none is found, it fell through to proximity-based matching. This meant two new parkings with different IDs but the same name and overlapping coordinates (common at large transport hubs) could be collapsed into one record — silently dropping the second facility.

**How the code works:** `MergingParkingImporter.findNearbyOrExistingParking` now returns `null` immediately (signalling "this is a new parking") when the incoming parking has a non-empty `ORIGINAL_ID_KEY` value list and no existing parking was found by ID. Proximity matching is only attempted for parkings that arrived without any source identifier, preserving the original fallback behaviour for those cases.

### Unit tests

A new integration test `parkingsWithDifferentImportedIdsMustNotBeMergedByProximity` in `MergingParkingImporterTest` covers the scenario: two parkings with identical names and coordinates but different `importedId` values are imported sequentially and asserted to produce two distinct Tiamat records (different `netexId`, both at version 1).

All existing tests continue to pass.

### Documentation

The fix and its rationale are documented in a code comment at the insertion point in `MergingParkingImporter`.