### PR TITLE
Fix Read API ResultSet closed after Spring Boot 4 upgrade

### DIFF
--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryService.java
@@ -168,7 +168,7 @@ public class ReadApiNetexPublicationDeliveryService {
      * {@link org.rutebanken.tiamat.ext.fintraffic.api.repository.NetexRepository#streamStopPlaces}
      * remains open until all entities have been written.
      */
-    @Transactional(isolation = Isolation.READ_COMMITTED)
+    @Transactional(isolation = Isolation.READ_COMMITTED, readOnly = true)
     public void streamPublicationDelivery(
             ReadApiSearchKey searchKey,
             OutputStream outputStream

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryService.java
@@ -9,6 +9,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -158,6 +161,14 @@ public class ReadApiNetexPublicationDeliveryService {
         return bytes;
     }
 
+    /**
+     * Streams a full NeTEx PublicationDelivery to the given output stream, incrementally writing
+     * stop place entities as they are read from the database. The transaction spans the entire
+     * method so that the underlying JDBC {@link java.sql.ResultSet} from
+     * {@link org.rutebanken.tiamat.ext.fintraffic.api.repository.NetexRepository#streamStopPlaces}
+     * remains open until all entities have been written.
+     */
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void streamPublicationDelivery(
             ReadApiSearchKey searchKey,
             OutputStream outputStream

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/repository/FintrafficNetexRepository.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/repository/FintrafficNetexRepository.java
@@ -5,7 +5,7 @@ import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiEntityOutRecord;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.FintrafficReadApiSearchKey;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiSearchKey;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -20,7 +20,13 @@ public class FintrafficNetexRepository extends AbstractNetexRepository {
         super(jdbc, objectMapper);
     }
 
-    @Transactional(isolation = Isolation.READ_COMMITTED)
+    /**
+     * Streams all stop place entities matching the given search key from the Read API cache table.
+     * Returns a lazy {@link Stream} backed by an open JDBC {@link java.sql.ResultSet} — the stream must be
+     * consumed before the transaction commits. The caller must own the transaction. Closing the
+     * transaction here would close the ResultSet before the stream is consumed.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
     public Stream<ReadApiEntityOutRecord> streamStopPlaces(ReadApiSearchKey searchKey) {
         StringBuilder sql = new StringBuilder("""
             SELECT type, xml


### PR DESCRIPTION
### Summary

Fixes `InvalidResultSetAccessException: This ResultSet is closed` in the Fintraffic Read API (`GET /api/fintraffic/v1/stops`) after the Spring Boot 4 / Hibernate 7 upgrade.

`JdbcTemplate.queryForStream()` returns a lazy `Stream` backed by an open JDBC `ResultSet`. The original code placed `@Transactional(isolation = READ_COMMITTED)` on `streamStopPlaces()` — the method that *creates* the stream. Spring's `@Transactional` proxy commits the transaction when that method returns, releasing the JDBC connection back to the pool. HikariCP then closes all open statements and result sets as part of connection cleanup. By the time the caller iterates the stream, the `ResultSet` is already closed.

The fix:
1. Moves `@Transactional(isolation = READ_COMMITTED, readOnly = true)` to `ReadApiNetexPublicationDeliveryService.streamPublicationDelivery()`, which iterates the stream. The transaction now stays open for the entire duration of streaming.
2. Replaces the annotation on `FintrafficNetexRepository.streamStopPlaces()` with `@Transactional(propagation = MANDATORY)` — enforcing that a transaction must already be active when the method is called, so the same bug cannot silently recur if called from a new context without a transaction.

### Transaction scope and read-only rationale

`streamPublicationDelivery()` must hold the transaction open while writing the full NeTEx response to the HTTP output stream (up to ~300 MB). The response is streamed directly to the client via CloudFront and ALB, neither of which buffers the full body — so the transaction can stay open for the duration of the client download.

The concern is that a long-running transaction on a write-heavy table could block autovacuum and delay interactive write requests from the Abzu editor. Marking the transaction `readOnly = true` mitigates this: PostgreSQL read-only transactions use a virtual transaction ID rather than a real `xid`, so they do not hold back the `xmin` horizon and autovacuum can proceed normally. Since the Read API has very low concurrency, Hikari connection pool exhaustion is not a concern.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Unit tests

- Existing unit tests in `FintrafficApiControllerTest` and `ReadApiNetexPublicationDeliveryServiceTest` pass without changes — both use plain instantiation (not Spring proxies), so the `@Transactional` annotations are not exercised.
- Verified manually by running Tiamat locally and confirming the Read API returns a complete NeTEx response (69,008 StopPlaces, 100,707 Quays) with no `ResultSet is closed` errors.

### Documentation

Javadoc added to both `streamPublicationDelivery()` and `streamStopPlaces()` explaining the transaction ownership requirement and why `MANDATORY` propagation is used.