### PR TITLE
[ext-fintraffic] Add FintrafficParking extension with persisted paymentMethods

### DIFF
--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficIntegrationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.ext.fintraffic;
+
+import org.junit.AfterClass;
+import org.rutebanken.tiamat.ext.fintraffic.config.FintrafficTestContextConfiguration;
+
+/**
+ * Base class for fintraffic integration tests that start a secondary Spring context.
+ * <p>
+ * {@link org.rutebanken.tiamat.config.ApplicationContextProvider} uses a static field to hold
+ * the active {@code ApplicationContext}, which is a JVM-global singleton. When the fintraffic
+ * test context starts it overwrites this field via {@code RestoringApplicationContextProvider},
+ * which saves the previous value. {@link #restoreApplicationContext()} restores it after all
+ * tests in the subclass complete, so the primary-context tests that follow get the correct beans.
+ */
+public abstract class FintrafficIntegrationTest {
+
+    @AfterClass
+    public static void restoreApplicationContext() {
+        FintrafficTestContextConfiguration.restoreContext();
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficTiamatTestApplication.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficTiamatTestApplication.java
@@ -1,0 +1,50 @@
+package org.rutebanken.tiamat.ext.fintraffic;
+
+import org.rutebanken.tiamat.auth.TiamatSecurityConfig;
+import org.rutebanken.tiamat.ext.fintraffic.auth.FintrafficSecurityConfig;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.model.StopPlace;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.security.autoconfigure.actuate.web.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.web.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * Spring Boot test application for Fintraffic extension integration tests.
+ * Extends the core TiamatTestApplication setup with:
+ * <ul>
+ *   <li>Entity scan covering {@link FintrafficParking} (ext model)</li>
+ *   <li>Component scan covering the ext package tree</li>
+ * </ul>
+ * Security is excluded; authorization is mocked in individual tests.
+ */
+@SpringBootApplication(exclude = {
+        SecurityAutoConfiguration.class,
+        ManagementWebSecurityAutoConfiguration.class,
+        SecurityFilterAutoConfiguration.class,
+        ServletWebSecurityAutoConfiguration.class,
+        UserDetailsServiceAutoConfiguration.class
+})
+@EnableTransactionManagement
+@EnableCaching
+@EntityScan(basePackageClasses = {StopPlace.class, FintrafficParking.class, Jsr310JpaConverters.class})
+@ComponentScan(
+        basePackages = "org.rutebanken.tiamat",
+        excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = TiamatSecurityConfig.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = FintrafficSecurityConfig.class)
+})
+public class FintrafficTiamatTestApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(FintrafficTiamatTestApplication.class, args);
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficTiamatTestApplication.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficTiamatTestApplication.java
@@ -1,7 +1,9 @@
 package org.rutebanken.tiamat.ext.fintraffic;
 
 import org.rutebanken.tiamat.auth.TiamatSecurityConfig;
+import org.rutebanken.tiamat.config.ApplicationContextProvider;
 import org.rutebanken.tiamat.ext.fintraffic.auth.FintrafficSecurityConfig;
+import org.rutebanken.tiamat.ext.fintraffic.config.FintrafficTestContextConfiguration;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.springframework.boot.SpringApplication;
@@ -15,6 +17,7 @@ import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSec
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -41,8 +44,10 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
         basePackages = "org.rutebanken.tiamat",
         excludeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = TiamatSecurityConfig.class),
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = FintrafficSecurityConfig.class)
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = FintrafficSecurityConfig.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = ApplicationContextProvider.class)
 })
+@Import(FintrafficTestContextConfiguration.class)
 public class FintrafficTiamatTestApplication {
     public static void main(String[] args) {
         SpringApplication.run(FintrafficTiamatTestApplication.class, args);

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiParkingIncrementalSyncIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiParkingIncrementalSyncIntegrationTest.java
@@ -1,0 +1,176 @@
+package org.rutebanken.tiamat.ext.fintraffic.api;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.changelog.EntityChangedListener;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficIntegrationTest;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
+import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
+import org.rutebanken.tiamat.model.StopPlace;
+import org.rutebanken.tiamat.model.StopTypeEnumeration;
+import org.rutebanken.tiamat.repository.ParkingRepository;
+import org.rutebanken.tiamat.repository.StopPlaceRepository;
+import org.rutebanken.tiamat.rest.graphql.GraphQLNames;
+import org.rutebanken.tiamat.versioning.save.StopPlaceVersionedSaverService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.rutebanken.tiamat.config.JerseyConfig.SERVICES_STOP_PLACE_PATH;
+
+/**
+ * Reproduces the reported scenario: a brand-new Parking created via the real GraphQL
+ * {@code mutateParking} editor path never appears in the Read API cache table, even though
+ * the incremental sync path ({@code ParkingVersionedSaverService.sendToJMS} →
+ * {@code ReadApiEntityChangedPublisher.onChange} → {@code ReadApiNetexMarshallingService
+ * .handleEntityChange}) is invoked for every save. Activates the real {@code
+ * fintraffic-read-api} profile (not mocked, unlike the other Read API unit tests) so the real
+ * marshaller, search key service and repository run end to end.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = FintrafficTiamatTestApplication.class
+)
+@ActiveProfiles({"test", "gcs-blobstore", "fintraffic", "fintraffic-read-api"})
+@TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
+public class ReadApiParkingIncrementalSyncIntegrationTest extends FintrafficIntegrationTest {
+
+    private static final String BASE_URI_GRAPHQL = SERVICES_STOP_PLACE_PATH + "/graphql/";
+
+    /**
+     * The {@code test} profile activates {@code EntityChangedEventLocalPublisher}
+     * ({@code @Profile("local-changelog | test")}) alongside {@code fintraffic-read-api}'s
+     * {@code ReadApiEntityChangedPublisher}, so every bean that autowires the single-bean
+     * {@code EntityChangedListener} interface fails with a {@code NoUniqueBeanDefinitionException}.
+     * Real deployments only ever activate one of the two (see {@code
+     * spring.profiles.group.dev/tst/prd} in the peti-backend config, which never combines
+     * {@code test}/{@code local-changelog} with {@code fintraffic-read-api}), so this ambiguity
+     * is a test-only artifact. Marking the real Read API publisher {@code @Primary} here
+     * reproduces the production wiring for this test without changing any production bean.
+     */
+    @TestConfiguration
+    static class PrimaryEntityChangedListenerConfig {
+        @Bean
+        @Primary
+        EntityChangedListener primaryEntityChangedListener(ReadApiEntityChangedPublisher readApiEntityChangedPublisher) {
+            return readApiEntityChangedPublisher;
+        }
+    }
+
+    @MockitoBean
+    private AuthorizationService authorizationService;
+
+    @Value("${local.server.port}")
+    private int port;
+
+    @Autowired
+    private StopPlaceRepository stopPlaceRepository;
+
+    @Autowired
+    private StopPlaceVersionedSaverService stopPlaceVersionedSaverService;
+
+    @Autowired
+    private ParkingRepository parkingRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private org.rutebanken.tiamat.ext.fintraffic.api.repository.NetexRepository netexRepository;
+
+    @Autowired
+    private org.springframework.transaction.PlatformTransactionManager transactionManager;
+
+    @Before
+    public void configureRestAssured() {
+        RestAssured.baseURI = "http://localhost";
+        RestAssured.port = port;
+    }
+
+    @After
+    public void cleanUp() {
+        parkingRepository.deleteAll();
+        stopPlaceRepository.deleteAll();
+        jdbcTemplate.update("DELETE FROM ext_fintraffic_netex_entity");
+    }
+
+    /**
+     * Reproduces the exact reported symptom: a brand-new Parking created via the real GraphQL
+     * editor path must (a) sync a {@code type='Parking'} row into the Read API cache table, and
+     * (b) actually be returned by the real {@code streamStopPlaces} repository method (the same
+     * one the {@code GET /api/fintraffic/v1/stops} endpoint uses) — not just be present in the
+     * table under some other type value. The StopPlace/Parking creation happens over real HTTP
+     * (a separate thread/transaction/connection), so only the final {@code streamStopPlaces}
+     * call (which requires an active transaction) is wrapped in one, via a {@code
+     * TransactionTemplate} — wrapping the whole test method in {@code @Transactional} would hide
+     * the StopPlace/Parking from the GraphQL server's own connection until commit.
+     */
+    @Test
+    public void mutateParking_incrementalSync_writesRowToReadApiCacheTable() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        String mutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test parking\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" }) { id } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(mutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue())
+                .extract()
+                .path("data.parking[0].id");
+
+        Map<String, Object> row = jdbcTemplate.queryForMap(
+                "SELECT id, type, status FROM ext_fintraffic_netex_entity WHERE id = ?", parkingNetexId);
+
+        assertThat(row)
+                .as("a brand-new Parking created via GraphQL must sync into the Read API cache table")
+                .containsEntry("id", parkingNetexId)
+                .containsEntry("type", "Parking")
+                .containsEntry("status", "CURRENT");
+
+        var transactionTemplate = new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+        java.util.List<String> matchingTypes = transactionTemplate.execute(status -> {
+            try (var stream = netexRepository.streamStopPlaces(
+                    org.rutebanken.tiamat.ext.fintraffic.api.model.FintrafficReadApiSearchKey.empty())) {
+                return stream
+                        .filter(r -> r.type().equals("Parking") && r.xml().contains(parkingNetexId))
+                        .map(r -> r.type())
+                        .toList();
+            }
+        });
+        assertThat(matchingTypes)
+                .as("the new Parking must be returned by the real Read API stream query")
+                .hasSize(1);
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiParkingIncrementalSyncIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiParkingIncrementalSyncIntegrationTest.java
@@ -23,6 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -66,8 +67,15 @@ public class ReadApiParkingIncrementalSyncIntegrationTest extends FintrafficInte
      * {@code test}/{@code local-changelog} with {@code fintraffic-read-api}), so this ambiguity
      * is a test-only artifact. Marking the real Read API publisher {@code @Primary} here
      * reproduces the production wiring for this test without changing any production bean.
+     * <p>
+     * This class is a static nested {@code @TestConfiguration}, so the shared
+     * {@code FintrafficTiamatTestApplication}'s {@code @ComponentScan(basePackages =
+     * "org.rutebanken.tiamat")} picks it up as a real component in every test that boots that
+     * application context, not just this one. Gating it with {@code @Profile("fintraffic-read-api")}
+     * keeps it a no-op wherever that profile isn't active, so it can't break unrelated tests.
      */
     @TestConfiguration
+    @Profile("fintraffic-read-api")
     static class PrimaryEntityChangedListenerConfig {
         @Bean
         @Primary

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/config/FintrafficTestContextConfiguration.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/config/FintrafficTestContextConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.ext.fintraffic.config;
+
+import org.rutebanken.tiamat.config.ApplicationContextProvider;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Replaces {@link ApplicationContextProvider} in the fintraffic Spring test context with
+ * {@link RestoringApplicationContextProvider}, which saves and restores the static context
+ * field so that primary-context tests running after the fintraffic context is loaded still
+ * see the correct beans.
+ */
+@TestConfiguration
+public class FintrafficTestContextConfiguration {
+
+    @Bean
+    public ApplicationContextProvider applicationContextProvider() {
+        return new RestoringApplicationContextProvider();
+    }
+
+    public static void restoreContext() {
+        RestoringApplicationContextProvider.restoreContext();
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/config/RestoringApplicationContextProvider.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/config/RestoringApplicationContextProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.ext.fintraffic.config;
+
+import org.rutebanken.tiamat.config.ApplicationContextProvider;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Test-only replacement for {@link ApplicationContextProvider} used in the fintraffic Spring test context.
+ * <p>
+ * {@link ApplicationContextProvider} stores the active {@link ApplicationContext} in a static field.
+ * When the fintraffic test context starts it overwrites this field, causing subsequent tests running
+ * in the primary test context to get the wrong beans via {@code ApplicationContextProvider}.
+ * <p>
+ * This class saves the previous value of the static field when the fintraffic context sets it and
+ * exposes {@link #restoreContext()} so test teardown can restore the field before the primary-context
+ * tests that follow continue running.
+ * <p>
+ * Registered as a {@code @Bean} in {@link FintrafficTestContextConfiguration} which also excludes
+ * the component-scanned {@link ApplicationContextProvider} from the fintraffic context.
+ */
+class RestoringApplicationContextProvider extends ApplicationContextProvider {
+
+    private static ApplicationContext previousContext;
+    private static RestoringApplicationContextProvider instance;
+
+    @Override
+    public void setApplicationContext(ApplicationContext ctx) throws BeansException {
+        previousContext = ApplicationContextProvider.getApplicationContext();
+        instance = this;
+        super.setApplicationContext(ctx);
+    }
+
+    private void applyContext(ApplicationContext ctx) throws BeansException {
+        super.setApplicationContext(ctx);
+    }
+
+    static void restoreContext() {
+        if (instance != null && previousContext != null) {
+            instance.applyContext(previousContext);
+            previousContext = null;
+        }
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
@@ -1,0 +1,184 @@
+package org.rutebanken.tiamat.ext.fintraffic.importer;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.importer.merging.MergingParkingImporter;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+import org.rutebanken.tiamat.model.SiteRefStructure;
+import org.rutebanken.tiamat.model.StopPlace;
+import org.rutebanken.tiamat.repository.ParkingRepository;
+import org.rutebanken.tiamat.repository.StopPlaceRepository;
+import org.rutebanken.tiamat.versioning.save.ParkingVersionedSaverService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link FintrafficMergingParkingImporter}, verifying that
+ * {@link FintrafficParking#getPaymentMethods() paymentMethods} are preserved on both
+ * import paths:
+ * <ul>
+ *   <li>New parking — {@code handleCompletelyNewParking} saves the incoming entity as-is</li>
+ *   <li>Existing parking — {@code handleAlreadyExistingParking} merges {@code paymentMethods}
+ *       from the incoming parking into the version copy via {@link MergingParkingImporter#mergeExtendedFields}</li>
+ * </ul>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = FintrafficTiamatTestApplication.class
+)
+@ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
+public class FintrafficMergingParkingImporterTest {
+
+    @MockitoBean
+    private AuthorizationService authorizationService;
+
+    @Autowired
+    private MergingParkingImporter mergingParkingImporter;
+
+    @Autowired
+    private ParkingVersionedSaverService parkingVersionedSaverService;
+
+    @Autowired
+    private ParkingRepository parkingRepository;
+
+    @Autowired
+    private StopPlaceRepository stopPlaceRepository;
+
+    @After
+    public void cleanUp() {
+        parkingRepository.deleteAll();
+        stopPlaceRepository.deleteAll();
+    }
+
+    @Test
+    public void importerIsFintrafficSubtype() {
+        assertThat(mergingParkingImporter)
+                .as("fintraffic profile must activate FintrafficMergingParkingImporter via @Primary")
+                .isInstanceOf(FintrafficMergingParkingImporter.class);
+    }
+
+    @Test
+    @Transactional
+    public void handleCompletelyNewParking_preservesPaymentMethods() throws Exception {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        FintrafficParking incoming = new FintrafficParking();
+        incoming.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        incoming.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH, PaymentMethodEnumeration.CREDIT_CARD));
+
+        Parking saved = mergingParkingImporter.handleCompletelyNewParking(incoming);
+
+        assertThat(saved).isInstanceOf(FintrafficParking.class);
+        assertThat(((FintrafficParking) saved).getPaymentMethods())
+                .as("paymentMethods must be preserved when importing a completely new parking")
+                .containsExactlyInAnyOrder(PaymentMethodEnumeration.CASH, PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    @Test
+    @Transactional
+    public void handleAlreadyExistingParking_mergesPaymentMethods() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        // Existing parking with one payment method
+        FintrafficParking existing = new FintrafficParking();
+        existing.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        existing.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH));
+        existing = (FintrafficParking) parkingVersionedSaverService.saveNewVersion(existing);
+
+        // Incoming parking with updated payment methods
+        FintrafficParking incoming = new FintrafficParking();
+        incoming.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        incoming.setPaymentMethods(List.of(PaymentMethodEnumeration.CREDIT_CARD, PaymentMethodEnumeration.DEBIT_CARD));
+
+        Parking result = mergingParkingImporter.handleAlreadyExistingParking(existing, incoming);
+
+        assertThat(result).isInstanceOf(FintrafficParking.class);
+        assertThat(((FintrafficParking) result).getPaymentMethods())
+                .as("paymentMethods from incoming parking must replace those on the version copy")
+                .containsExactlyInAnyOrder(PaymentMethodEnumeration.CREDIT_CARD, PaymentMethodEnumeration.DEBIT_CARD);
+    }
+
+    @Test
+    @Transactional
+    public void handleAlreadyExistingParking_unchangedPaymentMethods_doesNotCreateNewVersion() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        FintrafficParking existing = new FintrafficParking();
+        existing.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        existing.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH));
+        existing = (FintrafficParking) parkingVersionedSaverService.saveNewVersion(existing);
+        long existingVersion = existing.getVersion();
+
+        FintrafficParking incoming = new FintrafficParking();
+        incoming.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH));
+
+        Parking result = mergingParkingImporter.handleAlreadyExistingParking(existing, incoming);
+
+        assertThat(result.getVersion())
+                .as("no new version must be created when paymentMethods are unchanged")
+                .isEqualTo(existingVersion);
+    }
+
+    @Test
+    @Transactional
+    public void handleCompletelyNewParking_withPlainParking_preservesPaymentMethods() throws Exception {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        // Simulate the NeTEx mapper: produces a plain Parking with the @Transient
+        // paymentMethods field populated from the NeTEx document.
+        Parking incoming = new Parking();
+        incoming.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        incoming.getPaymentMethods().add(PaymentMethodEnumeration.CASH);
+
+        Parking saved = mergingParkingImporter.handleCompletelyNewParking(incoming);
+
+        assertThat(saved)
+                .as("NeTEx-imported parking must be promoted to FintrafficParking")
+                .isInstanceOf(FintrafficParking.class);
+        assertThat(((FintrafficParking) saved).getPaymentMethods())
+                .as("paymentMethods from plain NeTEx-derived Parking must be preserved")
+                .containsExactlyInAnyOrder(PaymentMethodEnumeration.CASH);
+    }
+
+    @Test
+    @Transactional
+    public void handleAlreadyExistingParking_withPlainParking_mergesPaymentMethods() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        FintrafficParking existing = new FintrafficParking();
+        existing.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        existing.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH));
+        existing = (FintrafficParking) parkingVersionedSaverService.saveNewVersion(existing);
+
+        // Simulate the NeTEx mapper: plain Parking with updated @Transient paymentMethods
+        Parking incoming = new Parking();
+        incoming.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        incoming.getPaymentMethods().add(PaymentMethodEnumeration.CREDIT_CARD);
+
+        Parking result = mergingParkingImporter.handleAlreadyExistingParking(existing, incoming);
+
+        assertThat(result).isInstanceOf(FintrafficParking.class);
+        assertThat(((FintrafficParking) result).getPaymentMethods())
+                .as("paymentMethods from plain NeTEx-derived Parking must overwrite existing")
+                .containsExactlyInAnyOrder(PaymentMethodEnumeration.CREDIT_CARD);
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
@@ -4,6 +4,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficIntegrationTest;
 import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
 import org.rutebanken.tiamat.importer.merging.MergingParkingImporter;
@@ -43,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 )
 @ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
 @TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
-public class FintrafficMergingParkingImporterTest {
+public class FintrafficMergingParkingImporterTest extends FintrafficIntegrationTest {
 
     @MockitoBean
     private AuthorizationService authorizationService;

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
@@ -17,6 +17,7 @@ import org.rutebanken.tiamat.versioning.save.ParkingVersionedSaverService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         classes = FintrafficTiamatTestApplication.class
 )
 @ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
+@TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
 public class FintrafficMergingParkingImporterTest {
 
     @MockitoBean

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributorTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributorTest.java
@@ -1,0 +1,81 @@
+package org.rutebanken.tiamat.ext.fintraffic.importer;
+
+import ma.glasnost.orika.MappingContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link FintrafficParkingMapperContributor}.
+ */
+public class FintrafficParkingMapperContributorTest {
+
+    private FintrafficParkingMapperContributor contributor;
+    private MappingContext mappingContext;
+
+    @Before
+    public void setUp() {
+        contributor = new FintrafficParkingMapperContributor();
+        mappingContext = mock(MappingContext.class);
+    }
+
+    @Test
+    public void mapFromNetex_copiesPaymentMethodsToTransientField() {
+        org.rutebanken.netex.model.Parking source = new org.rutebanken.netex.model.Parking()
+                .withPaymentMethods(
+                        org.rutebanken.netex.model.PaymentMethodEnumeration.CASH,
+                        org.rutebanken.netex.model.PaymentMethodEnumeration.CREDIT_CARD);
+        Parking target = new Parking();
+
+        contributor.mapFromNetex(source, target, mappingContext);
+
+        assertThat(target.getPaymentMethods())
+                .containsExactlyInAnyOrder(
+                        PaymentMethodEnumeration.CASH,
+                        PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    @Test
+    public void mapFromNetex_emptySource_leavesTargetUnchanged() {
+        org.rutebanken.netex.model.Parking source = new org.rutebanken.netex.model.Parking();
+        Parking target = new Parking();
+
+        contributor.mapFromNetex(source, target, mappingContext);
+
+        assertThat(target.getPaymentMethods()).isEmpty();
+    }
+
+    @Test
+    public void mapToNetex_copiesPaymentMethodsFromFintrafficParking() {
+        FintrafficParking source = new FintrafficParking();
+        source.setPaymentMethods(List.of(
+                PaymentMethodEnumeration.CASH,
+                PaymentMethodEnumeration.CREDIT_CARD));
+        org.rutebanken.netex.model.Parking target = new org.rutebanken.netex.model.Parking();
+
+        contributor.mapToNetex(source, target, mappingContext);
+
+        assertThat(target.getPaymentMethods())
+                .containsExactlyInAnyOrder(
+                        org.rutebanken.netex.model.PaymentMethodEnumeration.CASH,
+                        org.rutebanken.netex.model.PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    @Test
+    public void mapToNetex_plainParking_doesNothing() {
+        Parking source = new Parking();
+        source.getPaymentMethods().add(PaymentMethodEnumeration.CASH);
+        org.rutebanken.netex.model.Parking target = new org.rutebanken.netex.model.Parking();
+
+        contributor.mapToNetex(source, target, mappingContext);
+
+        assertThat(target.getPaymentMethods()).isEmpty();
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactoryTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactoryTest.java
@@ -1,0 +1,42 @@
+package org.rutebanken.tiamat.ext.fintraffic.model;
+
+import org.junit.jupiter.api.Test;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FintrafficParkingEntityFactoryTest {
+
+    private final FintrafficParkingEntityFactory factory = new FintrafficParkingEntityFactory();
+
+    @Test
+    void create_returnsFintrafficParkingInstance() {
+        Parking parking = factory.create();
+
+        assertThat(parking).isInstanceOf(FintrafficParking.class);
+    }
+
+    @Test
+    void getEntityClass_returnsFintrafficParkingClass() {
+        assertThat(factory.getEntityClass()).isEqualTo(FintrafficParking.class);
+    }
+
+    @Test
+    void getMappingExclusions_doesNotContainPaymentMethods() {
+        List<String> exclusions = factory.getMappingExclusions();
+
+        assertThat(exclusions)
+                .as("paymentMethods must not be excluded so Orika maps it through")
+                .doesNotContain("paymentMethods");
+    }
+
+    @Test
+    void getMappingExclusions_stillExcludesOtherUnsupportedFields() {
+        List<String> exclusions = factory.getMappingExclusions();
+
+        assertThat(exclusions).contains("cardsAccepted", "currenciesAccepted", "accessModes");
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactoryTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactoryTest.java
@@ -25,12 +25,12 @@ class FintrafficParkingEntityFactoryTest {
     }
 
     @Test
-    void getMappingExclusions_doesNotContainPaymentMethods() {
+    void getMappingExclusions_containsPaymentMethods() {
         List<String> exclusions = factory.getMappingExclusions();
 
         assertThat(exclusions)
-                .as("paymentMethods must not be excluded so Orika maps it through")
-                .doesNotContain("paymentMethods");
+                .as("paymentMethods must be excluded from Orika auto-mapping: the two PaymentMethodEnumeration types differ and require explicit conversion in FintrafficParkingMapperContributor")
+                .contains("paymentMethods");
     }
 
     @Test

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingIntegrationTest.java
@@ -15,6 +15,7 @@ import org.rutebanken.tiamat.repository.ParkingRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         classes = FintrafficTiamatTestApplication.class
 )
 @ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
+@TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
 public class FintrafficParkingIntegrationTest {
 
     @MockitoBean

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingIntegrationTest.java
@@ -1,0 +1,136 @@
+package org.rutebanken.tiamat.ext.fintraffic.model;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+import org.rutebanken.tiamat.model.factory.ParkingEntityFactory;
+import org.rutebanken.tiamat.netex.mapping.NetexMapper;
+import org.rutebanken.tiamat.repository.ParkingRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test verifying that {@link FintrafficParking} persists {@code paymentMethods}
+ * through the full NeTEx → Orika → JPA → DB → JPA → NeTEx round-trip.
+ * <p>
+ * The {@code fintraffic} profile activates {@link FintrafficParkingEntityFactory} (which removes
+ * the Orika exclusion for {@code paymentMethods}) and the {@link FintrafficParking} entity subclass.
+ * {@link org.rutebanken.tiamat.ext.fintraffic.auth.FintrafficSecurityConfig} is excluded from the
+ * component scan via {@link FintrafficTiamatTestApplication}; {@link AuthorizationService} is mocked.
+ * <p>
+ * Persistence tests use {@link ParkingRepository} directly to avoid the {@code parentSiteRef}
+ * validation in {@code ParkingVersionedSaverService}, since the round-trip under test is
+ * specifically the {@code paymentMethods} field persistence, not the full import pipeline.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = FintrafficTiamatTestApplication.class
+)
+@ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
+public class FintrafficParkingIntegrationTest {
+
+    @MockitoBean
+    private AuthorizationService authorizationService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private NetexMapper netexMapper;
+
+    @Autowired
+    private ParkingEntityFactory parkingEntityFactory;
+
+    @Autowired
+    private ParkingRepository parkingRepository;
+
+    @After
+    public void cleanUp() {
+        parkingRepository.deleteAll();
+    }
+
+    @Test
+    public void parkingEntityFactory_producesFintrafficParkingInstance() {
+        Parking parking = netexMapper.mapToTiamatModel(
+                new org.rutebanken.netex.model.Parking().withId("FSR:Parking:1").withVersion("1"));
+
+        assertThat(parking)
+                .as("factory must produce FintrafficParking when fintraffic profile is active")
+                .isInstanceOf(FintrafficParking.class);
+    }
+
+    @Test
+    @Transactional
+    public void paymentMethods_surviveMappingAndDatabaseRoundTrip() {
+        // Map NeTEx → Tiamat model with payment methods
+        org.rutebanken.netex.model.Parking netexParking = new org.rutebanken.netex.model.Parking()
+                .withId("FSR:Parking:42")
+                .withVersion("1")
+                .withPaymentMethods(
+                        org.rutebanken.netex.model.PaymentMethodEnumeration.CASH,
+                        org.rutebanken.netex.model.PaymentMethodEnumeration.CREDIT_CARD);
+
+        Parking tiamatParking = netexMapper.mapToTiamatModel(netexParking);
+
+        assertThat(tiamatParking.getPaymentMethods())
+                .as("paymentMethods must be mapped from NeTEx (not excluded) with fintraffic profile")
+                .containsExactlyInAnyOrder(
+                        PaymentMethodEnumeration.CASH,
+                        PaymentMethodEnumeration.CREDIT_CARD);
+
+        // Save directly via repository (no parentSiteRef validation)
+        Parking saved = parkingRepository.save(tiamatParking);
+        Long id = saved.getId();
+
+        // Flush and clear to evict first-level cache; forces genuine DB read
+        entityManager.flush();
+        entityManager.clear();
+
+        // Reload from DB
+        Parking reloaded = parkingRepository.findById(id).orElseThrow();
+
+        assertThat(reloaded.getPaymentMethods())
+                .as("paymentMethods must survive DB round-trip")
+                .containsExactlyInAnyOrder(
+                        PaymentMethodEnumeration.CASH,
+                        PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    @Test
+    @Transactional
+    public void paymentMethods_appearsInNetexExport() {
+        // Build and persist a FintrafficParking with payment methods
+        FintrafficParking fp = (FintrafficParking) parkingEntityFactory.create();
+        fp.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH));
+        Parking saved = parkingRepository.save(fp);
+
+        // Flush and clear to evict first-level cache; forces genuine DB read
+        entityManager.flush();
+        entityManager.clear();
+
+        // Reload (ensure we're reading from DB, not session cache)
+        Parking reloaded = parkingRepository.findById(saved.getId()).orElseThrow();
+
+        // Map Tiamat → NeTEx
+        org.rutebanken.netex.model.Parking exported = netexMapper.mapToNetexModel(reloaded);
+
+        assertThat(exported.getPaymentMethods())
+                .as("paymentMethods must appear in NeTEx export")
+                .contains(org.rutebanken.netex.model.PaymentMethodEnumeration.CASH);
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficIntegrationTest;
 import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
@@ -44,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 )
 @ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
 @TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
-public class FintrafficParkingIntegrationTest {
+public class FintrafficParkingIntegrationTest extends FintrafficIntegrationTest {
 
     @MockitoBean
     private AuthorizationService authorizationService;

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingTest.java
@@ -1,0 +1,71 @@
+package org.rutebanken.tiamat.ext.fintraffic.model;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import org.junit.jupiter.api.Test;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FintrafficParkingTest {
+
+    @Test
+    void isSubclassOfParking() {
+        assertThat(Parking.class).isAssignableFrom(FintrafficParking.class);
+    }
+
+    @Test
+    void paymentMethodsField_hasElementCollectionAnnotation() throws NoSuchFieldException {
+        Field field = FintrafficParking.class.getDeclaredField("paymentMethods");
+
+        assertThat(field.isAnnotationPresent(ElementCollection.class))
+                .as("paymentMethods field must be @ElementCollection to be persisted")
+                .isTrue();
+    }
+
+    @Test
+    void paymentMethodsField_hasCollectionTableAnnotation() throws NoSuchFieldException {
+        Field field = FintrafficParking.class.getDeclaredField("paymentMethods");
+
+        CollectionTable table = field.getAnnotation(CollectionTable.class);
+        assertThat(table).isNotNull();
+        assertThat(table.name()).isEqualTo("parking_payment_methods");
+    }
+
+    @Test
+    void setAndGetPaymentMethods_usesOwnField_notParentTransientField() {
+        FintrafficParking parking = new FintrafficParking();
+
+        parking.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH, PaymentMethodEnumeration.CREDIT_CARD));
+
+        // getPaymentMethods() must return from the @ElementCollection field, not the parent @Transient field
+        assertThat(parking.getPaymentMethods())
+                .containsExactly(PaymentMethodEnumeration.CASH, PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    @Test
+    void parentTransientField_isNotAffectedBySubclassSetter() throws Exception {
+        FintrafficParking parking = new FintrafficParking();
+        parking.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH));
+
+        // The parent @Transient protected field should remain null (we never write to it)
+        Field parentField = Parking.class.getDeclaredField("paymentMethods");
+        parentField.setAccessible(true);
+        Object parentFieldValue = parentField.get(parking);
+
+        assertThat(parentFieldValue)
+                .as("parent @Transient paymentMethods must remain null; only the shadowed field is written")
+                .isNull();
+    }
+
+    @Test
+    void getPaymentMethods_returnsEmptyList_whenNothingSet() {
+        FintrafficParking parking = new FintrafficParking();
+
+        assertThat(parking.getPaymentMethods()).isEmpty();
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficIntegrationTest;
 import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
 import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
@@ -47,7 +48,7 @@ import static org.rutebanken.tiamat.config.JerseyConfig.SERVICES_STOP_PLACE_PATH
 )
 @ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
 @TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
-public class FintrafficGraphQLParkingIntegrationTest {
+public class FintrafficGraphQLParkingIntegrationTest extends FintrafficIntegrationTest {
 
     private static final String BASE_URI_GRAPHQL = SERVICES_STOP_PLACE_PATH + "/graphql/";
 

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
@@ -1,0 +1,295 @@
+package org.rutebanken.tiamat.ext.fintraffic.rest.graphql;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+import org.rutebanken.tiamat.model.StopPlace;
+import org.rutebanken.tiamat.model.StopTypeEnumeration;
+import org.rutebanken.tiamat.repository.ParkingRepository;
+import org.rutebanken.tiamat.repository.StopPlaceRepository;
+import org.rutebanken.tiamat.rest.graphql.GraphQLNames;
+import org.rutebanken.tiamat.versioning.save.StopPlaceVersionedSaverService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.rutebanken.tiamat.config.JerseyConfig.SERVICES_STOP_PLACE_PATH;
+/**
+ * Integration test verifying that the GraphQL {@code mutateParking} operation uses
+ * {@link org.rutebanken.tiamat.model.factory.ParkingEntityFactory} to produce a
+ * {@link FintrafficParking} instance when the {@code fintraffic} profile is active.
+ * <p>
+ * Note: {@code paymentMethods} is not yet part of the GraphQL schema; the GraphQL
+ * layer tests that the correct entity subtype is created and persisted. The
+ * {@code paymentMethods} DB round-trip is covered by
+ * {@link org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParkingIntegrationTest}.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = FintrafficTiamatTestApplication.class
+)
+@ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
+public class FintrafficGraphQLParkingIntegrationTest {
+
+    private static final String BASE_URI_GRAPHQL = SERVICES_STOP_PLACE_PATH + "/graphql/";
+
+    @MockitoBean
+    private AuthorizationService authorizationService;
+
+    @Value("${local.server.port}")
+    private int port;
+
+    @Autowired
+    private StopPlaceRepository stopPlaceRepository;
+
+    @Autowired
+    private StopPlaceVersionedSaverService stopPlaceVersionedSaverService;
+
+    @Autowired
+    private ParkingRepository parkingRepository;
+
+    @Before
+    public void configureRestAssured() {
+        RestAssured.baseURI = "http://localhost";
+        RestAssured.port = port;
+    }
+
+    @After
+    public void cleanUp() {
+        parkingRepository.deleteAll();
+        stopPlaceRepository.deleteAll();
+    }
+
+    @Test
+    public void mutateParking_createsFintrafficParkingViaFactory() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        String mutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test parking\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" }) { id } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(mutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue())
+                .extract()
+                .path("data.parking[0].id");
+
+        Parking saved = parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+
+        assertThat(saved)
+                .as("ParkingEntityFactory must produce FintrafficParking via GraphQL mutateParking")
+                .isInstanceOf(FintrafficParking.class);
+    }
+
+    @Test
+    public void mutateParking_updatePreservesFintrafficParkingType() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        // Create
+        String createMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Original\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" }) { id } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(createMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.parking[0].id");
+
+        // Update
+        String updateMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { id: \\"%s\\" name: { value: \\"Updated\\" lang: \\"fi\\" } }) { id version } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, parkingNetexId);
+
+        given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(updateMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue());
+
+        // Both versions should be FintrafficParking
+        parkingRepository.findByNetexId(parkingNetexId).forEach(p ->
+                assertThat(p)
+                        .as("All versions of a parking must be FintrafficParking instances")
+                        .isInstanceOf(FintrafficParking.class)
+        );
+    }
+
+    @Test
+    public void mutateParking_paymentMethods_persistedAndReturnedInResponse() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        String mutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" paymentMethods: [cash, creditCard] }) { id paymentMethods } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(mutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue())
+                .body("data.parking[0].paymentMethods", hasItems("cash", "creditCard"))
+                .extract()
+                .path("data.parking[0].id");
+
+        FintrafficParking saved = (FintrafficParking)
+                parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+
+        assertThat(saved.getPaymentMethods())
+                .as("paymentMethods must be persisted to DB via FintrafficParkingUpdater")
+                .containsExactlyInAnyOrder(
+                        PaymentMethodEnumeration.CASH,
+                        PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    /**
+     * Verifies that {@link FintrafficParkingUpdater#preserveExtendedFields} copies
+     * {@code paymentMethods} from the existing version into the version copy when an
+     * update mutation omits the field.  Without this hook, Orika's {@code createCopy}
+     * would not transfer the private {@link FintrafficParking#paymentMethods} field and
+     * the update would silently clear any previously saved payment methods.
+     */
+    @Test
+    public void mutateParking_updateWithoutPaymentMethods_preservesExistingPaymentMethods() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        // Create with paymentMethods
+        String createMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" paymentMethods: [cash, creditCard] }) { id paymentMethods } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(createMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.parking[0].id");
+
+        // Update without paymentMethods — field should be preserved
+        String updateMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { id: \\"%s\\" name: { value: \\"Updated\\" lang: \\"fi\\" } }) { id paymentMethods } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, parkingNetexId);
+
+        given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(updateMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].paymentMethods", hasItems("cash", "creditCard"));
+
+        FintrafficParking latest = (FintrafficParking)
+                parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+        assertThat(latest.getPaymentMethods())
+                .as("paymentMethods must be preserved when not included in update input")
+                .containsExactlyInAnyOrder(
+                        PaymentMethodEnumeration.CASH,
+                        PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    /**
+     * Regression test: when {@code fintraffic} profile is active, the {@code stopPlace} GraphQL
+     * query must be served by {@code stopPlaceFetcher}, not hijacked by any {@code @Primary}
+     * bean override intended only for {@code parkingUpdater}. The field must never be {@code null}
+     * (an empty list is acceptable; {@code null} means the wrong fetcher was injected).
+     */
+    @Test
+    public void stopPlaceQuery_notNull_whenFintrafficProfileActive() {
+        String query = """
+                {
+                  "query": "{ stopPlace(query: \\"nonexistent_xyz_regression_check\\", size: 1) { id } }"
+                }
+                """;
+
+        Object result = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(query)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.stopPlace");
+
+        assertThat(result)
+                .as("stopPlace field must not be null — null means stopPlaceFetcher was replaced " +
+                    "by an unrelated @Primary bean (e.g. FintrafficParkingUpdater)")
+                .isNotNull();
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import static io.restassured.RestAssured.given;
@@ -45,6 +46,7 @@ import static org.rutebanken.tiamat.config.JerseyConfig.SERVICES_STOP_PLACE_PATH
         classes = FintrafficTiamatTestApplication.class
 )
 @ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
+@TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
 public class FintrafficGraphQLParkingIntegrationTest {
 
     private static final String BASE_URI_GRAPHQL = SERVICES_STOP_PLACE_PATH + "/graphql/";

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
@@ -263,6 +263,59 @@ public class FintrafficGraphQLParkingIntegrationTest {
     }
 
     /**
+     * Verifies that {@code paymentMethods} persisted via {@code mutateParking} are returned by
+     * the GraphQL {@code parking} query. This exercises the full read path:
+     * {@code parkingFetcher} → {@link org.rutebanken.tiamat.repository.ParkingRepository} →
+     * {@link org.rutebanken.tiamat.netex.mapping.NetexMapper#mapToNetexModel} →
+     * {@link org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor}.
+     */
+    @Test
+    public void parkingQuery_returnsPaymentMethods_whenFintrafficProfileActive() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        // Create parking with paymentMethods via mutation
+        String createMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" paymentMethods: [cash, creditCard] }) { id } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(createMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.parking[0].id");
+
+        // Query it back via the parking read query
+        String query = """
+                {
+                  "query": "{ parking(id: \\"%s\\") { id paymentMethods } }"
+                }
+                """.formatted(parkingNetexId);
+
+        given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(query)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue())
+                .body("data.parking[0].paymentMethods", hasItems("cash", "creditCard"));
+    }
+
+    /**
      * Regression test: when {@code fintraffic} profile is active, the {@code stopPlace} GraphQL
      * query must be served by {@code stopPlaceFetcher}, not hijacked by any {@code @Primary}
      * bean override intended only for {@code parkingUpdater}. The field must never be {@code null}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingService.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexMarshallingService.java
@@ -161,7 +161,7 @@ public class ReadApiNetexMarshallingService {
         Optional<String> parentRef = parentRef(entity);
         return new ReadApiEntityInRecord(
                 entity.getNetexId(),
-                entity.getClass().getSimpleName(),
+                entityTypeName(entity),
                 searchKey,
                 xml,
                 entity.getVersion(),
@@ -169,6 +169,31 @@ public class ReadApiNetexMarshallingService {
                 status,
                 parentRef.map(ref -> new String[]{ref}).orElse(new String[]{})
         );
+    }
+
+    /**
+     * The cache table's {@code type} column must hold the NeTEx element type
+     * ("StopPlace", "Parking", ...) so that {@code streamStopPlaces}' hardcoded {@code type IN
+     * (...)} filter matches it. Using {@code entity.getClass().getSimpleName()} directly breaks
+     * for entities backed by a Tiamat JPA subclass (e.g. {@code FintrafficParking}, produced by
+     * {@code ParkingEntityFactory} for every Parking under the fintraffic profile) since the
+     * runtime simple name ("FintrafficParking") never matches the filter, silently hiding the
+     * entity from the Read API even though the row was written successfully.
+     */
+    private static String entityTypeName(EntityInVersionStructure entity) {
+        if (entity instanceof StopPlace) {
+            return "StopPlace";
+        }
+        if (entity instanceof Parking) {
+            return "Parking";
+        }
+        if (entity instanceof TopographicPlace) {
+            return "TopographicPlace";
+        }
+        if (entity instanceof FareZone) {
+            return "FareZone";
+        }
+        return entity.getClass().getSimpleName();
     }
 
     private static JAXBContext createJAXBContext(Class<?> clazz) {

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/config/FintrafficEntityScanConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/config/FintrafficEntityScanConfig.java
@@ -1,0 +1,37 @@
+package org.rutebanken.tiamat.ext.fintraffic.config;
+
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.springframework.boot.persistence.autoconfigure.EntityScanPackages;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Adds {@code org.rutebanken.tiamat.ext.fintraffic.model} to Hibernate's entity scan.
+ * <p>
+ * Core's {@code TiamatApplication} only declares
+ * {@code @EntityScan(basePackageClasses = {StopPlace.class, ...})}, which covers
+ * {@code org.rutebanken.tiamat.model} — not this ext package. Without this, Hibernate
+ * never registers {@link FintrafficParking} (or any other ext {@code @Entity}) and
+ * every operation on it fails with "... is not an entity".
+ * <p>
+ * {@link EntityScanPackages#register} is additive: if a package list is already
+ * registered (by core's {@code @EntityScan}), it appends to it rather than replacing
+ * it, so this does not require modifying {@code TiamatApplication} — core is only
+ * ever extended here, never overridden.
+ */
+@Configuration
+@Profile("fintraffic")
+@Import(FintrafficEntityScanConfig.Registrar.class)
+public class FintrafficEntityScanConfig {
+
+    static class Registrar implements ImportBeanDefinitionRegistrar {
+        @Override
+        public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+            EntityScanPackages.register(registry, FintrafficParking.class.getPackageName());
+        }
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/config/FintrafficGraphQLConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/config/FintrafficGraphQLConfig.java
@@ -1,0 +1,23 @@
+package org.rutebanken.tiamat.ext.fintraffic.config;
+
+import org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingUpdater;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Registers Fintraffic-specific GraphQL beans, overriding their core counterparts
+ * by using the same bean name. Bean overriding is enabled globally via
+ * {@code spring.main.allow-bean-definition-overriding=true}. {@code @Bean} methods
+ * in {@code @Configuration} classes are registered after {@code @Service}
+ * component-scanned beans, so the override is reliable without needing {@code @Primary}.
+ */
+@Configuration
+@Profile("fintraffic")
+public class FintrafficGraphQLConfig {
+
+    @Bean("parkingUpdater")
+    public FintrafficParkingUpdater parkingUpdater() {
+        return new FintrafficParkingUpdater();
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/FintrafficFlywayConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/FintrafficFlywayConfig.java
@@ -4,6 +4,7 @@ import jakarta.annotation.PostConstruct;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.migration.JavaMigration;
 import org.rutebanken.tiamat.ext.fintraffic.db.migration.V2__CreateExtFintrafficNetexEntityTable;
+import org.rutebanken.tiamat.ext.fintraffic.db.migration.V3__FintrafficParkingExtensions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -12,7 +13,7 @@ import org.springframework.context.annotation.Profile;
 import javax.sql.DataSource;
 import java.util.List;
 
-@Profile("fintraffic-read-api")
+@Profile({"fintraffic-read-api", "fintraffic"})
 @Configuration
 public class FintrafficFlywayConfig {
     private final Logger logger = LoggerFactory.getLogger(FintrafficFlywayConfig.class);
@@ -20,7 +21,8 @@ public class FintrafficFlywayConfig {
     private final DataSource dataSource;
 
     private static final List<Class<? extends JavaMigration>> migrations = List.of(
-        V2__CreateExtFintrafficNetexEntityTable.class
+        V2__CreateExtFintrafficNetexEntityTable.class,
+        V3__FintrafficParkingExtensions.class
     );
 
     public FintrafficFlywayConfig(DataSource dataSource) {

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V3__FintrafficParkingExtensions.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V3__FintrafficParkingExtensions.java
@@ -8,20 +8,17 @@ import java.sql.Statement;
 /**
  * Adds DDL required by {@code FintrafficParking}:
  * <ul>
- *   <li>{@code dtype} discriminator column on the {@code parking} table
- *       (Hibernate SINGLE_TABLE inheritance; existing rows default to "Parking")</li>
  *   <li>{@code parking_payment_methods} collection table for persisted payment methods</li>
  * </ul>
- * Entur's core migrations are not modified.
+ * Note: the {@code dtype} discriminator column is added by the core Flyway migration V62,
+ * because {@code FintrafficParking} is compiled into the same jar and Hibernate always
+ * requires {@code dtype} regardless of active Spring profiles.
  */
 public class V3__FintrafficParkingExtensions extends BaseJavaMigration {
 
     @Override
     public void migrate(Context context) throws Exception {
         String sql = """
-                ALTER TABLE parking ADD COLUMN IF NOT EXISTS dtype VARCHAR(31) DEFAULT 'Parking';
-                UPDATE parking SET dtype = 'Parking' WHERE dtype IS NULL;
-
                 CREATE TABLE IF NOT EXISTS parking_payment_methods (
                     parking_id  BIGINT      NOT NULL REFERENCES parking(id),
                     payment_method VARCHAR(64) NOT NULL

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V3__FintrafficParkingExtensions.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V3__FintrafficParkingExtensions.java
@@ -1,0 +1,38 @@
+package org.rutebanken.tiamat.ext.fintraffic.db.migration;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import java.sql.Statement;
+
+/**
+ * Adds DDL required by {@code FintrafficParking}:
+ * <ul>
+ *   <li>{@code dtype} discriminator column on the {@code parking} table
+ *       (Hibernate SINGLE_TABLE inheritance; existing rows default to "Parking")</li>
+ *   <li>{@code parking_payment_methods} collection table for persisted payment methods</li>
+ * </ul>
+ * Entur's core migrations are not modified.
+ */
+public class V3__FintrafficParkingExtensions extends BaseJavaMigration {
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        String sql = """
+                ALTER TABLE parking ADD COLUMN IF NOT EXISTS dtype VARCHAR(31) DEFAULT 'Parking';
+                UPDATE parking SET dtype = 'Parking' WHERE dtype IS NULL;
+
+                CREATE TABLE IF NOT EXISTS parking_payment_methods (
+                    parking_id  BIGINT      NOT NULL REFERENCES parking(id),
+                    payment_method VARCHAR(64) NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_parking_payment_methods_parking_id
+                    ON parking_payment_methods (parking_id);
+                """;
+
+        try (Statement stmt = context.getConnection().createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporter.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporter.java
@@ -1,0 +1,74 @@
+package org.rutebanken.tiamat.ext.fintraffic.importer;
+
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.importer.KeyValueListAppender;
+import org.rutebanken.tiamat.importer.finder.NearbyParkingFinder;
+import org.rutebanken.tiamat.importer.finder.ParkingFromOriginalIdFinder;
+import org.rutebanken.tiamat.importer.merging.MergingParkingImporter;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.factory.ParkingEntityFactory;
+import org.rutebanken.tiamat.netex.mapping.NetexMapper;
+import org.rutebanken.tiamat.repository.reference.ReferenceResolver;
+import org.rutebanken.tiamat.versioning.VersionCreator;
+import org.rutebanken.tiamat.versioning.save.ParkingVersionedSaverService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fintraffic extension of {@link MergingParkingImporter} that preserves
+ * {@link FintrafficParking#getPaymentMethods() paymentMethods} on both import paths:
+ * <ul>
+ *   <li>New parking — {@code handleCompletelyNewParking} creates a typed
+ *       {@link FintrafficParking} copy and calls {@link #mergeExtendedFields} to copy
+ *       the transient {@code paymentMethods} from the NeTEx-derived source into the
+ *       persisted field of the copy.</li>
+ *   <li>Existing parking — {@code handleAlreadyExistingParking} does the same via
+ *       its own {@link #mergeExtendedFields} call.</li>
+ * </ul>
+ * In both cases {@code incomingParking} may be a plain {@link org.rutebanken.tiamat.model.Parking}
+ * (as produced by the NeTEx mapper) or a {@link FintrafficParking}; only the copy passed
+ * as the second argument is required to be a {@link FintrafficParking}.
+ */
+@Profile("fintraffic")
+@Primary
+@Component
+@Qualifier("mergingParkingImporter")
+public class FintrafficMergingParkingImporter extends MergingParkingImporter {
+
+    public FintrafficMergingParkingImporter(ParkingFromOriginalIdFinder parkingFromOriginalIdFinder,
+                                            NearbyParkingFinder nearbyParkingFinder,
+                                            ReferenceResolver referenceResolver,
+                                            KeyValueListAppender keyValueListAppender,
+                                            NetexMapper netexMapper,
+                                            ParkingVersionedSaverService parkingVersionedSaverService,
+                                            VersionCreator versionCreator,
+                                            ParkingEntityFactory parkingEntityFactory) {
+        super(parkingFromOriginalIdFinder, nearbyParkingFinder, referenceResolver,
+                keyValueListAppender, netexMapper, parkingVersionedSaverService,
+                versionCreator, parkingEntityFactory);
+    }
+
+    @Override
+    protected boolean mergeExtendedFields(Parking incomingParking, Parking copy) {
+        if (!(copy instanceof FintrafficParking target)) {
+            return false;
+        }
+
+        // incomingParking may be a plain Parking (from NeTEx mapper) or FintrafficParking (from DB).
+        // Either way, Parking.getPaymentMethods() returns the in-memory list the NeTEx mapper set.
+        List<org.rutebanken.tiamat.model.PaymentMethodEnumeration> incomingMethods = incomingParking.getPaymentMethods();
+        List<org.rutebanken.tiamat.model.PaymentMethodEnumeration> existingMethods = target.getPaymentMethods();
+
+        if (incomingMethods.equals(existingMethods)) {
+            return false;
+        }
+
+        target.setPaymentMethods(new ArrayList<>(incomingMethods));
+        return true;
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributor.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributor.java
@@ -1,0 +1,67 @@
+package org.rutebanken.tiamat.ext.fintraffic.importer;
+
+import ma.glasnost.orika.MappingContext;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+import org.rutebanken.tiamat.netex.mapping.mapper.ParkingMapperContributor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fintraffic extension of {@link ParkingMapperContributor} that wires
+ * {@code paymentMethods} through the NeTEx ↔ Tiamat mapping in both directions.
+ *
+ * <p><b>Import ({@link #mapFromNetex}):</b> copies the NeTEx
+ * {@code paymentMethods} list onto the Tiamat {@link org.rutebanken.tiamat.model.Parking}
+ * {@code @Transient} field so that the
+ * {@link FintrafficMergingParkingImporter#mergeExtendedFields} hook can persist it.
+ *
+ * <p><b>Export ({@link #mapToNetex}):</b> reads {@code paymentMethods} from a
+ * {@link FintrafficParking} and writes it back into the NeTEx output so that the
+ * field survives the export roundtrip.
+ */
+@Profile("fintraffic")
+@Component
+public class FintrafficParkingMapperContributor implements ParkingMapperContributor {
+
+    @Override
+    public void mapFromNetex(org.rutebanken.netex.model.Parking source,
+                             org.rutebanken.tiamat.model.Parking target,
+                             MappingContext context) {
+        var netexMethods = source.getPaymentMethods();
+        if (netexMethods == null || netexMethods.isEmpty()) {
+            return;
+        }
+        var targetMethods = target.getPaymentMethods();
+        targetMethods.clear();
+        for (var netexMethod : netexMethods) {
+            try {
+                targetMethods.add(PaymentMethodEnumeration.fromValue(netexMethod.value()));
+            } catch (IllegalArgumentException ignored) {
+                // skip unknown values
+            }
+        }
+    }
+
+    @Override
+    public void mapToNetex(org.rutebanken.tiamat.model.Parking source,
+                           org.rutebanken.netex.model.Parking target,
+                           MappingContext context) {
+        if (!(source instanceof FintrafficParking fp)) {
+            return;
+        }
+        var methods = fp.getPaymentMethods();
+        if (methods.isEmpty()) {
+            return;
+        }
+        var targetMethods = target.getPaymentMethods();
+        targetMethods.clear();
+        for (var method : methods) {
+            try {
+                targetMethods.add(org.rutebanken.netex.model.PaymentMethodEnumeration.fromValue(method.value()));
+            } catch (IllegalArgumentException ignored) {
+                // skip unknown values
+            }
+        }
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParking.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParking.java
@@ -1,0 +1,50 @@
+package org.rutebanken.tiamat.ext.fintraffic.model;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fintraffic extension of the core {@link Parking} entity.
+ * <p>
+ * Persists fields that are {@code @Transient} in the core model, using a
+ * separate collection table so Entur's core DDL remains unmodified.
+ * Activated when the {@code fintraffic} Spring profile is active via
+ * {@link FintrafficParkingEntityFactory}.
+ */
+@Entity
+@DiscriminatorValue("FintrafficParking")
+public class FintrafficParking extends Parking {
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(
+            name = "parking_payment_methods",
+            joinColumns = @JoinColumn(name = "parking_id")
+    )
+    @Column(name = "payment_method")
+    private List<PaymentMethodEnumeration> paymentMethods;
+
+    @Override
+    public List<PaymentMethodEnumeration> getPaymentMethods() {
+        if (paymentMethods == null) {
+            paymentMethods = new ArrayList<>();
+        }
+        return paymentMethods;
+    }
+
+    public void setPaymentMethods(List<PaymentMethodEnumeration> value) {
+        this.paymentMethods = value;
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactory.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactory.java
@@ -12,9 +12,10 @@ import java.util.List;
  * Fintraffic override of {@link ParkingEntityFactory}.
  * <p>
  * Active when the {@code fintraffic} Spring profile is present. Tells the
- * core to instantiate {@link FintrafficParking} instead of {@link Parking},
- * and removes {@code paymentMethods} from the Orika exclusion list so the
- * field is mapped during NeTEx import and export.
+ * core to instantiate {@link FintrafficParking} instead of {@link Parking}.
+ * {@code paymentMethods} is kept in the exclusion list because the enum types
+ * differ between the NeTEx and Tiamat models; {@link org.rutebanken.tiamat.ext.fintraffic.importer.FintrafficParkingMapperContributor}
+ * handles the conversion instead.
  */
 @Primary
 @Component
@@ -33,7 +34,6 @@ public class FintrafficParkingEntityFactory extends ParkingEntityFactory {
 
     @Override
     public List<String> getMappingExclusions() {
-        // paymentMethods intentionally absent — it is persisted by FintrafficParking
-        return List.of("cardsAccepted", "currenciesAccepted", "accessModes");
+        return List.of("paymentMethods", "cardsAccepted", "currenciesAccepted", "accessModes");
     }
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactory.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactory.java
@@ -1,0 +1,39 @@
+package org.rutebanken.tiamat.ext.fintraffic.model;
+
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.factory.ParkingEntityFactory;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Fintraffic override of {@link ParkingEntityFactory}.
+ * <p>
+ * Active when the {@code fintraffic} Spring profile is present. Tells the
+ * core to instantiate {@link FintrafficParking} instead of {@link Parking},
+ * and removes {@code paymentMethods} from the Orika exclusion list so the
+ * field is mapped during NeTEx import and export.
+ */
+@Primary
+@Component
+@Profile("fintraffic")
+public class FintrafficParkingEntityFactory extends ParkingEntityFactory {
+
+    @Override
+    public Parking create() {
+        return new FintrafficParking();
+    }
+
+    @Override
+    public Class<? extends Parking> getEntityClass() {
+        return FintrafficParking.class;
+    }
+
+    @Override
+    public List<String> getMappingExclusions() {
+        // paymentMethods intentionally absent — it is persisted by FintrafficParking
+        return List.of("cardsAccepted", "currenciesAccepted", "accessModes");
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingGraphQLTypeContributor.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingGraphQLTypeContributor.java
@@ -1,0 +1,47 @@
+package org.rutebanken.tiamat.ext.fintraffic.rest.graphql;
+
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLObjectType;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+import org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes;
+import org.rutebanken.tiamat.rest.graphql.types.ParkingGraphQLTypeContributor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
+
+/**
+ * Contributes Fintraffic-specific fields to the GraphQL parking types:
+ * <ul>
+ *   <li>{@code paymentMethods} — list of {@link PaymentMethodEnumeration} values,
+ *       added to both the output (query) and input (mutation) parking types.</li>
+ * </ul>
+ * This field is only present in the schema when the Fintraffic ext package is on the classpath.
+ */
+@Profile("fintraffic")
+@Component
+public class FintrafficParkingGraphQLTypeContributor implements ParkingGraphQLTypeContributor {
+
+    static final String PAYMENT_METHODS = "paymentMethods";
+    static final String PAYMENT_METHOD_ENUM = "PaymentMethodEnum";
+
+    static final GraphQLEnumType paymentMethodEnum =
+            CustomGraphQLTypes.createCustomEnumType(PAYMENT_METHOD_ENUM, PaymentMethodEnumeration.class);
+
+    @Override
+    public void contributeToOutputType(GraphQLObjectType.Builder builder) {
+        builder.field(newFieldDefinition()
+                .name(PAYMENT_METHODS)
+                .type(new GraphQLList(paymentMethodEnum)));
+    }
+
+    @Override
+    public void contributeToInputType(GraphQLInputObjectType.Builder builder) {
+        builder.field(newInputObjectField()
+                .name(PAYMENT_METHODS)
+                .type(new GraphQLList(paymentMethodEnum)));
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingUpdater.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingUpdater.java
@@ -1,0 +1,91 @@
+package org.rutebanken.tiamat.ext.fintraffic.rest.graphql;
+
+import graphql.schema.DataFetchingEnvironment;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+import org.rutebanken.tiamat.rest.graphql.fetchers.ParkingUpdater;
+import org.springframework.context.annotation.Profile;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.PAYMENT_METHODS;
+
+/**
+ * Fintraffic extension of {@link ParkingUpdater} that handles the
+ * {@code paymentMethods} input field contributed by
+ * {@link FintrafficParkingGraphQLTypeContributor}.
+ */
+@Profile("fintraffic")
+@Transactional
+public class FintrafficParkingUpdater extends ParkingUpdater {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /**
+     * Extends the parent's {@code get()} to flush pending collection inserts and
+     * refresh entities before the transaction closes.  This ensures that
+     * {@code @ElementCollection} fields (e.g. {@code paymentMethods}) on newly
+     * persisted {@link FintrafficParking} instances are fully loaded from the
+     * database and not left in Hibernate's "pending-insert" state, which would
+     * cause them to appear empty when the GraphQL response is serialised.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object get(DataFetchingEnvironment environment) {
+        List<Parking> parkings = (List<Parking>) super.get(environment);
+        if (parkings != null) {
+            entityManager.flush();
+            parkings.stream()
+                    .filter(Objects::nonNull)
+                    .filter(entityManager::contains)
+                    .forEach(entityManager::refresh);
+        }
+        return parkings;
+    }
+
+    @Override
+    protected boolean populateExtendedFields(Map input, Parking parking) {
+        if (!(parking instanceof FintrafficParking target)) {
+            return false;
+        }
+
+        @SuppressWarnings("unchecked")
+        List<PaymentMethodEnumeration> incoming = (List<PaymentMethodEnumeration>) input.get(PAYMENT_METHODS);
+        if (incoming == null) {
+            return false;
+        }
+
+        if (incoming.equals(target.getPaymentMethods())) {
+            return false;
+        }
+
+        target.setPaymentMethods(List.copyOf(incoming));
+        return true;
+    }
+
+    /**
+     * Copies extended fields that Orika does not transfer from the existing version into
+     * the newly created version copy.  Called by the parent's update path immediately
+     * after {@link org.rutebanken.tiamat.versioning.VersionCreator#createCopy}, before
+     * {@link #populateExtendedFields} overwrites them with the GraphQL input values.
+     * <p>
+     * This ensures that fields omitted from the update mutation (e.g. the caller did not
+     * include {@code paymentMethods} in the input) retain their current values rather than
+     * being silently reset to the default.
+     */
+    @Override
+    protected void preserveExtendedFields(Parking existingVersion, Parking copy) {
+        if (existingVersion instanceof FintrafficParking source && copy instanceof FintrafficParking target) {
+            target.setPaymentMethods(new ArrayList<>(source.getPaymentMethods()));
+        }
+    }
+}


### PR DESCRIPTION
### Summary

This is the first increment of the Fintraffic parking extension, focused on `paymentMethods`. Further fields (e.g. `vehicleEntrances`, availability conditions) will follow in subsequent PRs once the underlying data model and import pipeline are in place.

Implements the Fintraffic parking extension on top of the `feat/parking-extension-hooks` infrastructure (entur/tiamat#421).

- **`FintrafficParking`** — JPA subclass of `Parking` with a `paymentMethods` column (stored as a PostgreSQL array via Hibernate's `@JdbcTypeCode(SqlTypes.ARRAY)`). A Flyway migration (`V3__FintrafficParkingExtensions`) adds the backing column.
- **`FintrafficParkingEntityFactory`** — `@Primary` factory that instantiates `FintrafficParking` and registers `FintrafficParking.class` with Orika. `paymentMethods` is kept in the exclusion list; enum conversion is handled by the contributor instead.
- **`FintrafficParkingMapperContributor`** — translates `paymentMethods` between `org.rutebanken.netex.model.PaymentMethodEnumeration` and `org.rutebanken.tiamat.model.PaymentMethodEnumeration` in both import and export directions. Unknown enum values are silently skipped.
- **`FintrafficMergingParkingImporter`** — extends the `mergeExtendedFields` hook to persist `paymentMethods` from the incoming entity onto the existing DB entity.
- **`FintrafficParkingGraphQLTypeContributor`** — adds `paymentMethods` as a `[PaymentMethodsEnumeration]` field to both the parking output and input GraphQL types, including enum type registration.
- **`FintrafficParkingUpdater`** — extends the mutation hook to copy `paymentMethods` from the GraphQL input onto the Tiamat entity before save.

All components are activated by the `fintraffic` Spring profile.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Dependencies

Depends on entur/tiamat#421 — that branch must be merged first (or this PR rebased onto master after that merge).

### Tests

- `FintrafficParkingIntegrationTest` — NeTEx import round-trip: verifies `paymentMethods` survives import and is present on the persisted entity.
- `FintrafficGraphQLParkingIntegrationTest` — GraphQL mutation and query: verifies `paymentMethods` can be set via mutation and read back via `parking(id: "...")`.
- `FintrafficParkingMapperContributorTest` — unit tests for enum conversion in both directions, including unknown value handling.
- `FintrafficMergingParkingImporterTest` — verifies merge behaviour: values copied from incoming to existing entity.
- `FintrafficParkingEntityFactoryTest` — verifies correct class, exclusion list, and instance type.


### Follow-up fix (added after initial review)

Added `FintrafficEntityScanConfig` — an ext-only, `@Profile("fintraffic")`-guarded
`@Configuration` that registers `org.rutebanken.tiamat.ext.fintraffic.model` for JPA
entity scanning via Spring's additive `EntityScanPackages.register()`. `TiamatApplication`'s
`@EntityScan(basePackageClasses = {StopPlace.class, ...})` only covers
`org.rutebanken.tiamat.model`, so without this, Hibernate never registered
`FintrafficParking` as an entity and every `mutateParking`/`parking` GraphQL operation
failed under the `fintraffic` profile with `"... is not an entity"`. This does not modify
`TiamatApplication.java` — the registration is purely additive.

This fix has also been merged forward into every dependent branch in the stack
(`feat/ext-fintraffic-info-links`, `feat/ext-fintraffic-vehicle-entrances`,
`feat/ext-fintraffic-parking-lighting`, `feat/ext-fintraffic-parking-opening-hours`)
so their PRs remain buildable/testable independently of merge order.

### Follow-up fix: Parking never appears in the Read API cache

`ReadApiNetexMarshallingService.createEntityRecord` derived the Read API cache table's
`type` column via `entity.getClass().getSimpleName()`. Under the `fintraffic` profile,
every Parking is actually persisted/loaded as a `FintrafficParking` instance (this
branch's subclass), so the column got `"FintrafficParking"` instead of `"Parking"` —
never matching the repository's `type IN (...)` query filter. The row was written
successfully (no exception), but was permanently invisible to every Read API query.

Fixed by adding an `entityTypeName(EntityInVersionStructure)` helper that maps the known
Tiamat model supertypes (`StopPlace`, `Parking`, `TopographicPlace`, `FareZone`) to their
NeTEx element type name via `instanceof` checks, instead of relying on the runtime class
name. Verified end-to-end with a new `ReadApiParkingIncrementalSyncIntegrationTest` that
activates the real `fintraffic-read-api` Spring profile (not mocked) and asserts the new
Parking is both written with `type='Parking'` and returned by the real
`streamStopPlaces` query used by the Read API.