### PR TITLE
Fix NeTEx export failure for multimodal parents referencing unshared topographic places

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/exporter/StreamingPublicationDelivery.java
+++ b/src/main/java/org/rutebanken/tiamat/exporter/StreamingPublicationDelivery.java
@@ -82,6 +82,7 @@ import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -209,6 +210,16 @@ public class StreamingPublicationDelivery {
         final Set<Long> stopPlacePrimaryIds = stopPlaceRepository.getDatabaseIds(exportParams, ignorePaging);
         logger.info("Got {} stop place IDs from stop place search", stopPlacePrimaryIds.size());
 
+        // Parent stops of multimodal stop places are appended to the export by ParentStopFetchingIterator,
+        // but they are not part of the stop place search result (and may be excluded from it by paging).
+        // Include them when gathering referenced entities so topographic places, tariff zones and parkings
+        // referenced only by a parent are exported too - otherwise marshalling fails on a dangling reference.
+        final Set<Long> exportedStopPlaceIds = new HashSet<>(stopPlacePrimaryIds);
+        exportedStopPlaceIds.addAll(stopPlaceRepository.getParentStopPlaceIds(stopPlacePrimaryIds));
+        if (exportedStopPlaceIds.size() > stopPlacePrimaryIds.size()) {
+            logger.info("Added {} parent stop place IDs for entity gathering", exportedStopPlaceIds.size() - stopPlacePrimaryIds.size());
+        }
+
         tiamatSiteFrameExporter.addRelevantPathLinks(stopPlacePrimaryIds, siteFrame);
 
 
@@ -226,9 +237,9 @@ public class StreamingPublicationDelivery {
 
         logger.info("Preparing scrollable iterators");
         prepareStopPlaces(exportParams, stopPlacePrimaryIds, mappedStopPlaceCount, netexSiteFrame, entitiesEvictor);
-        prepareTopographicPlaces(exportParams, stopPlacePrimaryIds, mappedTopographicPlacesCount, netexSiteFrame, entitiesEvictor);
-        prepareTariffZones(exportParams, stopPlacePrimaryIds, mappedTariffZonesCount, netexSiteFrame, entitiesEvictor);
-        prepareParkings(exportParams, stopPlacePrimaryIds, mappedParkingCount, netexSiteFrame, entitiesEvictor);
+        prepareTopographicPlaces(exportParams, exportedStopPlaceIds, mappedTopographicPlacesCount, netexSiteFrame, entitiesEvictor);
+        prepareTariffZones(exportParams, exportedStopPlaceIds, mappedTariffZonesCount, netexSiteFrame, entitiesEvictor);
+        prepareParkings(exportParams, exportedStopPlaceIds, mappedParkingCount, netexSiteFrame, entitiesEvictor);
         prepareGroupOfStopPlaces(exportParams, stopPlacePrimaryIds, mappedGroupOfStopPlacesCount, netexSiteFrame,netexResourceFrame, entitiesEvictor);
         prepareFareZones(exportParams,stopPlacePrimaryIds,mappedFareZonesCount,mappedGroupOfTariffZonesCount,netexSiteFrame,netexFareFrame,entitiesEvictor);
         prepareScheduledStopPoints(stopPlacePrimaryIds, netexServiceFrame);

--- a/src/main/java/org/rutebanken/tiamat/exporter/StreamingPublicationDelivery.java
+++ b/src/main/java/org/rutebanken/tiamat/exporter/StreamingPublicationDelivery.java
@@ -217,7 +217,7 @@ public class StreamingPublicationDelivery {
         final Set<Long> exportedStopPlaceIds = new HashSet<>(stopPlacePrimaryIds);
         exportedStopPlaceIds.addAll(stopPlaceRepository.getParentStopPlaceIds(stopPlacePrimaryIds));
         if (exportedStopPlaceIds.size() > stopPlacePrimaryIds.size()) {
-            logger.info("Added {} parent stop place IDs for entity gathering", exportedStopPlaceIds.size() - stopPlacePrimaryIds.size());
+            logger.debug("Added {} parent stop place IDs for entity gathering", exportedStopPlaceIds.size() - stopPlacePrimaryIds.size());
         }
 
         tiamatSiteFrameExporter.addRelevantPathLinks(stopPlacePrimaryIds, siteFrame);

--- a/src/main/java/org/rutebanken/tiamat/repository/StopPlaceRepositoryCustom.java
+++ b/src/main/java/org/rutebanken/tiamat/repository/StopPlaceRepositoryCustom.java
@@ -68,6 +68,14 @@ public interface StopPlaceRepositoryCustom extends DataManagedObjectStructureRep
 
     Set<Long> getDatabaseIds(ExportParams exportParams, boolean ignorePaging);
 
+    /**
+     * Returns the database ids of all versions of the parent stop places referenced by the given stop place ids.
+     * Used during export to gather entities (topographic places, tariff zones, parkings) referenced by parents
+     * that are appended to the export by {@link org.rutebanken.tiamat.exporter.async.ParentStopFetchingIterator}
+     * but are not part of the original stop place search result.
+     */
+    Set<Long> getParentStopPlaceIds(Set<Long> stopPlaceDatabaseIds);
+
     Page<StopPlace> findStopPlace(ExportParams exportParams);
 
     Page<StopPlace> findStopPlacesWithEffectiveChangeInPeriod(ChangedStopPlaceSearch search);

--- a/src/main/java/org/rutebanken/tiamat/repository/StopPlaceRepositoryImpl.java
+++ b/src/main/java/org/rutebanken/tiamat/repository/StopPlaceRepositoryImpl.java
@@ -651,6 +651,31 @@ public class StopPlaceRepositoryImpl implements StopPlaceRepositoryCustom {
     }
 
     @Override
+    public Set<Long> getParentStopPlaceIds(Set<Long> stopPlaceDatabaseIds) {
+        if (stopPlaceDatabaseIds == null || stopPlaceDatabaseIds.isEmpty()) {
+            return new HashSet<>();
+        }
+        // The exact parent stop versions referenced by the given stops, matching ParentStopFetchingIterator
+        // which appends the parent version each child references (findFirstByNetexIdAndVersion). Matching on
+        // both netex_id and version (parent_site_ref_version is stored as text) avoids gathering entities for
+        // unrelated parent versions. These parents are not part of the search result, so their referenced
+        // topographic places / tariff zones / parkings would otherwise be missing and break schema validation.
+        Query query = entityManager.createNativeQuery(
+                "SELECT DISTINCT parent.id " +
+                "FROM stop_place child " +
+                "JOIN stop_place parent ON parent.netex_id = child.parent_site_ref " +
+                "    AND CAST(parent.version AS text) = child.parent_site_ref_version " +
+                "WHERE child.id IN (:ids) AND child.parent_site_ref IS NOT NULL");
+        query.setParameter("ids", stopPlaceDatabaseIds);
+
+        Set<Long> result = new HashSet<>();
+        for (Object object : query.getResultList()) {
+            result.add(((Number) object).longValue());
+        }
+        return result;
+    }
+
+    @Override
     public Page<StopPlace> findStopPlace(ExportParams exportParams) {
         Pair<String, Map<String, Object>> queryWithParams = stopPlaceQueryFromSearchBuilder.buildQueryString(exportParams);
 

--- a/src/test/java/org/rutebanken/tiamat/exporter/StreamingPublicationDeliveryIntegrationTest.java
+++ b/src/test/java/org/rutebanken/tiamat/exporter/StreamingPublicationDeliveryIntegrationTest.java
@@ -27,6 +27,7 @@ import org.rutebanken.tiamat.exporter.params.StopPlaceSearch;
 import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
 import org.rutebanken.tiamat.model.GroupOfStopPlaces;
 import org.rutebanken.tiamat.model.PurposeOfGrouping;
+import org.rutebanken.tiamat.model.SiteRefStructure;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.model.StopPlaceReference;
 import org.rutebanken.tiamat.model.TariffZone;
@@ -425,6 +426,95 @@ public class StreamingPublicationDeliveryIntegrationTest extends TiamatIntegrati
 
         List<org.rutebanken.netex.model.StopPlace> stopPlaces = publicationDeliveryTestHelper.extractStopPlaces(publicationDeliveryStructure);
         assertThat(stopPlaces).hasSize(2);
+    }
+
+    /**
+     * Reproduces the export failure where a multimodal parent stop references a topographic place
+     * that none of its children reference.
+     *
+     * The parent stop is appended to the export by {@link org.rutebanken.tiamat.exporter.async.ParentStopFetchingIterator}
+     * but is not part of the stop place search result (here the export is requested by the child id). Before the fix,
+     * topographic places were gathered only from the search result, so the parent's TopographicPlaceRef had no matching
+     * TopographicPlace in the document and the (schema validating) sync export threw a MarshalException
+     * (cvc-identity-constraint.4.3: Key 'TopographicPlace_KeyRef' ... not found).
+     */
+    @Test
+    public void exportMultimodalParentReferencingTopographicPlaceNotReferencedByChildren() throws Exception {
+
+        TopographicPlace county = new TopographicPlace(new EmbeddableMultilingualString("County"));
+        county.setTopographicPlaceType(TopographicPlaceTypeEnumeration.COUNTY);
+        county = topographicPlaceVersionedSaverService.saveNewVersion(county);
+
+        // Two versions of the same municipality. The parent references v1, the child references v2 -
+        // mirroring a parent left pointing at an older topographic place version than its children.
+        // Two distinct municipalities under the county. The parent references one, its child the other.
+        // (In production the same mismatch arises from a parent pointing at an older *version* of one
+        // municipality than its children - e.g. a pre-municipality-reform code.)
+        TopographicPlace parentMunicipality = new TopographicPlace(new EmbeddableMultilingualString("Parent municipality"));
+        parentMunicipality.setTopographicPlaceType(TopographicPlaceTypeEnumeration.MUNICIPALITY);
+        parentMunicipality.setParentTopographicPlaceRef(new TopographicPlaceRefStructure(county.getNetexId(), String.valueOf(county.getVersion())));
+        parentMunicipality = topographicPlaceVersionedSaverService.saveNewVersion(parentMunicipality);
+
+        TopographicPlace childMunicipality = new TopographicPlace(new EmbeddableMultilingualString("Child municipality"));
+        childMunicipality.setTopographicPlaceType(TopographicPlaceTypeEnumeration.MUNICIPALITY);
+        childMunicipality.setParentTopographicPlaceRef(new TopographicPlaceRefStructure(county.getNetexId(), String.valueOf(county.getVersion())));
+        childMunicipality = topographicPlaceVersionedSaverService.saveNewVersion(childMunicipality);
+
+        // Multimodal parent stop referencing the municipality that none of its children reference.
+        StopPlace parent = new StopPlace(new EmbeddableMultilingualString("Multimodal parent"));
+        parent.setParentStopPlace(true);
+        parent.setVersion(1L);
+        parent.setTopographicPlace(parentMunicipality);
+        stopPlaceRepository.save(parent);
+
+        // Child stop referencing the other municipality, linked to the parent via parentSiteRef.
+        StopPlace child = new StopPlace(new EmbeddableMultilingualString("Child stop"));
+        child.setVersion(1L);
+        child.setTopographicPlace(childMunicipality);
+        child.setParentSiteRef(new SiteRefStructure(parent.getNetexId(), String.valueOf(parent.getVersion())));
+        stopPlaceRepository.save(child);
+
+        stopPlaceRepository.flush();
+
+        ExportParams exportParams = ExportParams.newExportParamsBuilder()
+                .setStopPlaceSearch(
+                        StopPlaceSearch.newStopPlaceSearchBuilder()
+                                .setNetexIdList(List.of(child.getNetexId()))
+                                .setAllVersions(true)
+                                .build())
+                .setTopographicPlaceExportMode(ExportParams.ExportMode.RELEVANT)
+                .setTariffZoneExportMode(ExportParams.ExportMode.NONE)
+                .build();
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+        // The sync streaming delivery validates against the schema, so before the fix this call itself throws
+        // (cvc-identity-constraint.4.3: Key 'TopographicPlace_KeyRef' ... not found).
+        streamingPublicationDelivery.stream(exportParams, byteArrayOutputStream);
+
+        String xml = byteArrayOutputStream.toString();
+
+        validate(xml);
+        netexXmlReferenceValidator.validateNetexReferences(new ByteArrayInputStream(xml.getBytes()), "publicationDelivery");
+
+        PublicationDeliveryStructure publicationDeliveryStructure = publicationDeliveryUnmarshaller.unmarshal(new ByteArrayInputStream(xml.getBytes()));
+        org.rutebanken.netex.model.SiteFrame siteFrame = publicationDeliveryHelper.findSiteFrame(publicationDeliveryStructure);
+
+        // The parent stop must have been appended to the export.
+        List<org.rutebanken.netex.model.StopPlace> stops = siteFrame.getStopPlaces().getStopPlace_().stream()
+                .map(sp -> (org.rutebanken.netex.model.StopPlace) sp.getValue())
+                .toList();
+        assertThat(stops)
+                .as("both the searched child and its appended parent must be exported")
+                .extracting(org.rutebanken.netex.model.StopPlace::getId)
+                .contains(child.getNetexId(), parent.getNetexId());
+
+        // Both municipalities must be present: the one referenced by the child and the one referenced only by the parent.
+        assertThat(siteFrame.getTopographicPlaces()).isNotNull();
+        assertThat(siteFrame.getTopographicPlaces().getTopographicPlace())
+                .as("the topographic place referenced only by the parent must also be exported")
+                .extracting(org.rutebanken.netex.model.TopographicPlace::getId)
+                .contains(parentMunicipality.getNetexId(), childMunicipality.getNetexId());
     }
 
     private void validate(String xml) throws JAXBException, IOException, SAXException {


### PR DESCRIPTION
Fix NeTEx export failure for multimodal parents referencing unshared topographic places ,Parent stop places are appended to the export by ParentStopFetchingIterator but are not part of the stop place search result, so topographic places,tariff zones and parkings referenced only by a parent were never gathered. This produced a dangling TopographicPlace_KeyRef and a MarshalException (cvc-identity-constraint.4.3) when exporting such stops.  Gather referenced entities from the parent stops too via the new  StopPlaceRepository.getParentStopPlaceIds.


### Type of change
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)


### Unit tests

A new integration test added. All test pass. manual verification done.


### Documentation

Inline commits added.


