### PR TITLE
Fix Read API OOM when streaming full dataset

### DIFF
--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficReadApiConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/FintrafficReadApiConfig.java
@@ -16,15 +16,25 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import javax.sql.DataSource;
+
 @Profile("fintraffic-read-api")
 @Configuration
 @EnableConfigurationProperties(AreaCodeMappingConfig.class)
 public class FintrafficReadApiConfig {
     @Bean
     public NetexRepository netexRepository(
-            JdbcTemplate jdbc,
+            DataSource dataSource,
             ObjectMapper objectMapper
     ) {
+        // A dedicated JdbcTemplate with fetchSize enables PostgreSQL server-side cursors
+        // in queryForStream. Without fetchSize > 0, the driver fetches all rows at once
+        // — the entire ext_fintraffic_netex_entity table (~300 MB) into the heap, causing OOM.
+        // fetchSize=1000 instructs the driver to stream rows in batches of 1000 from the DB.
+        // This only works because streamStopPlaces() is always called inside a transaction
+        // (autoCommit=false is required for PostgreSQL server-side cursors).
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+        jdbc.setFetchSize(1000);
         return new FintrafficNetexRepository(jdbc, objectMapper);
     }
 


### PR DESCRIPTION
### Summary

- Fixes `OutOfMemoryError: Java heap space` when calling the Read API (`/api/fintraffic/v1/stops`) against a full dataset (~300–500 MB)

`JdbcTemplate.queryForStream` only uses PostgreSQL server-side cursors (streaming rows from the DB in batches) when `fetchSize > 0`. Without it, the PostgreSQL JDBC driver fetches all rows in a single round-trip before the Java stream begins iterating — loading the entire `ext_fintraffic_netex_entity` table into heap at once.

A dedicated `JdbcTemplate` with `fetchSize=1000` is created for the Read API repository to avoid affecting the shared template used by the rest of the application. This only works because `streamStopPlaces()` is always called inside a transaction (`autoCommit=false` is a prerequisite for PostgreSQL server-side cursors).

Reproduced locally by running Tiamat with `-Xmx512m` (matching the ~25% JVM ergonomic heap of the 2 GiB Fargate container used in dev). A request to `/api/fintraffic/v1/stops` caused OOM before the fix and returned HTTP 200 with a 519 MB response in ~9.5 s after the fix.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Unit tests

No new unit tests — the change is in Spring bean wiring, not business logic. Existing unit tests (`FintrafficApiControllerTest`, `ReadApiNetexPublicationDeliveryServiceTest`) mock the repository and are unaffected. Verification was done by manually reproducing the OOM with a capped heap and confirming it is resolved after the fix.

### Documentation

The comment in `FintrafficReadApiConfig` explains why a dedicated template is needed, why `fetchSize` matters for PostgreSQL, and the `autoCommit=false` prerequisite.
