### PR TITLE
[ext-fintraffic] Persist and expose parking lighting

### DIFF
--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficIntegrationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.ext.fintraffic;
+
+import org.junit.AfterClass;
+import org.rutebanken.tiamat.ext.fintraffic.config.FintrafficTestContextConfiguration;
+
+/**
+ * Base class for fintraffic integration tests that start a secondary Spring context.
+ * <p>
+ * {@link org.rutebanken.tiamat.config.ApplicationContextProvider} uses a static field to hold
+ * the active {@code ApplicationContext}, which is a JVM-global singleton. When the fintraffic
+ * test context starts it overwrites this field via {@code RestoringApplicationContextProvider},
+ * which saves the previous value. {@link #restoreApplicationContext()} restores it after all
+ * tests in the subclass complete, so the primary-context tests that follow get the correct beans.
+ */
+public abstract class FintrafficIntegrationTest {
+
+    @AfterClass
+    public static void restoreApplicationContext() {
+        FintrafficTestContextConfiguration.restoreContext();
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficTiamatTestApplication.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficTiamatTestApplication.java
@@ -1,0 +1,50 @@
+package org.rutebanken.tiamat.ext.fintraffic;
+
+import org.rutebanken.tiamat.auth.TiamatSecurityConfig;
+import org.rutebanken.tiamat.ext.fintraffic.auth.FintrafficSecurityConfig;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.model.StopPlace;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.security.autoconfigure.actuate.web.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.web.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * Spring Boot test application for Fintraffic extension integration tests.
+ * Extends the core TiamatTestApplication setup with:
+ * <ul>
+ *   <li>Entity scan covering {@link FintrafficParking} (ext model)</li>
+ *   <li>Component scan covering the ext package tree</li>
+ * </ul>
+ * Security is excluded; authorization is mocked in individual tests.
+ */
+@SpringBootApplication(exclude = {
+        SecurityAutoConfiguration.class,
+        ManagementWebSecurityAutoConfiguration.class,
+        SecurityFilterAutoConfiguration.class,
+        ServletWebSecurityAutoConfiguration.class,
+        UserDetailsServiceAutoConfiguration.class
+})
+@EnableTransactionManagement
+@EnableCaching
+@EntityScan(basePackageClasses = {StopPlace.class, FintrafficParking.class, Jsr310JpaConverters.class})
+@ComponentScan(
+        basePackages = "org.rutebanken.tiamat",
+        excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = TiamatSecurityConfig.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = FintrafficSecurityConfig.class)
+})
+public class FintrafficTiamatTestApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(FintrafficTiamatTestApplication.class, args);
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficTiamatTestApplication.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/FintrafficTiamatTestApplication.java
@@ -1,7 +1,9 @@
 package org.rutebanken.tiamat.ext.fintraffic;
 
 import org.rutebanken.tiamat.auth.TiamatSecurityConfig;
+import org.rutebanken.tiamat.config.ApplicationContextProvider;
 import org.rutebanken.tiamat.ext.fintraffic.auth.FintrafficSecurityConfig;
+import org.rutebanken.tiamat.ext.fintraffic.config.FintrafficTestContextConfiguration;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.springframework.boot.SpringApplication;
@@ -15,6 +17,7 @@ import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSec
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -41,8 +44,10 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
         basePackages = "org.rutebanken.tiamat",
         excludeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = TiamatSecurityConfig.class),
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = FintrafficSecurityConfig.class)
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = FintrafficSecurityConfig.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = ApplicationContextProvider.class)
 })
+@Import(FintrafficTestContextConfiguration.class)
 public class FintrafficTiamatTestApplication {
     public static void main(String[] args) {
         SpringApplication.run(FintrafficTiamatTestApplication.class, args);

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/config/FintrafficTestContextConfiguration.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/config/FintrafficTestContextConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.ext.fintraffic.config;
+
+import org.rutebanken.tiamat.config.ApplicationContextProvider;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Replaces {@link ApplicationContextProvider} in the fintraffic Spring test context with
+ * {@link RestoringApplicationContextProvider}, which saves and restores the static context
+ * field so that primary-context tests running after the fintraffic context is loaded still
+ * see the correct beans.
+ */
+@TestConfiguration
+public class FintrafficTestContextConfiguration {
+
+    @Bean
+    public ApplicationContextProvider applicationContextProvider() {
+        return new RestoringApplicationContextProvider();
+    }
+
+    public static void restoreContext() {
+        RestoringApplicationContextProvider.restoreContext();
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/config/RestoringApplicationContextProvider.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/config/RestoringApplicationContextProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.ext.fintraffic.config;
+
+import org.rutebanken.tiamat.config.ApplicationContextProvider;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Test-only replacement for {@link ApplicationContextProvider} used in the fintraffic Spring test context.
+ * <p>
+ * {@link ApplicationContextProvider} stores the active {@link ApplicationContext} in a static field.
+ * When the fintraffic test context starts it overwrites this field, causing subsequent tests running
+ * in the primary test context to get the wrong beans via {@code ApplicationContextProvider}.
+ * <p>
+ * This class saves the previous value of the static field when the fintraffic context sets it and
+ * exposes {@link #restoreContext()} so test teardown can restore the field before the primary-context
+ * tests that follow continue running.
+ * <p>
+ * Registered as a {@code @Bean} in {@link FintrafficTestContextConfiguration} which also excludes
+ * the component-scanned {@link ApplicationContextProvider} from the fintraffic context.
+ */
+class RestoringApplicationContextProvider extends ApplicationContextProvider {
+
+    private static ApplicationContext previousContext;
+    private static RestoringApplicationContextProvider instance;
+
+    @Override
+    public void setApplicationContext(ApplicationContext ctx) throws BeansException {
+        previousContext = ApplicationContextProvider.getApplicationContext();
+        instance = this;
+        super.setApplicationContext(ctx);
+    }
+
+    private void applyContext(ApplicationContext ctx) throws BeansException {
+        super.setApplicationContext(ctx);
+    }
+
+    static void restoreContext() {
+        if (instance != null && previousContext != null) {
+            instance.applyContext(previousContext);
+            previousContext = null;
+        }
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.rutebanken.tiamat.auth.AuthorizationService;
 import org.rutebanken.tiamat.ext.fintraffic.FintrafficIntegrationTest;
 import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
 import org.rutebanken.tiamat.importer.merging.MergingParkingImporter;
 import org.rutebanken.tiamat.model.Parking;
@@ -183,5 +184,69 @@ public class FintrafficMergingParkingImporterTest extends FintrafficIntegrationT
         assertThat(((FintrafficParking) result).getPaymentMethods())
                 .as("paymentMethods from plain NeTEx-derived Parking must overwrite existing")
                 .containsExactlyInAnyOrder(PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    @Test
+    @Transactional
+    public void handleCompletelyNewParking_preservesInfoLinks() throws Exception {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        FintrafficParking incoming = new FintrafficParking();
+        incoming.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        incoming.setInfoLinks(List.of(
+                new FintrafficInfoLink("https://example.com/parking", "resource")));
+
+        Parking saved = mergingParkingImporter.handleCompletelyNewParking(incoming);
+
+        assertThat(saved).isInstanceOf(FintrafficParking.class);
+        assertThat(((FintrafficParking) saved).getInfoLinks())
+                .as("infoLinks must be preserved when importing a completely new parking")
+                .containsExactly(new FintrafficInfoLink("https://example.com/parking", "resource"));
+    }
+
+    @Test
+    @Transactional
+    public void handleAlreadyExistingParking_mergesInfoLinks() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        FintrafficParking existing = new FintrafficParking();
+        existing.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        existing.setInfoLinks(List.of(new FintrafficInfoLink("https://old.example.com", "info")));
+        existing = (FintrafficParking) parkingVersionedSaverService.saveNewVersion(existing);
+
+        FintrafficParking incoming = new FintrafficParking();
+        incoming.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        incoming.setInfoLinks(List.of(new FintrafficInfoLink("https://new.example.com", "resource")));
+
+        Parking result = mergingParkingImporter.handleAlreadyExistingParking(existing, incoming);
+
+        assertThat(result).isInstanceOf(FintrafficParking.class);
+        assertThat(((FintrafficParking) result).getInfoLinks())
+                .as("infoLinks from incoming parking must replace those on the version copy")
+                .containsExactly(new FintrafficInfoLink("https://new.example.com", "resource"));
+    }
+
+    @Test
+    @Transactional
+    public void handleAlreadyExistingParking_unchangedInfoLinks_doesNotCreateNewVersion() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        FintrafficParking existing = new FintrafficParking();
+        existing.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        existing.setInfoLinks(List.of(new FintrafficInfoLink("https://example.com", "resource")));
+        existing = (FintrafficParking) parkingVersionedSaverService.saveNewVersion(existing);
+        long existingVersion = existing.getVersion();
+
+        FintrafficParking incoming = new FintrafficParking();
+        incoming.setInfoLinks(List.of(new FintrafficInfoLink("https://example.com", "resource")));
+
+        Parking result = mergingParkingImporter.handleAlreadyExistingParking(existing, incoming);
+
+        assertThat(result.getVersion())
+                .as("no new version must be created when infoLinks are unchanged")
+                .isEqualTo(existingVersion);
     }
 }

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
@@ -1,0 +1,184 @@
+package org.rutebanken.tiamat.ext.fintraffic.importer;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.importer.merging.MergingParkingImporter;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+import org.rutebanken.tiamat.model.SiteRefStructure;
+import org.rutebanken.tiamat.model.StopPlace;
+import org.rutebanken.tiamat.repository.ParkingRepository;
+import org.rutebanken.tiamat.repository.StopPlaceRepository;
+import org.rutebanken.tiamat.versioning.save.ParkingVersionedSaverService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link FintrafficMergingParkingImporter}, verifying that
+ * {@link FintrafficParking#getPaymentMethods() paymentMethods} are preserved on both
+ * import paths:
+ * <ul>
+ *   <li>New parking — {@code handleCompletelyNewParking} saves the incoming entity as-is</li>
+ *   <li>Existing parking — {@code handleAlreadyExistingParking} merges {@code paymentMethods}
+ *       from the incoming parking into the version copy via {@link MergingParkingImporter#mergeExtendedFields}</li>
+ * </ul>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = FintrafficTiamatTestApplication.class
+)
+@ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
+public class FintrafficMergingParkingImporterTest {
+
+    @MockitoBean
+    private AuthorizationService authorizationService;
+
+    @Autowired
+    private MergingParkingImporter mergingParkingImporter;
+
+    @Autowired
+    private ParkingVersionedSaverService parkingVersionedSaverService;
+
+    @Autowired
+    private ParkingRepository parkingRepository;
+
+    @Autowired
+    private StopPlaceRepository stopPlaceRepository;
+
+    @After
+    public void cleanUp() {
+        parkingRepository.deleteAll();
+        stopPlaceRepository.deleteAll();
+    }
+
+    @Test
+    public void importerIsFintrafficSubtype() {
+        assertThat(mergingParkingImporter)
+                .as("fintraffic profile must activate FintrafficMergingParkingImporter via @Primary")
+                .isInstanceOf(FintrafficMergingParkingImporter.class);
+    }
+
+    @Test
+    @Transactional
+    public void handleCompletelyNewParking_preservesPaymentMethods() throws Exception {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        FintrafficParking incoming = new FintrafficParking();
+        incoming.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        incoming.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH, PaymentMethodEnumeration.CREDIT_CARD));
+
+        Parking saved = mergingParkingImporter.handleCompletelyNewParking(incoming);
+
+        assertThat(saved).isInstanceOf(FintrafficParking.class);
+        assertThat(((FintrafficParking) saved).getPaymentMethods())
+                .as("paymentMethods must be preserved when importing a completely new parking")
+                .containsExactlyInAnyOrder(PaymentMethodEnumeration.CASH, PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    @Test
+    @Transactional
+    public void handleAlreadyExistingParking_mergesPaymentMethods() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        // Existing parking with one payment method
+        FintrafficParking existing = new FintrafficParking();
+        existing.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        existing.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH));
+        existing = (FintrafficParking) parkingVersionedSaverService.saveNewVersion(existing);
+
+        // Incoming parking with updated payment methods
+        FintrafficParking incoming = new FintrafficParking();
+        incoming.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        incoming.setPaymentMethods(List.of(PaymentMethodEnumeration.CREDIT_CARD, PaymentMethodEnumeration.DEBIT_CARD));
+
+        Parking result = mergingParkingImporter.handleAlreadyExistingParking(existing, incoming);
+
+        assertThat(result).isInstanceOf(FintrafficParking.class);
+        assertThat(((FintrafficParking) result).getPaymentMethods())
+                .as("paymentMethods from incoming parking must replace those on the version copy")
+                .containsExactlyInAnyOrder(PaymentMethodEnumeration.CREDIT_CARD, PaymentMethodEnumeration.DEBIT_CARD);
+    }
+
+    @Test
+    @Transactional
+    public void handleAlreadyExistingParking_unchangedPaymentMethods_doesNotCreateNewVersion() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        FintrafficParking existing = new FintrafficParking();
+        existing.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        existing.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH));
+        existing = (FintrafficParking) parkingVersionedSaverService.saveNewVersion(existing);
+        long existingVersion = existing.getVersion();
+
+        FintrafficParking incoming = new FintrafficParking();
+        incoming.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH));
+
+        Parking result = mergingParkingImporter.handleAlreadyExistingParking(existing, incoming);
+
+        assertThat(result.getVersion())
+                .as("no new version must be created when paymentMethods are unchanged")
+                .isEqualTo(existingVersion);
+    }
+
+    @Test
+    @Transactional
+    public void handleCompletelyNewParking_withPlainParking_preservesPaymentMethods() throws Exception {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        // Simulate the NeTEx mapper: produces a plain Parking with the @Transient
+        // paymentMethods field populated from the NeTEx document.
+        Parking incoming = new Parking();
+        incoming.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        incoming.getPaymentMethods().add(PaymentMethodEnumeration.CASH);
+
+        Parking saved = mergingParkingImporter.handleCompletelyNewParking(incoming);
+
+        assertThat(saved)
+                .as("NeTEx-imported parking must be promoted to FintrafficParking")
+                .isInstanceOf(FintrafficParking.class);
+        assertThat(((FintrafficParking) saved).getPaymentMethods())
+                .as("paymentMethods from plain NeTEx-derived Parking must be preserved")
+                .containsExactlyInAnyOrder(PaymentMethodEnumeration.CASH);
+    }
+
+    @Test
+    @Transactional
+    public void handleAlreadyExistingParking_withPlainParking_mergesPaymentMethods() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        FintrafficParking existing = new FintrafficParking();
+        existing.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        existing.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH));
+        existing = (FintrafficParking) parkingVersionedSaverService.saveNewVersion(existing);
+
+        // Simulate the NeTEx mapper: plain Parking with updated @Transient paymentMethods
+        Parking incoming = new Parking();
+        incoming.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        incoming.getPaymentMethods().add(PaymentMethodEnumeration.CREDIT_CARD);
+
+        Parking result = mergingParkingImporter.handleAlreadyExistingParking(existing, incoming);
+
+        assertThat(result).isInstanceOf(FintrafficParking.class);
+        assertThat(((FintrafficParking) result).getPaymentMethods())
+                .as("paymentMethods from plain NeTEx-derived Parking must overwrite existing")
+                .containsExactlyInAnyOrder(PaymentMethodEnumeration.CREDIT_CARD);
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
@@ -4,6 +4,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficIntegrationTest;
 import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
 import org.rutebanken.tiamat.importer.merging.MergingParkingImporter;
@@ -43,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 )
 @ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
 @TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
-public class FintrafficMergingParkingImporterTest {
+public class FintrafficMergingParkingImporterTest extends FintrafficIntegrationTest {
 
     @MockitoBean
     private AuthorizationService authorizationService;

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
@@ -17,6 +17,7 @@ import org.rutebanken.tiamat.versioning.save.ParkingVersionedSaverService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         classes = FintrafficTiamatTestApplication.class
 )
 @ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
+@TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
 public class FintrafficMergingParkingImporterTest {
 
     @MockitoBean

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporterTest.java
@@ -8,6 +8,7 @@ import org.rutebanken.tiamat.ext.fintraffic.FintrafficIntegrationTest;
 import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParkingEntranceForVehicles;
 import org.rutebanken.tiamat.importer.merging.MergingParkingImporter;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
@@ -247,6 +248,76 @@ public class FintrafficMergingParkingImporterTest extends FintrafficIntegrationT
 
         assertThat(result.getVersion())
                 .as("no new version must be created when infoLinks are unchanged")
+                .isEqualTo(existingVersion);
+    }
+
+    @Test
+    @Transactional
+    public void handleCompletelyNewParking_preservesVehicleEntrances() throws Exception {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        FintrafficParkingEntranceForVehicles entrance = new FintrafficParkingEntranceForVehicles(
+                "Main", "door", null, null, true, false, "A1");
+        FintrafficParking incoming = new FintrafficParking();
+        incoming.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        incoming.setFintrafficVehicleEntrances(List.of(entrance));
+
+        Parking saved = mergingParkingImporter.handleCompletelyNewParking(incoming);
+
+        assertThat(saved).isInstanceOf(FintrafficParking.class);
+        assertThat(((FintrafficParking) saved).getFintrafficVehicleEntrances())
+                .as("vehicleEntrances must be preserved when importing a completely new parking")
+                .containsExactly(entrance);
+    }
+
+    @Test
+    @Transactional
+    public void handleAlreadyExistingParking_mergesVehicleEntrances() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        FintrafficParking existing = new FintrafficParking();
+        existing.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        existing.setFintrafficVehicleEntrances(List.of(
+                new FintrafficParkingEntranceForVehicles("Old", "gate", null, null, true, true, null)));
+        existing = (FintrafficParking) parkingVersionedSaverService.saveNewVersion(existing);
+
+        FintrafficParkingEntranceForVehicles newEntrance =
+                new FintrafficParkingEntranceForVehicles("New", "door", null, null, true, false, "B2");
+        FintrafficParking incoming = new FintrafficParking();
+        incoming.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        incoming.setFintrafficVehicleEntrances(List.of(newEntrance));
+
+        Parking result = mergingParkingImporter.handleAlreadyExistingParking(existing, incoming);
+
+        assertThat(result).isInstanceOf(FintrafficParking.class);
+        assertThat(((FintrafficParking) result).getFintrafficVehicleEntrances())
+                .as("vehicleEntrances from incoming parking must replace those on the version copy")
+                .containsExactly(newEntrance);
+    }
+
+    @Test
+    @Transactional
+    public void handleAlreadyExistingParking_unchangedVehicleEntrances_doesNotCreateNewVersion() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        FintrafficParkingEntranceForVehicles entrance =
+                new FintrafficParkingEntranceForVehicles("Main", "door", null, null, true, false, "A1");
+        FintrafficParking existing = new FintrafficParking();
+        existing.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        existing.setFintrafficVehicleEntrances(List.of(entrance));
+        existing = (FintrafficParking) parkingVersionedSaverService.saveNewVersion(existing);
+        long existingVersion = existing.getVersion();
+
+        FintrafficParking incoming = new FintrafficParking();
+        incoming.setFintrafficVehicleEntrances(List.of(entrance));
+
+        Parking result = mergingParkingImporter.handleAlreadyExistingParking(existing, incoming);
+
+        assertThat(result.getVersion())
+                .as("no new version must be created when vehicleEntrances are unchanged")
                 .isEqualTo(existingVersion);
     }
 }

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributorTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributorTest.java
@@ -3,14 +3,20 @@ package org.rutebanken.tiamat.ext.fintraffic.importer;
 import ma.glasnost.orika.MappingContext;
 import org.junit.Before;
 import org.junit.Test;
+import org.rutebanken.netex.model.EntranceEnumeration;
 import org.rutebanken.netex.model.GroupOfEntities_VersionStructure;
 import org.rutebanken.netex.model.InfoLinkStructure;
+import org.rutebanken.netex.model.MultilingualString;
+import org.rutebanken.netex.model.ParkingEntranceForVehicles;
+import org.rutebanken.netex.model.ParkingEntrancesForVehicles_RelStructure;
 import org.rutebanken.netex.model.TypeOfInfolinkEnumeration;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParkingEntranceForVehicles;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -159,5 +165,80 @@ public class FintrafficParkingMapperContributorTest {
         contributor.mapToNetex(source, target, mappingContext);
 
         assertThat(target.getInfoLinks()).isNull();
+    }
+
+    // --- vehicleEntrances ---
+
+    @Test
+    public void mapFromNetex_copiesVehicleEntrancesToFintrafficParking() {
+        ParkingEntranceForVehicles entrance = new ParkingEntranceForVehicles()
+                .withLabel(new MultilingualString().withValue("Main entrance"))
+                .withEntranceType(EntranceEnumeration.DOOR)
+                .withWidth(new BigDecimal("3.50"))
+                .withHeight(new BigDecimal("2.20"))
+                .withIsEntry(true)
+                .withIsExit(false)
+                .withPublicCode("A1");
+        ParkingEntrancesForVehicles_RelStructure relStruct = new ParkingEntrancesForVehicles_RelStructure()
+                .withParkingEntranceForVehiclesRefOrParkingEntranceForVehicles(entrance);
+        org.rutebanken.netex.model.Parking source = new org.rutebanken.netex.model.Parking();
+        source.setVehicleEntrances(relStruct);
+        FintrafficParking target = new FintrafficParking();
+
+        contributor.mapFromNetex(source, target, mappingContext);
+
+        assertThat(target.getFintrafficVehicleEntrances()).hasSize(1);
+        FintrafficParkingEntranceForVehicles mapped = target.getFintrafficVehicleEntrances().getFirst();
+        assertThat(mapped.getLabel()).isEqualTo("Main entrance");
+        assertThat(mapped.getEntranceType()).isEqualTo("door");
+        assertThat(mapped.getWidth()).isEqualByComparingTo(new BigDecimal("3.50"));
+        assertThat(mapped.getHeight()).isEqualByComparingTo(new BigDecimal("2.20"));
+        assertThat(mapped.getIsEntry()).isTrue();
+        assertThat(mapped.getIsExit()).isFalse();
+        assertThat(mapped.getPublicCode()).isEqualTo("A1");
+    }
+
+    @Test
+    public void mapFromNetex_noVehicleEntrances_leavesTargetEmpty() {
+        org.rutebanken.netex.model.Parking source = new org.rutebanken.netex.model.Parking();
+        FintrafficParking target = new FintrafficParking();
+
+        contributor.mapFromNetex(source, target, mappingContext);
+
+        assertThat(target.getFintrafficVehicleEntrances()).isEmpty();
+    }
+
+    @Test
+    public void mapToNetex_copiesVehicleEntrancesFromFintrafficParking() {
+        FintrafficParking source = new FintrafficParking();
+        source.setFintrafficVehicleEntrances(List.of(
+                new FintrafficParkingEntranceForVehicles("Exit", "gate",
+                        new BigDecimal("4.00"), new BigDecimal("3.00"), false, true, "B2")));
+        org.rutebanken.netex.model.Parking target = new org.rutebanken.netex.model.Parking();
+
+        contributor.mapToNetex(source, target, mappingContext);
+
+        assertThat(target.getVehicleEntrances()).isNotNull();
+        var items = target.getVehicleEntrances()
+                .getParkingEntranceForVehiclesRefOrParkingEntranceForVehicles();
+        assertThat(items).hasSize(1);
+        ParkingEntranceForVehicles netex = (ParkingEntranceForVehicles) items.getFirst();
+        assertThat(netex.getLabel().getValue()).isEqualTo("Exit");
+        assertThat(netex.getEntranceType()).isEqualTo(EntranceEnumeration.GATE);
+        assertThat(netex.getWidth()).isEqualByComparingTo(new BigDecimal("4.00"));
+        assertThat(netex.getHeight()).isEqualByComparingTo(new BigDecimal("3.00"));
+        assertThat(netex.isIsEntry()).isFalse();
+        assertThat(netex.isIsExit()).isTrue();
+        assertThat(netex.getPublicCode()).isEqualTo("B2");
+    }
+
+    @Test
+    public void mapToNetex_emptyVehicleEntrances_doesNotSetField() {
+        FintrafficParking source = new FintrafficParking();
+        org.rutebanken.netex.model.Parking target = new org.rutebanken.netex.model.Parking();
+
+        contributor.mapToNetex(source, target, mappingContext);
+
+        assertThat(target.getVehicleEntrances()).isNull();
     }
 }

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributorTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributorTest.java
@@ -1,0 +1,81 @@
+package org.rutebanken.tiamat.ext.fintraffic.importer;
+
+import ma.glasnost.orika.MappingContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link FintrafficParkingMapperContributor}.
+ */
+public class FintrafficParkingMapperContributorTest {
+
+    private FintrafficParkingMapperContributor contributor;
+    private MappingContext mappingContext;
+
+    @Before
+    public void setUp() {
+        contributor = new FintrafficParkingMapperContributor();
+        mappingContext = mock(MappingContext.class);
+    }
+
+    @Test
+    public void mapFromNetex_copiesPaymentMethodsToTransientField() {
+        org.rutebanken.netex.model.Parking source = new org.rutebanken.netex.model.Parking()
+                .withPaymentMethods(
+                        org.rutebanken.netex.model.PaymentMethodEnumeration.CASH,
+                        org.rutebanken.netex.model.PaymentMethodEnumeration.CREDIT_CARD);
+        Parking target = new Parking();
+
+        contributor.mapFromNetex(source, target, mappingContext);
+
+        assertThat(target.getPaymentMethods())
+                .containsExactlyInAnyOrder(
+                        PaymentMethodEnumeration.CASH,
+                        PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    @Test
+    public void mapFromNetex_emptySource_leavesTargetUnchanged() {
+        org.rutebanken.netex.model.Parking source = new org.rutebanken.netex.model.Parking();
+        Parking target = new Parking();
+
+        contributor.mapFromNetex(source, target, mappingContext);
+
+        assertThat(target.getPaymentMethods()).isEmpty();
+    }
+
+    @Test
+    public void mapToNetex_copiesPaymentMethodsFromFintrafficParking() {
+        FintrafficParking source = new FintrafficParking();
+        source.setPaymentMethods(List.of(
+                PaymentMethodEnumeration.CASH,
+                PaymentMethodEnumeration.CREDIT_CARD));
+        org.rutebanken.netex.model.Parking target = new org.rutebanken.netex.model.Parking();
+
+        contributor.mapToNetex(source, target, mappingContext);
+
+        assertThat(target.getPaymentMethods())
+                .containsExactlyInAnyOrder(
+                        org.rutebanken.netex.model.PaymentMethodEnumeration.CASH,
+                        org.rutebanken.netex.model.PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    @Test
+    public void mapToNetex_plainParking_doesNothing() {
+        Parking source = new Parking();
+        source.getPaymentMethods().add(PaymentMethodEnumeration.CASH);
+        org.rutebanken.netex.model.Parking target = new org.rutebanken.netex.model.Parking();
+
+        contributor.mapToNetex(source, target, mappingContext);
+
+        assertThat(target.getPaymentMethods()).isEmpty();
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributorTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributorTest.java
@@ -3,6 +3,10 @@ package org.rutebanken.tiamat.ext.fintraffic.importer;
 import ma.glasnost.orika.MappingContext;
 import org.junit.Before;
 import org.junit.Test;
+import org.rutebanken.netex.model.GroupOfEntities_VersionStructure;
+import org.rutebanken.netex.model.InfoLinkStructure;
+import org.rutebanken.netex.model.TypeOfInfolinkEnumeration;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
@@ -25,6 +29,8 @@ public class FintrafficParkingMapperContributorTest {
         contributor = new FintrafficParkingMapperContributor();
         mappingContext = mock(MappingContext.class);
     }
+
+    // --- paymentMethods ---
 
     @Test
     public void mapFromNetex_copiesPaymentMethodsToTransientField() {
@@ -77,5 +83,81 @@ public class FintrafficParkingMapperContributorTest {
         contributor.mapToNetex(source, target, mappingContext);
 
         assertThat(target.getPaymentMethods()).isEmpty();
+    }
+
+    // --- infoLinks ---
+
+    @Test
+    public void mapFromNetex_copiesInfoLinksToFintrafficParking() {
+        var infoLinks = new GroupOfEntities_VersionStructure.InfoLinks()
+                .withInfoLink(
+                        new InfoLinkStructure()
+                                .withValue("https://example.com/parking")
+                                .withTypeOfInfoLink(TypeOfInfolinkEnumeration.RESOURCE),
+                        new InfoLinkStructure()
+                                .withValue("https://example.com/info"));
+        org.rutebanken.netex.model.Parking source = new org.rutebanken.netex.model.Parking();
+        source.setInfoLinks(infoLinks);
+        FintrafficParking target = new FintrafficParking();
+
+        contributor.mapFromNetex(source, target, mappingContext);
+
+        assertThat(target.getInfoLinks())
+                .hasSize(2)
+                .contains(new FintrafficInfoLink("https://example.com/parking", "resource"))
+                .contains(new FintrafficInfoLink("https://example.com/info", null));
+    }
+
+    @Test
+    public void mapFromNetex_noInfoLinks_leavesTargetEmpty() {
+        org.rutebanken.netex.model.Parking source = new org.rutebanken.netex.model.Parking();
+        FintrafficParking target = new FintrafficParking();
+
+        contributor.mapFromNetex(source, target, mappingContext);
+
+        assertThat(target.getInfoLinks()).isEmpty();
+    }
+
+    @Test
+    public void mapFromNetex_plainParking_infoLinksIgnored() {
+        var infoLinks = new GroupOfEntities_VersionStructure.InfoLinks()
+                .withInfoLink(new InfoLinkStructure().withValue("https://example.com"));
+        org.rutebanken.netex.model.Parking source = new org.rutebanken.netex.model.Parking();
+        source.setInfoLinks(infoLinks);
+        Parking target = new Parking(); // plain, not FintrafficParking
+
+        contributor.mapFromNetex(source, target, mappingContext);
+
+        // no exception, just silently ignored
+    }
+
+    @Test
+    public void mapToNetex_copiesInfoLinksFromFintrafficParking() {
+        FintrafficParking source = new FintrafficParking();
+        source.setInfoLinks(List.of(
+                new FintrafficInfoLink("https://example.com/resource", "resource"),
+                new FintrafficInfoLink("https://example.com/plain", null)));
+        org.rutebanken.netex.model.Parking target = new org.rutebanken.netex.model.Parking();
+
+        contributor.mapToNetex(source, target, mappingContext);
+
+        assertThat(target.getInfoLinks()).isNotNull();
+        var netexLinks = target.getInfoLinks().getInfoLink();
+        assertThat(netexLinks).hasSize(2);
+        assertThat(netexLinks.get(0).getValue()).isEqualTo("https://example.com/resource");
+        assertThat(netexLinks.get(0).getTypeOfInfoLink())
+                .containsExactly(TypeOfInfolinkEnumeration.RESOURCE);
+        assertThat(netexLinks.get(1).getValue()).isEqualTo("https://example.com/plain");
+        assertThat(netexLinks.get(1).getTypeOfInfoLink()).isEmpty();
+    }
+
+    @Test
+    public void mapToNetex_emptyInfoLinks_doesNotSetField() {
+        FintrafficParking source = new FintrafficParking();
+        org.rutebanken.netex.model.Parking target = new org.rutebanken.netex.model.Parking();
+
+        contributor.mapToNetex(source, target, mappingContext);
+
+        assertThat(target.getInfoLinks()).isNull();
     }
 }

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributorTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributorTest.java
@@ -241,4 +241,70 @@ public class FintrafficParkingMapperContributorTest {
 
         assertThat(target.getVehicleEntrances()).isNull();
     }
+
+    // --- lighting ---
+
+    @Test
+    public void mapFromNetex_copiesLightingToFintrafficParking() {
+        org.rutebanken.netex.model.Parking source = new org.rutebanken.netex.model.Parking()
+                .withLighting(org.rutebanken.netex.model.LightingEnumeration.WELL_LIT);
+        FintrafficParking target = new FintrafficParking();
+
+        contributor.mapFromNetex(source, target, mappingContext);
+
+        assertThat(target.getLighting()).isEqualTo(org.rutebanken.tiamat.model.LightingEnumeration.WELL_LIT);
+    }
+
+    @Test
+    public void mapFromNetex_noLighting_leavesTargetUnset() {
+        org.rutebanken.netex.model.Parking source = new org.rutebanken.netex.model.Parking();
+        FintrafficParking target = new FintrafficParking();
+
+        contributor.mapFromNetex(source, target, mappingContext);
+
+        assertThat(target.getLighting()).isNull();
+    }
+
+    @Test
+    public void mapFromNetex_plainParking_lightingIgnored() {
+        org.rutebanken.netex.model.Parking source = new org.rutebanken.netex.model.Parking()
+                .withLighting(org.rutebanken.netex.model.LightingEnumeration.WELL_LIT);
+        Parking target = new Parking(); // plain, not FintrafficParking
+
+        contributor.mapFromNetex(source, target, mappingContext);
+
+        // no exception, just silently ignored
+    }
+
+    @Test
+    public void mapToNetex_copiesLightingFromFintrafficParking() {
+        FintrafficParking source = new FintrafficParking();
+        source.setLighting(org.rutebanken.tiamat.model.LightingEnumeration.POORLY_LIT);
+        org.rutebanken.netex.model.Parking target = new org.rutebanken.netex.model.Parking();
+
+        contributor.mapToNetex(source, target, mappingContext);
+
+        assertThat(target.getLighting()).isEqualTo(org.rutebanken.netex.model.LightingEnumeration.POORLY_LIT);
+    }
+
+    @Test
+    public void mapToNetex_noLighting_doesNotSetField() {
+        FintrafficParking source = new FintrafficParking();
+        org.rutebanken.netex.model.Parking target = new org.rutebanken.netex.model.Parking();
+
+        contributor.mapToNetex(source, target, mappingContext);
+
+        assertThat(target.getLighting()).isNull();
+    }
+
+    @Test
+    public void mapToNetex_plainParking_doesNothingForLighting() {
+        Parking source = new Parking();
+        source.setLighting(org.rutebanken.tiamat.model.LightingEnumeration.UNLIT);
+        org.rutebanken.netex.model.Parking target = new org.rutebanken.netex.model.Parking();
+
+        contributor.mapToNetex(source, target, mappingContext);
+
+        assertThat(target.getLighting()).isNull();
+    }
 }

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactoryTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactoryTest.java
@@ -1,0 +1,42 @@
+package org.rutebanken.tiamat.ext.fintraffic.model;
+
+import org.junit.jupiter.api.Test;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FintrafficParkingEntityFactoryTest {
+
+    private final FintrafficParkingEntityFactory factory = new FintrafficParkingEntityFactory();
+
+    @Test
+    void create_returnsFintrafficParkingInstance() {
+        Parking parking = factory.create();
+
+        assertThat(parking).isInstanceOf(FintrafficParking.class);
+    }
+
+    @Test
+    void getEntityClass_returnsFintrafficParkingClass() {
+        assertThat(factory.getEntityClass()).isEqualTo(FintrafficParking.class);
+    }
+
+    @Test
+    void getMappingExclusions_doesNotContainPaymentMethods() {
+        List<String> exclusions = factory.getMappingExclusions();
+
+        assertThat(exclusions)
+                .as("paymentMethods must not be excluded so Orika maps it through")
+                .doesNotContain("paymentMethods");
+    }
+
+    @Test
+    void getMappingExclusions_stillExcludesOtherUnsupportedFields() {
+        List<String> exclusions = factory.getMappingExclusions();
+
+        assertThat(exclusions).contains("cardsAccepted", "currenciesAccepted", "accessModes");
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactoryTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactoryTest.java
@@ -25,12 +25,12 @@ class FintrafficParkingEntityFactoryTest {
     }
 
     @Test
-    void getMappingExclusions_doesNotContainPaymentMethods() {
+    void getMappingExclusions_containsPaymentMethods() {
         List<String> exclusions = factory.getMappingExclusions();
 
         assertThat(exclusions)
-                .as("paymentMethods must not be excluded so Orika maps it through")
-                .doesNotContain("paymentMethods");
+                .as("paymentMethods must be excluded from Orika auto-mapping: the two PaymentMethodEnumeration types differ and require explicit conversion in FintrafficParkingMapperContributor")
+                .contains("paymentMethods");
     }
 
     @Test

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingIntegrationTest.java
@@ -15,6 +15,7 @@ import org.rutebanken.tiamat.repository.ParkingRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         classes = FintrafficTiamatTestApplication.class
 )
 @ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
+@TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
 public class FintrafficParkingIntegrationTest {
 
     @MockitoBean

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingIntegrationTest.java
@@ -1,0 +1,136 @@
+package org.rutebanken.tiamat.ext.fintraffic.model;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+import org.rutebanken.tiamat.model.factory.ParkingEntityFactory;
+import org.rutebanken.tiamat.netex.mapping.NetexMapper;
+import org.rutebanken.tiamat.repository.ParkingRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test verifying that {@link FintrafficParking} persists {@code paymentMethods}
+ * through the full NeTEx → Orika → JPA → DB → JPA → NeTEx round-trip.
+ * <p>
+ * The {@code fintraffic} profile activates {@link FintrafficParkingEntityFactory} (which removes
+ * the Orika exclusion for {@code paymentMethods}) and the {@link FintrafficParking} entity subclass.
+ * {@link org.rutebanken.tiamat.ext.fintraffic.auth.FintrafficSecurityConfig} is excluded from the
+ * component scan via {@link FintrafficTiamatTestApplication}; {@link AuthorizationService} is mocked.
+ * <p>
+ * Persistence tests use {@link ParkingRepository} directly to avoid the {@code parentSiteRef}
+ * validation in {@code ParkingVersionedSaverService}, since the round-trip under test is
+ * specifically the {@code paymentMethods} field persistence, not the full import pipeline.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = FintrafficTiamatTestApplication.class
+)
+@ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
+public class FintrafficParkingIntegrationTest {
+
+    @MockitoBean
+    private AuthorizationService authorizationService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private NetexMapper netexMapper;
+
+    @Autowired
+    private ParkingEntityFactory parkingEntityFactory;
+
+    @Autowired
+    private ParkingRepository parkingRepository;
+
+    @After
+    public void cleanUp() {
+        parkingRepository.deleteAll();
+    }
+
+    @Test
+    public void parkingEntityFactory_producesFintrafficParkingInstance() {
+        Parking parking = netexMapper.mapToTiamatModel(
+                new org.rutebanken.netex.model.Parking().withId("FSR:Parking:1").withVersion("1"));
+
+        assertThat(parking)
+                .as("factory must produce FintrafficParking when fintraffic profile is active")
+                .isInstanceOf(FintrafficParking.class);
+    }
+
+    @Test
+    @Transactional
+    public void paymentMethods_surviveMappingAndDatabaseRoundTrip() {
+        // Map NeTEx → Tiamat model with payment methods
+        org.rutebanken.netex.model.Parking netexParking = new org.rutebanken.netex.model.Parking()
+                .withId("FSR:Parking:42")
+                .withVersion("1")
+                .withPaymentMethods(
+                        org.rutebanken.netex.model.PaymentMethodEnumeration.CASH,
+                        org.rutebanken.netex.model.PaymentMethodEnumeration.CREDIT_CARD);
+
+        Parking tiamatParking = netexMapper.mapToTiamatModel(netexParking);
+
+        assertThat(tiamatParking.getPaymentMethods())
+                .as("paymentMethods must be mapped from NeTEx (not excluded) with fintraffic profile")
+                .containsExactlyInAnyOrder(
+                        PaymentMethodEnumeration.CASH,
+                        PaymentMethodEnumeration.CREDIT_CARD);
+
+        // Save directly via repository (no parentSiteRef validation)
+        Parking saved = parkingRepository.save(tiamatParking);
+        Long id = saved.getId();
+
+        // Flush and clear to evict first-level cache; forces genuine DB read
+        entityManager.flush();
+        entityManager.clear();
+
+        // Reload from DB
+        Parking reloaded = parkingRepository.findById(id).orElseThrow();
+
+        assertThat(reloaded.getPaymentMethods())
+                .as("paymentMethods must survive DB round-trip")
+                .containsExactlyInAnyOrder(
+                        PaymentMethodEnumeration.CASH,
+                        PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    @Test
+    @Transactional
+    public void paymentMethods_appearsInNetexExport() {
+        // Build and persist a FintrafficParking with payment methods
+        FintrafficParking fp = (FintrafficParking) parkingEntityFactory.create();
+        fp.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH));
+        Parking saved = parkingRepository.save(fp);
+
+        // Flush and clear to evict first-level cache; forces genuine DB read
+        entityManager.flush();
+        entityManager.clear();
+
+        // Reload (ensure we're reading from DB, not session cache)
+        Parking reloaded = parkingRepository.findById(saved.getId()).orElseThrow();
+
+        // Map Tiamat → NeTEx
+        org.rutebanken.netex.model.Parking exported = netexMapper.mapToNetexModel(reloaded);
+
+        assertThat(exported.getPaymentMethods())
+                .as("paymentMethods must appear in NeTEx export")
+                .contains(org.rutebanken.netex.model.PaymentMethodEnumeration.CASH);
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficIntegrationTest;
 import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
@@ -44,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 )
 @ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
 @TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
-public class FintrafficParkingIntegrationTest {
+public class FintrafficParkingIntegrationTest extends FintrafficIntegrationTest {
 
     @MockitoBean
     private AuthorizationService authorizationService;

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingTest.java
@@ -1,0 +1,71 @@
+package org.rutebanken.tiamat.ext.fintraffic.model;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import org.junit.jupiter.api.Test;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FintrafficParkingTest {
+
+    @Test
+    void isSubclassOfParking() {
+        assertThat(Parking.class).isAssignableFrom(FintrafficParking.class);
+    }
+
+    @Test
+    void paymentMethodsField_hasElementCollectionAnnotation() throws NoSuchFieldException {
+        Field field = FintrafficParking.class.getDeclaredField("paymentMethods");
+
+        assertThat(field.isAnnotationPresent(ElementCollection.class))
+                .as("paymentMethods field must be @ElementCollection to be persisted")
+                .isTrue();
+    }
+
+    @Test
+    void paymentMethodsField_hasCollectionTableAnnotation() throws NoSuchFieldException {
+        Field field = FintrafficParking.class.getDeclaredField("paymentMethods");
+
+        CollectionTable table = field.getAnnotation(CollectionTable.class);
+        assertThat(table).isNotNull();
+        assertThat(table.name()).isEqualTo("parking_payment_methods");
+    }
+
+    @Test
+    void setAndGetPaymentMethods_usesOwnField_notParentTransientField() {
+        FintrafficParking parking = new FintrafficParking();
+
+        parking.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH, PaymentMethodEnumeration.CREDIT_CARD));
+
+        // getPaymentMethods() must return from the @ElementCollection field, not the parent @Transient field
+        assertThat(parking.getPaymentMethods())
+                .containsExactly(PaymentMethodEnumeration.CASH, PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    @Test
+    void parentTransientField_isNotAffectedBySubclassSetter() throws Exception {
+        FintrafficParking parking = new FintrafficParking();
+        parking.setPaymentMethods(List.of(PaymentMethodEnumeration.CASH));
+
+        // The parent @Transient protected field should remain null (we never write to it)
+        Field parentField = Parking.class.getDeclaredField("paymentMethods");
+        parentField.setAccessible(true);
+        Object parentFieldValue = parentField.get(parking);
+
+        assertThat(parentFieldValue)
+                .as("parent @Transient paymentMethods must remain null; only the shadowed field is written")
+                .isNull();
+    }
+
+    @Test
+    void getPaymentMethods_returnsEmptyList_whenNothingSet() {
+        FintrafficParking parking = new FintrafficParking();
+
+        assertThat(parking.getPaymentMethods()).isEmpty();
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficIntegrationTest;
 import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
 import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
@@ -47,7 +48,7 @@ import static org.rutebanken.tiamat.config.JerseyConfig.SERVICES_STOP_PLACE_PATH
 )
 @ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
 @TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
-public class FintrafficGraphQLParkingIntegrationTest {
+public class FintrafficGraphQLParkingIntegrationTest extends FintrafficIntegrationTest {
 
     private static final String BASE_URI_GRAPHQL = SERVICES_STOP_PLACE_PATH + "/graphql/";
 

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
@@ -1,0 +1,295 @@
+package org.rutebanken.tiamat.ext.fintraffic.rest.graphql;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.rutebanken.tiamat.auth.AuthorizationService;
+import org.rutebanken.tiamat.ext.fintraffic.FintrafficTiamatTestApplication;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+import org.rutebanken.tiamat.model.StopPlace;
+import org.rutebanken.tiamat.model.StopTypeEnumeration;
+import org.rutebanken.tiamat.repository.ParkingRepository;
+import org.rutebanken.tiamat.repository.StopPlaceRepository;
+import org.rutebanken.tiamat.rest.graphql.GraphQLNames;
+import org.rutebanken.tiamat.versioning.save.StopPlaceVersionedSaverService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.rutebanken.tiamat.config.JerseyConfig.SERVICES_STOP_PLACE_PATH;
+/**
+ * Integration test verifying that the GraphQL {@code mutateParking} operation uses
+ * {@link org.rutebanken.tiamat.model.factory.ParkingEntityFactory} to produce a
+ * {@link FintrafficParking} instance when the {@code fintraffic} profile is active.
+ * <p>
+ * Note: {@code paymentMethods} is not yet part of the GraphQL schema; the GraphQL
+ * layer tests that the correct entity subtype is created and persisted. The
+ * {@code paymentMethods} DB round-trip is covered by
+ * {@link org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParkingIntegrationTest}.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = FintrafficTiamatTestApplication.class
+)
+@ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
+public class FintrafficGraphQLParkingIntegrationTest {
+
+    private static final String BASE_URI_GRAPHQL = SERVICES_STOP_PLACE_PATH + "/graphql/";
+
+    @MockitoBean
+    private AuthorizationService authorizationService;
+
+    @Value("${local.server.port}")
+    private int port;
+
+    @Autowired
+    private StopPlaceRepository stopPlaceRepository;
+
+    @Autowired
+    private StopPlaceVersionedSaverService stopPlaceVersionedSaverService;
+
+    @Autowired
+    private ParkingRepository parkingRepository;
+
+    @Before
+    public void configureRestAssured() {
+        RestAssured.baseURI = "http://localhost";
+        RestAssured.port = port;
+    }
+
+    @After
+    public void cleanUp() {
+        parkingRepository.deleteAll();
+        stopPlaceRepository.deleteAll();
+    }
+
+    @Test
+    public void mutateParking_createsFintrafficParkingViaFactory() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        String mutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test parking\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" }) { id } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(mutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue())
+                .extract()
+                .path("data.parking[0].id");
+
+        Parking saved = parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+
+        assertThat(saved)
+                .as("ParkingEntityFactory must produce FintrafficParking via GraphQL mutateParking")
+                .isInstanceOf(FintrafficParking.class);
+    }
+
+    @Test
+    public void mutateParking_updatePreservesFintrafficParkingType() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        // Create
+        String createMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Original\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" }) { id } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(createMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.parking[0].id");
+
+        // Update
+        String updateMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { id: \\"%s\\" name: { value: \\"Updated\\" lang: \\"fi\\" } }) { id version } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, parkingNetexId);
+
+        given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(updateMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue());
+
+        // Both versions should be FintrafficParking
+        parkingRepository.findByNetexId(parkingNetexId).forEach(p ->
+                assertThat(p)
+                        .as("All versions of a parking must be FintrafficParking instances")
+                        .isInstanceOf(FintrafficParking.class)
+        );
+    }
+
+    @Test
+    public void mutateParking_paymentMethods_persistedAndReturnedInResponse() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        String mutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" paymentMethods: [cash, creditCard] }) { id paymentMethods } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(mutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue())
+                .body("data.parking[0].paymentMethods", hasItems("cash", "creditCard"))
+                .extract()
+                .path("data.parking[0].id");
+
+        FintrafficParking saved = (FintrafficParking)
+                parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+
+        assertThat(saved.getPaymentMethods())
+                .as("paymentMethods must be persisted to DB via FintrafficParkingUpdater")
+                .containsExactlyInAnyOrder(
+                        PaymentMethodEnumeration.CASH,
+                        PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    /**
+     * Verifies that {@link FintrafficParkingUpdater#preserveExtendedFields} copies
+     * {@code paymentMethods} from the existing version into the version copy when an
+     * update mutation omits the field.  Without this hook, Orika's {@code createCopy}
+     * would not transfer the private {@link FintrafficParking#paymentMethods} field and
+     * the update would silently clear any previously saved payment methods.
+     */
+    @Test
+    public void mutateParking_updateWithoutPaymentMethods_preservesExistingPaymentMethods() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        // Create with paymentMethods
+        String createMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" paymentMethods: [cash, creditCard] }) { id paymentMethods } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(createMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.parking[0].id");
+
+        // Update without paymentMethods — field should be preserved
+        String updateMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { id: \\"%s\\" name: { value: \\"Updated\\" lang: \\"fi\\" } }) { id paymentMethods } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, parkingNetexId);
+
+        given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(updateMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].paymentMethods", hasItems("cash", "creditCard"));
+
+        FintrafficParking latest = (FintrafficParking)
+                parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+        assertThat(latest.getPaymentMethods())
+                .as("paymentMethods must be preserved when not included in update input")
+                .containsExactlyInAnyOrder(
+                        PaymentMethodEnumeration.CASH,
+                        PaymentMethodEnumeration.CREDIT_CARD);
+    }
+
+    /**
+     * Regression test: when {@code fintraffic} profile is active, the {@code stopPlace} GraphQL
+     * query must be served by {@code stopPlaceFetcher}, not hijacked by any {@code @Primary}
+     * bean override intended only for {@code parkingUpdater}. The field must never be {@code null}
+     * (an empty list is acceptable; {@code null} means the wrong fetcher was injected).
+     */
+    @Test
+    public void stopPlaceQuery_notNull_whenFintrafficProfileActive() {
+        String query = """
+                {
+                  "query": "{ stopPlace(query: \\"nonexistent_xyz_regression_check\\", size: 1) { id } }"
+                }
+                """;
+
+        Object result = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(query)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.stopPlace");
+
+        assertThat(result)
+                .as("stopPlace field must not be null — null means stopPlaceFetcher was replaced " +
+                    "by an unrelated @Primary bean (e.g. FintrafficParkingUpdater)")
+                .isNotNull();
+    }
+}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.rutebanken.tiamat.config.JerseyConfig.SERVICES_STOP_PLACE_PATH;
@@ -481,6 +482,46 @@ public class FintrafficGraphQLParkingIntegrationTest extends FintrafficIntegrati
         assertThat(entrance.getIsEntry()).isTrue();
         assertThat(entrance.getIsExit()).isFalse();
         assertThat(entrance.getPublicCode()).isEqualTo("A1");
+    }
+
+    @Test
+    public void mutateParking_vehicleEntrances_widthAndHeight_persistedAndReturnedInResponse() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        String mutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" vehicleEntrances: [{ label: \\"Main\\" entranceType: door width: 2.75 height: 3.5 isEntry: true isExit: false publicCode: \\"A1\\" }] }) { id vehicleEntrances { label entranceType width height isEntry isExit publicCode } } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(mutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue())
+                .body("data.parking[0].vehicleEntrances[0].width", equalTo(2.75f))
+                .body("data.parking[0].vehicleEntrances[0].height", equalTo(3.5f))
+                .extract()
+                .path("data.parking[0].id");
+
+        FintrafficParking saved = (FintrafficParking)
+                parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+
+        assertThat(saved.getFintrafficVehicleEntrances()).hasSize(1);
+        org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParkingEntranceForVehicles entrance =
+                saved.getFintrafficVehicleEntrances().getFirst();
+        assertThat(entrance.getWidth()).isNotNull();
+        assertThat(entrance.getHeight()).isNotNull();
+        assertThat(entrance.getWidth()).isEqualByComparingTo("2.75");
+        assertThat(entrance.getHeight()).isEqualByComparingTo("3.5");
     }
 
     @Test

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
@@ -437,4 +437,100 @@ public class FintrafficGraphQLParkingIntegrationTest extends FintrafficIntegrati
                 .as("infoLinks must be preserved when not included in update input")
                 .containsExactly(new org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink("https://example.com", "resource"));
     }
+
+    @Test
+    public void mutateParking_vehicleEntrances_persistedAndReturnedInResponse() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        String mutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" vehicleEntrances: [{ label: \\"Main\\" entranceType: door isEntry: true isExit: false publicCode: \\"A1\\" }] }) { id vehicleEntrances { label entranceType isEntry isExit publicCode } } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(mutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue())
+                .body("data.parking[0].vehicleEntrances[0].label", org.hamcrest.Matchers.equalTo("Main"))
+                .body("data.parking[0].vehicleEntrances[0].entranceType", org.hamcrest.Matchers.equalTo("door"))
+                .body("data.parking[0].vehicleEntrances[0].isEntry", org.hamcrest.Matchers.equalTo(true))
+                .body("data.parking[0].vehicleEntrances[0].isExit", org.hamcrest.Matchers.equalTo(false))
+                .body("data.parking[0].vehicleEntrances[0].publicCode", org.hamcrest.Matchers.equalTo("A1"))
+                .extract()
+                .path("data.parking[0].id");
+
+        FintrafficParking saved = (FintrafficParking)
+                parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+
+        assertThat(saved.getFintrafficVehicleEntrances()).hasSize(1);
+        org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParkingEntranceForVehicles entrance =
+                saved.getFintrafficVehicleEntrances().getFirst();
+        assertThat(entrance.getLabel()).isEqualTo("Main");
+        assertThat(entrance.getEntranceType()).isEqualTo("door");
+        assertThat(entrance.getIsEntry()).isTrue();
+        assertThat(entrance.getIsExit()).isFalse();
+        assertThat(entrance.getPublicCode()).isEqualTo("A1");
+    }
+
+    @Test
+    public void mutateParking_updateWithoutVehicleEntrances_preservesExistingVehicleEntrances() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        String createMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" vehicleEntrances: [{ label: \\"Main\\" entranceType: door isEntry: true }] }) { id } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(createMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.parking[0].id");
+
+        String updateMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { id: \\"%s\\" name: { value: \\"Updated\\" lang: \\"fi\\" } }) { id vehicleEntrances { label } } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, parkingNetexId);
+
+        given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(updateMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].vehicleEntrances[0].label", org.hamcrest.Matchers.equalTo("Main"));
+
+        FintrafficParking latest = (FintrafficParking)
+                parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+        assertThat(latest.getFintrafficVehicleEntrances())
+                .as("vehicleEntrances must be preserved when not included in update input")
+                .hasSize(1);
+        assertThat(latest.getFintrafficVehicleEntrances().getFirst().getLabel()).isEqualTo("Main");
+    }
 }

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import static io.restassured.RestAssured.given;
@@ -45,6 +46,7 @@ import static org.rutebanken.tiamat.config.JerseyConfig.SERVICES_STOP_PLACE_PATH
         classes = FintrafficTiamatTestApplication.class
 )
 @ActiveProfiles({"test", "gcs-blobstore", "fintraffic"})
+@TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
 public class FintrafficGraphQLParkingIntegrationTest {
 
     private static final String BASE_URI_GRAPHQL = SERVICES_STOP_PLACE_PATH + "/graphql/";

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
@@ -348,4 +348,93 @@ public class FintrafficGraphQLParkingIntegrationTest extends FintrafficIntegrati
                     "by an unrelated @Primary bean (e.g. FintrafficParkingUpdater)")
                 .isNotNull();
     }
+
+    @Test
+    public void mutateParking_infoLinks_persistedAndReturnedInResponse() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        String mutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" infoLinks: [{ uri: \\"https://example.com\\" typeOfInfoLink: resource }] }) { id infoLinks { uri typeOfInfoLink } } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(mutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue())
+                .body("data.parking[0].infoLinks[0].uri", org.hamcrest.Matchers.equalTo("https://example.com"))
+                .body("data.parking[0].infoLinks[0].typeOfInfoLink", org.hamcrest.Matchers.equalTo("resource"))
+                .extract()
+                .path("data.parking[0].id");
+
+        FintrafficParking saved = (FintrafficParking)
+                parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+
+        assertThat(saved.getInfoLinks())
+                .as("infoLinks must be persisted to DB via FintrafficParkingUpdater")
+                .containsExactly(new org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink("https://example.com", "resource"));
+    }
+
+    @Test
+    public void mutateParking_updateWithoutInfoLinks_preservesExistingInfoLinks() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        // Create with infoLinks
+        String createMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" infoLinks: [{ uri: \\"https://example.com\\" typeOfInfoLink: resource }] }) { id } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(createMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.parking[0].id");
+
+        // Update without infoLinks — field should be preserved
+        String updateMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { id: \\"%s\\" name: { value: \\"Updated\\" lang: \\"fi\\" } }) { id infoLinks { uri typeOfInfoLink } } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, parkingNetexId);
+
+        given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(updateMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].infoLinks[0].uri", org.hamcrest.Matchers.equalTo("https://example.com"));
+
+        FintrafficParking latest = (FintrafficParking)
+                parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+        assertThat(latest.getInfoLinks())
+                .as("infoLinks must be preserved when not included in update input")
+                .containsExactly(new org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink("https://example.com", "resource"));
+    }
 }

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
@@ -263,6 +263,59 @@ public class FintrafficGraphQLParkingIntegrationTest {
     }
 
     /**
+     * Verifies that {@code paymentMethods} persisted via {@code mutateParking} are returned by
+     * the GraphQL {@code parking} query. This exercises the full read path:
+     * {@code parkingFetcher} → {@link org.rutebanken.tiamat.repository.ParkingRepository} →
+     * {@link org.rutebanken.tiamat.netex.mapping.NetexMapper#mapToNetexModel} →
+     * {@link org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor}.
+     */
+    @Test
+    public void parkingQuery_returnsPaymentMethods_whenFintrafficProfileActive() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        // Create parking with paymentMethods via mutation
+        String createMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" paymentMethods: [cash, creditCard] }) { id } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(createMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.parking[0].id");
+
+        // Query it back via the parking read query
+        String query = """
+                {
+                  "query": "{ parking(id: \\"%s\\") { id paymentMethods } }"
+                }
+                """.formatted(parkingNetexId);
+
+        given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(query)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue())
+                .body("data.parking[0].paymentMethods", hasItems("cash", "creditCard"));
+    }
+
+    /**
      * Regression test: when {@code fintraffic} profile is active, the {@code stopPlace} GraphQL
      * query must be served by {@code stopPlaceFetcher}, not hijacked by any {@code @Primary}
      * bean override intended only for {@code parkingUpdater}. The field must never be {@code null}

--- a/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
+++ b/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficGraphQLParkingIntegrationTest.java
@@ -574,4 +574,135 @@ public class FintrafficGraphQLParkingIntegrationTest extends FintrafficIntegrati
                 .hasSize(1);
         assertThat(latest.getFintrafficVehicleEntrances().getFirst().getLabel()).isEqualTo("Main");
     }
+
+    @Test
+    public void mutateParking_lighting_persistedAndReturnedInResponse() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        String mutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" lighting: wellLit }) { id lighting } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(mutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].id", notNullValue())
+                .body("data.parking[0].lighting", equalTo("wellLit"))
+                .extract()
+                .path("data.parking[0].id");
+
+        FintrafficParking saved = (FintrafficParking)
+                parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+
+        assertThat(saved.getLighting())
+                .as("lighting must be persisted to DB via FintrafficParkingUpdater")
+                .isEqualTo(org.rutebanken.tiamat.model.LightingEnumeration.WELL_LIT);
+    }
+
+    @Test
+    public void mutateParking_lighting_persistedAndReadBack_viaQuery() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        String mutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" lighting: wellLit }) { id } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(mutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.parking[0].id");
+
+        // Separate read query — proves persistence, not just response echo
+        String query = """
+                {
+                  "query": "{ parking(id: \\"%s\\") { id lighting } }"
+                }
+                """.formatted(parkingNetexId);
+
+        given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(query)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].lighting", equalTo("wellLit"));
+    }
+
+    @Test
+    public void mutateParking_updateWithoutLighting_preservesExistingLighting() {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Test stop"));
+        stopPlace.setStopPlaceType(StopTypeEnumeration.ONSTREET_BUS);
+        stopPlace = stopPlaceVersionedSaverService.saveNewVersion(stopPlace);
+        String stopNetexId = stopPlace.getNetexId();
+
+        String createMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { name: { value: \\"Test\\" lang: \\"fi\\" } parkingType: parkAndRide parentSiteRef: \\"%s\\" lighting: wellLit }) { id } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, stopNetexId);
+
+        String parkingNetexId = given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(createMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("data.parking[0].id");
+
+        // Update without lighting — should be preserved
+        String updateMutation = """
+                {
+                  "query": "mutation { parking: %s (Parking: { id: \\"%s\\" name: { value: \\"Updated\\" lang: \\"fi\\" } }) { id lighting } }",
+                  "variables": ""
+                }
+                """.formatted(GraphQLNames.MUTATE_PARKING, parkingNetexId);
+
+        given()
+                .port(port)
+                .contentType(ContentType.JSON)
+                .body(updateMutation)
+                .when()
+                .post(BASE_URI_GRAPHQL)
+                .then()
+                .log().body()
+                .statusCode(200)
+                .body("data.parking[0].lighting", equalTo("wellLit"));
+
+        FintrafficParking latest = (FintrafficParking)
+                parkingRepository.findFirstByNetexIdOrderByVersionDesc(parkingNetexId);
+        assertThat(latest.getLighting())
+                .as("lighting must be preserved when not included in update input")
+                .isEqualTo(org.rutebanken.tiamat.model.LightingEnumeration.WELL_LIT);
+    }
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/config/FintrafficEntityScanConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/config/FintrafficEntityScanConfig.java
@@ -1,0 +1,37 @@
+package org.rutebanken.tiamat.ext.fintraffic.config;
+
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.springframework.boot.persistence.autoconfigure.EntityScanPackages;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Adds {@code org.rutebanken.tiamat.ext.fintraffic.model} to Hibernate's entity scan.
+ * <p>
+ * Core's {@code TiamatApplication} only declares
+ * {@code @EntityScan(basePackageClasses = {StopPlace.class, ...})}, which covers
+ * {@code org.rutebanken.tiamat.model} — not this ext package. Without this, Hibernate
+ * never registers {@link FintrafficParking} (or any other ext {@code @Entity}) and
+ * every operation on it fails with "... is not an entity".
+ * <p>
+ * {@link EntityScanPackages#register} is additive: if a package list is already
+ * registered (by core's {@code @EntityScan}), it appends to it rather than replacing
+ * it, so this does not require modifying {@code TiamatApplication} — core is only
+ * ever extended here, never overridden.
+ */
+@Configuration
+@Profile("fintraffic")
+@Import(FintrafficEntityScanConfig.Registrar.class)
+public class FintrafficEntityScanConfig {
+
+    static class Registrar implements ImportBeanDefinitionRegistrar {
+        @Override
+        public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+            EntityScanPackages.register(registry, FintrafficParking.class.getPackageName());
+        }
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/config/FintrafficGraphQLConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/config/FintrafficGraphQLConfig.java
@@ -1,0 +1,23 @@
+package org.rutebanken.tiamat.ext.fintraffic.config;
+
+import org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingUpdater;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Registers Fintraffic-specific GraphQL beans, overriding their core counterparts
+ * by using the same bean name. Bean overriding is enabled globally via
+ * {@code spring.main.allow-bean-definition-overriding=true}. {@code @Bean} methods
+ * in {@code @Configuration} classes are registered after {@code @Service}
+ * component-scanned beans, so the override is reliable without needing {@code @Primary}.
+ */
+@Configuration
+@Profile("fintraffic")
+public class FintrafficGraphQLConfig {
+
+    @Bean("parkingUpdater")
+    public FintrafficParkingUpdater parkingUpdater() {
+        return new FintrafficParkingUpdater();
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/FintrafficFlywayConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/FintrafficFlywayConfig.java
@@ -5,6 +5,7 @@ import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.migration.JavaMigration;
 import org.rutebanken.tiamat.ext.fintraffic.db.migration.V2__CreateExtFintrafficNetexEntityTable;
 import org.rutebanken.tiamat.ext.fintraffic.db.migration.V3__FintrafficParkingExtensions;
+import org.rutebanken.tiamat.ext.fintraffic.db.migration.V4__FintrafficParkingInfoLinks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -22,7 +23,8 @@ public class FintrafficFlywayConfig {
 
     private static final List<Class<? extends JavaMigration>> migrations = List.of(
         V2__CreateExtFintrafficNetexEntityTable.class,
-        V3__FintrafficParkingExtensions.class
+        V3__FintrafficParkingExtensions.class,
+        V4__FintrafficParkingInfoLinks.class
     );
 
     public FintrafficFlywayConfig(DataSource dataSource) {

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/FintrafficFlywayConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/FintrafficFlywayConfig.java
@@ -7,6 +7,7 @@ import org.rutebanken.tiamat.ext.fintraffic.db.migration.V2__CreateExtFintraffic
 import org.rutebanken.tiamat.ext.fintraffic.db.migration.V3__FintrafficParkingExtensions;
 import org.rutebanken.tiamat.ext.fintraffic.db.migration.V4__FintrafficParkingInfoLinks;
 import org.rutebanken.tiamat.ext.fintraffic.db.migration.V5__FintrafficParkingVehicleEntrances;
+import org.rutebanken.tiamat.ext.fintraffic.db.migration.V6__FintrafficParkingLighting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -26,7 +27,8 @@ public class FintrafficFlywayConfig {
         V2__CreateExtFintrafficNetexEntityTable.class,
         V3__FintrafficParkingExtensions.class,
         V4__FintrafficParkingInfoLinks.class,
-        V5__FintrafficParkingVehicleEntrances.class
+        V5__FintrafficParkingVehicleEntrances.class,
+        V6__FintrafficParkingLighting.class
     );
 
     public FintrafficFlywayConfig(DataSource dataSource) {

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/FintrafficFlywayConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/FintrafficFlywayConfig.java
@@ -6,6 +6,7 @@ import org.flywaydb.core.api.migration.JavaMigration;
 import org.rutebanken.tiamat.ext.fintraffic.db.migration.V2__CreateExtFintrafficNetexEntityTable;
 import org.rutebanken.tiamat.ext.fintraffic.db.migration.V3__FintrafficParkingExtensions;
 import org.rutebanken.tiamat.ext.fintraffic.db.migration.V4__FintrafficParkingInfoLinks;
+import org.rutebanken.tiamat.ext.fintraffic.db.migration.V5__FintrafficParkingVehicleEntrances;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -24,7 +25,8 @@ public class FintrafficFlywayConfig {
     private static final List<Class<? extends JavaMigration>> migrations = List.of(
         V2__CreateExtFintrafficNetexEntityTable.class,
         V3__FintrafficParkingExtensions.class,
-        V4__FintrafficParkingInfoLinks.class
+        V4__FintrafficParkingInfoLinks.class,
+        V5__FintrafficParkingVehicleEntrances.class
     );
 
     public FintrafficFlywayConfig(DataSource dataSource) {

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/FintrafficFlywayConfig.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/FintrafficFlywayConfig.java
@@ -4,6 +4,7 @@ import jakarta.annotation.PostConstruct;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.migration.JavaMigration;
 import org.rutebanken.tiamat.ext.fintraffic.db.migration.V2__CreateExtFintrafficNetexEntityTable;
+import org.rutebanken.tiamat.ext.fintraffic.db.migration.V3__FintrafficParkingExtensions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -12,7 +13,7 @@ import org.springframework.context.annotation.Profile;
 import javax.sql.DataSource;
 import java.util.List;
 
-@Profile("fintraffic-read-api")
+@Profile({"fintraffic-read-api", "fintraffic"})
 @Configuration
 public class FintrafficFlywayConfig {
     private final Logger logger = LoggerFactory.getLogger(FintrafficFlywayConfig.class);
@@ -20,7 +21,8 @@ public class FintrafficFlywayConfig {
     private final DataSource dataSource;
 
     private static final List<Class<? extends JavaMigration>> migrations = List.of(
-        V2__CreateExtFintrafficNetexEntityTable.class
+        V2__CreateExtFintrafficNetexEntityTable.class,
+        V3__FintrafficParkingExtensions.class
     );
 
     public FintrafficFlywayConfig(DataSource dataSource) {

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V3__FintrafficParkingExtensions.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V3__FintrafficParkingExtensions.java
@@ -8,20 +8,17 @@ import java.sql.Statement;
 /**
  * Adds DDL required by {@code FintrafficParking}:
  * <ul>
- *   <li>{@code dtype} discriminator column on the {@code parking} table
- *       (Hibernate SINGLE_TABLE inheritance; existing rows default to "Parking")</li>
  *   <li>{@code parking_payment_methods} collection table for persisted payment methods</li>
  * </ul>
- * Entur's core migrations are not modified.
+ * Note: the {@code dtype} discriminator column is added by the core Flyway migration V62,
+ * because {@code FintrafficParking} is compiled into the same jar and Hibernate always
+ * requires {@code dtype} regardless of active Spring profiles.
  */
 public class V3__FintrafficParkingExtensions extends BaseJavaMigration {
 
     @Override
     public void migrate(Context context) throws Exception {
         String sql = """
-                ALTER TABLE parking ADD COLUMN IF NOT EXISTS dtype VARCHAR(31) DEFAULT 'Parking';
-                UPDATE parking SET dtype = 'Parking' WHERE dtype IS NULL;
-
                 CREATE TABLE IF NOT EXISTS parking_payment_methods (
                     parking_id  BIGINT      NOT NULL REFERENCES parking(id),
                     payment_method VARCHAR(64) NOT NULL

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V3__FintrafficParkingExtensions.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V3__FintrafficParkingExtensions.java
@@ -1,0 +1,38 @@
+package org.rutebanken.tiamat.ext.fintraffic.db.migration;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import java.sql.Statement;
+
+/**
+ * Adds DDL required by {@code FintrafficParking}:
+ * <ul>
+ *   <li>{@code dtype} discriminator column on the {@code parking} table
+ *       (Hibernate SINGLE_TABLE inheritance; existing rows default to "Parking")</li>
+ *   <li>{@code parking_payment_methods} collection table for persisted payment methods</li>
+ * </ul>
+ * Entur's core migrations are not modified.
+ */
+public class V3__FintrafficParkingExtensions extends BaseJavaMigration {
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        String sql = """
+                ALTER TABLE parking ADD COLUMN IF NOT EXISTS dtype VARCHAR(31) DEFAULT 'Parking';
+                UPDATE parking SET dtype = 'Parking' WHERE dtype IS NULL;
+
+                CREATE TABLE IF NOT EXISTS parking_payment_methods (
+                    parking_id  BIGINT      NOT NULL REFERENCES parking(id),
+                    payment_method VARCHAR(64) NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_parking_payment_methods_parking_id
+                    ON parking_payment_methods (parking_id);
+                """;
+
+        try (Statement stmt = context.getConnection().createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V4__FintrafficParkingInfoLinks.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V4__FintrafficParkingInfoLinks.java
@@ -1,0 +1,39 @@
+package org.rutebanken.tiamat.ext.fintraffic.db.migration;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import java.sql.Statement;
+
+/**
+ * Creates the {@code parking_info_links} collection table required by
+ * {@link org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking#getInfoLinks()}.
+ * <p>
+ * {@code typeOfInfoLink} stores the NeTEx {@code TypeOfInfolinkEnumeration} value string
+ * (e.g. {@code resource}, {@code info}).  A CHECK constraint enforces the allowed
+ * set; nullable because the attribute is optional in the NeTEx schema.
+ */
+public class V4__FintrafficParkingInfoLinks extends BaseJavaMigration {
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        String sql = """
+                CREATE TABLE IF NOT EXISTS parking_info_links (
+                    parking_id          BIGINT NOT NULL REFERENCES parking(id),
+                    uri                 VARCHAR(512) NOT NULL,
+                    type_of_info_link   VARCHAR(64) CHECK (type_of_info_link IN (
+                        'contact', 'resource', 'info', 'image', 'document',
+                        'timetableDocument', 'fareSheet', 'dataLicence',
+                        'mobileAppDownload', 'mobileAppInstallCheck', 'map', 'icon', 'other'
+                    ))
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_parking_info_links_parking_id
+                    ON parking_info_links (parking_id);
+                """;
+
+        try (Statement stmt = context.getConnection().createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V5__FintrafficParkingVehicleEntrances.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V5__FintrafficParkingVehicleEntrances.java
@@ -1,0 +1,43 @@
+package org.rutebanken.tiamat.ext.fintraffic.db.migration;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import java.sql.Statement;
+
+/**
+ * Creates the {@code parking_vehicle_entrances} collection table required by
+ * {@link org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking#getVehicleEntrances()}.
+ * <p>
+ * {@code entrance_type} stores the NeTEx {@code EntranceEnumeration} value string
+ * (e.g. {@code door}, {@code gate}).  A CHECK constraint enforces the allowed set;
+ * nullable because the attribute is optional in the NeTEx schema.
+ */
+public class V5__FintrafficParkingVehicleEntrances extends BaseJavaMigration {
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        String sql = """
+                CREATE TABLE IF NOT EXISTS parking_vehicle_entrances (
+                    parking_id    BIGINT NOT NULL REFERENCES parking(id),
+                    label         VARCHAR(255),
+                    entrance_type VARCHAR(64) CHECK (entrance_type IN (
+                        'opening', 'openDoor', 'door', 'swingDoor', 'revolvingDoor',
+                        'automaticDoor', 'ticketBarrier', 'gate', 'other'
+                    )),
+                    width         NUMERIC(10, 2),
+                    height        NUMERIC(10, 2),
+                    is_entry      BOOLEAN,
+                    is_exit       BOOLEAN,
+                    public_code   VARCHAR(64)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_parking_vehicle_entrances_parking_id
+                    ON parking_vehicle_entrances (parking_id);
+                """;
+
+        try (Statement stmt = context.getConnection().createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V6__FintrafficParkingLighting.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V6__FintrafficParkingLighting.java
@@ -1,0 +1,23 @@
+package org.rutebanken.tiamat.ext.fintraffic.db.migration;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import java.sql.Statement;
+
+/**
+ * Adds a {@code lighting} column to the {@code parking} table, used by
+ * {@link org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking} to persist the
+ * {@code lighting} field that is {@code @Transient} in the core {@code SiteElement} model.
+ * <p>
+ * Only rows with {@code dtype = 'FintrafficParking'} will have non-null values.
+ */
+public class V6__FintrafficParkingLighting extends BaseJavaMigration {
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        try (Statement stmt = context.getConnection().createStatement()) {
+            stmt.execute("ALTER TABLE parking ADD COLUMN IF NOT EXISTS lighting VARCHAR(64)");
+        }
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V6__FintrafficParkingLighting.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/db/migration/V6__FintrafficParkingLighting.java
@@ -6,18 +6,25 @@ import org.flywaydb.core.api.migration.Context;
 import java.sql.Statement;
 
 /**
- * Adds a {@code lighting} column to the {@code parking} table, used by
+ * Creates the {@code parking_fintraffic_lighting} collection table used by
  * {@link org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking} to persist the
  * {@code lighting} field that is {@code @Transient} in the core {@code SiteElement} model.
  * <p>
- * Only rows with {@code dtype = 'FintrafficParking'} will have non-null values.
+ * Using a separate collection table (rather than a column on {@code parking}) keeps
+ * Entur's core DDL unmodified and prevents Hibernate from selecting ext-only columns in
+ * core tests that do not run the Fintraffic Flyway migrations.
  */
 public class V6__FintrafficParkingLighting extends BaseJavaMigration {
 
     @Override
     public void migrate(Context context) throws Exception {
         try (Statement stmt = context.getConnection().createStatement()) {
-            stmt.execute("ALTER TABLE parking ADD COLUMN IF NOT EXISTS lighting VARCHAR(64)");
+            stmt.execute("""
+                    CREATE TABLE IF NOT EXISTS parking_fintraffic_lighting (
+                        parking_id BIGINT NOT NULL REFERENCES parking(id),
+                        lighting   VARCHAR(64) NOT NULL
+                    )
+                    """);
         }
     }
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporter.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporter.java
@@ -1,0 +1,74 @@
+package org.rutebanken.tiamat.ext.fintraffic.importer;
+
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.importer.KeyValueListAppender;
+import org.rutebanken.tiamat.importer.finder.NearbyParkingFinder;
+import org.rutebanken.tiamat.importer.finder.ParkingFromOriginalIdFinder;
+import org.rutebanken.tiamat.importer.merging.MergingParkingImporter;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.factory.ParkingEntityFactory;
+import org.rutebanken.tiamat.netex.mapping.NetexMapper;
+import org.rutebanken.tiamat.repository.reference.ReferenceResolver;
+import org.rutebanken.tiamat.versioning.VersionCreator;
+import org.rutebanken.tiamat.versioning.save.ParkingVersionedSaverService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fintraffic extension of {@link MergingParkingImporter} that preserves
+ * {@link FintrafficParking#getPaymentMethods() paymentMethods} on both import paths:
+ * <ul>
+ *   <li>New parking — {@code handleCompletelyNewParking} creates a typed
+ *       {@link FintrafficParking} copy and calls {@link #mergeExtendedFields} to copy
+ *       the transient {@code paymentMethods} from the NeTEx-derived source into the
+ *       persisted field of the copy.</li>
+ *   <li>Existing parking — {@code handleAlreadyExistingParking} does the same via
+ *       its own {@link #mergeExtendedFields} call.</li>
+ * </ul>
+ * In both cases {@code incomingParking} may be a plain {@link org.rutebanken.tiamat.model.Parking}
+ * (as produced by the NeTEx mapper) or a {@link FintrafficParking}; only the copy passed
+ * as the second argument is required to be a {@link FintrafficParking}.
+ */
+@Profile("fintraffic")
+@Primary
+@Component
+@Qualifier("mergingParkingImporter")
+public class FintrafficMergingParkingImporter extends MergingParkingImporter {
+
+    public FintrafficMergingParkingImporter(ParkingFromOriginalIdFinder parkingFromOriginalIdFinder,
+                                            NearbyParkingFinder nearbyParkingFinder,
+                                            ReferenceResolver referenceResolver,
+                                            KeyValueListAppender keyValueListAppender,
+                                            NetexMapper netexMapper,
+                                            ParkingVersionedSaverService parkingVersionedSaverService,
+                                            VersionCreator versionCreator,
+                                            ParkingEntityFactory parkingEntityFactory) {
+        super(parkingFromOriginalIdFinder, nearbyParkingFinder, referenceResolver,
+                keyValueListAppender, netexMapper, parkingVersionedSaverService,
+                versionCreator, parkingEntityFactory);
+    }
+
+    @Override
+    protected boolean mergeExtendedFields(Parking incomingParking, Parking copy) {
+        if (!(copy instanceof FintrafficParking target)) {
+            return false;
+        }
+
+        // incomingParking may be a plain Parking (from NeTEx mapper) or FintrafficParking (from DB).
+        // Either way, Parking.getPaymentMethods() returns the in-memory list the NeTEx mapper set.
+        List<org.rutebanken.tiamat.model.PaymentMethodEnumeration> incomingMethods = incomingParking.getPaymentMethods();
+        List<org.rutebanken.tiamat.model.PaymentMethodEnumeration> existingMethods = target.getPaymentMethods();
+
+        if (incomingMethods.equals(existingMethods)) {
+            return false;
+        }
+
+        target.setPaymentMethods(new ArrayList<>(incomingMethods));
+        return true;
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporter.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporter.java
@@ -1,11 +1,13 @@
 package org.rutebanken.tiamat.ext.fintraffic.importer;
 
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
 import org.rutebanken.tiamat.importer.KeyValueListAppender;
 import org.rutebanken.tiamat.importer.finder.NearbyParkingFinder;
 import org.rutebanken.tiamat.importer.finder.ParkingFromOriginalIdFinder;
 import org.rutebanken.tiamat.importer.merging.MergingParkingImporter;
 import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
 import org.rutebanken.tiamat.model.factory.ParkingEntityFactory;
 import org.rutebanken.tiamat.netex.mapping.NetexMapper;
 import org.rutebanken.tiamat.repository.reference.ReferenceResolver;
@@ -21,18 +23,8 @@ import java.util.List;
 
 /**
  * Fintraffic extension of {@link MergingParkingImporter} that preserves
- * {@link FintrafficParking#getPaymentMethods() paymentMethods} on both import paths:
- * <ul>
- *   <li>New parking — {@code handleCompletelyNewParking} creates a typed
- *       {@link FintrafficParking} copy and calls {@link #mergeExtendedFields} to copy
- *       the transient {@code paymentMethods} from the NeTEx-derived source into the
- *       persisted field of the copy.</li>
- *   <li>Existing parking — {@code handleAlreadyExistingParking} does the same via
- *       its own {@link #mergeExtendedFields} call.</li>
- * </ul>
- * In both cases {@code incomingParking} may be a plain {@link org.rutebanken.tiamat.model.Parking}
- * (as produced by the NeTEx mapper) or a {@link FintrafficParking}; only the copy passed
- * as the second argument is required to be a {@link FintrafficParking}.
+ * {@link FintrafficParking#getPaymentMethods() paymentMethods} and
+ * {@link FintrafficParking#getInfoLinks() infoLinks} on both import paths.
  */
 @Profile("fintraffic")
 @Primary
@@ -59,16 +51,26 @@ public class FintrafficMergingParkingImporter extends MergingParkingImporter {
             return false;
         }
 
-        // incomingParking may be a plain Parking (from NeTEx mapper) or FintrafficParking (from DB).
-        // Either way, Parking.getPaymentMethods() returns the in-memory list the NeTEx mapper set.
-        List<org.rutebanken.tiamat.model.PaymentMethodEnumeration> incomingMethods = incomingParking.getPaymentMethods();
-        List<org.rutebanken.tiamat.model.PaymentMethodEnumeration> existingMethods = target.getPaymentMethods();
+        boolean changed = false;
 
-        if (incomingMethods.equals(existingMethods)) {
-            return false;
+        // paymentMethods — always available via Parking.getPaymentMethods() (transient field)
+        List<PaymentMethodEnumeration> incomingMethods = incomingParking.getPaymentMethods();
+        List<PaymentMethodEnumeration> existingMethods = target.getPaymentMethods();
+        if (!incomingMethods.equals(existingMethods)) {
+            target.setPaymentMethods(new ArrayList<>(incomingMethods));
+            changed = true;
         }
 
-        target.setPaymentMethods(new ArrayList<>(incomingMethods));
-        return true;
+        // infoLinks — only available when incomingParking is also a FintrafficParking
+        if (incomingParking instanceof FintrafficParking incomingFP) {
+            List<FintrafficInfoLink> incomingLinks = incomingFP.getInfoLinks();
+            List<FintrafficInfoLink> existingLinks = target.getInfoLinks();
+            if (!incomingLinks.equals(existingLinks)) {
+                target.setInfoLinks(new ArrayList<>(incomingLinks));
+                changed = true;
+            }
+        }
+
+        return changed;
     }
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporter.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficMergingParkingImporter.java
@@ -2,6 +2,7 @@ package org.rutebanken.tiamat.ext.fintraffic.importer;
 
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParkingEntranceForVehicles;
 import org.rutebanken.tiamat.importer.KeyValueListAppender;
 import org.rutebanken.tiamat.importer.finder.NearbyParkingFinder;
 import org.rutebanken.tiamat.importer.finder.ParkingFromOriginalIdFinder;
@@ -67,6 +68,13 @@ public class FintrafficMergingParkingImporter extends MergingParkingImporter {
             List<FintrafficInfoLink> existingLinks = target.getInfoLinks();
             if (!incomingLinks.equals(existingLinks)) {
                 target.setInfoLinks(new ArrayList<>(incomingLinks));
+                changed = true;
+            }
+
+            List<FintrafficParkingEntranceForVehicles> incomingEntrances = incomingFP.getFintrafficVehicleEntrances();
+            List<FintrafficParkingEntranceForVehicles> existingEntrances = target.getFintrafficVehicleEntrances();
+            if (!incomingEntrances.equals(existingEntrances)) {
+                target.setFintrafficVehicleEntrances(new ArrayList<>(incomingEntrances));
                 changed = true;
             }
         }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributor.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributor.java
@@ -1,24 +1,29 @@
 package org.rutebanken.tiamat.ext.fintraffic.importer;
 
 import ma.glasnost.orika.MappingContext;
+import org.rutebanken.netex.model.InfoLinkStructure;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
 import org.rutebanken.tiamat.netex.mapping.mapper.ParkingMapperContributor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Fintraffic extension of {@link ParkingMapperContributor} that wires
- * {@code paymentMethods} through the NeTEx ↔ Tiamat mapping in both directions.
+ * {@code paymentMethods} and {@code infoLinks} through the NeTEx ↔ Tiamat
+ * mapping in both directions.
  *
- * <p><b>Import ({@link #mapFromNetex}):</b> copies the NeTEx
- * {@code paymentMethods} list onto the Tiamat {@link org.rutebanken.tiamat.model.Parking}
- * {@code @Transient} field so that the
- * {@link FintrafficMergingParkingImporter#mergeExtendedFields} hook can persist it.
+ * <p><b>Import ({@link #mapFromNetex}):</b> copies the NeTEx fields onto the
+ * {@link FintrafficParking} so that the
+ * {@link FintrafficMergingParkingImporter#mergeExtendedFields} hook can persist them.
  *
- * <p><b>Export ({@link #mapToNetex}):</b> reads {@code paymentMethods} from a
- * {@link FintrafficParking} and writes it back into the NeTEx output so that the
- * field survives the export roundtrip.
+ * <p><b>Export ({@link #mapToNetex}):</b> reads the persisted fields from a
+ * {@link FintrafficParking} and writes them back into the NeTEx output so that the
+ * fields survive the export roundtrip.
  */
 @Profile("fintraffic")
 @Component
@@ -28,6 +33,25 @@ public class FintrafficParkingMapperContributor implements ParkingMapperContribu
     public void mapFromNetex(org.rutebanken.netex.model.Parking source,
                              org.rutebanken.tiamat.model.Parking target,
                              MappingContext context) {
+        mapPaymentMethodsFromNetex(source, target);
+        mapInfoLinksFromNetex(source, target);
+    }
+
+    @Override
+    public void mapToNetex(org.rutebanken.tiamat.model.Parking source,
+                           org.rutebanken.netex.model.Parking target,
+                           MappingContext context) {
+        if (!(source instanceof FintrafficParking fp)) {
+            return;
+        }
+        mapPaymentMethodsToNetex(fp, target);
+        mapInfoLinksToNetex(fp, target);
+    }
+
+    // --- paymentMethods ---
+
+    private void mapPaymentMethodsFromNetex(org.rutebanken.netex.model.Parking source,
+                                             org.rutebanken.tiamat.model.Parking target) {
         var netexMethods = source.getPaymentMethods();
         if (netexMethods == null || netexMethods.isEmpty()) {
             return;
@@ -43,14 +67,9 @@ public class FintrafficParkingMapperContributor implements ParkingMapperContribu
         }
     }
 
-    @Override
-    public void mapToNetex(org.rutebanken.tiamat.model.Parking source,
-                           org.rutebanken.netex.model.Parking target,
-                           MappingContext context) {
-        if (!(source instanceof FintrafficParking fp)) {
-            return;
-        }
-        var methods = fp.getPaymentMethods();
+    private void mapPaymentMethodsToNetex(FintrafficParking source,
+                                          org.rutebanken.netex.model.Parking target) {
+        var methods = source.getPaymentMethods();
         if (methods.isEmpty()) {
             return;
         }
@@ -64,4 +83,60 @@ public class FintrafficParkingMapperContributor implements ParkingMapperContribu
             }
         }
     }
+
+    // --- infoLinks ---
+
+    private void mapInfoLinksFromNetex(org.rutebanken.netex.model.Parking source,
+                                        org.rutebanken.tiamat.model.Parking target) {
+        if (!(target instanceof FintrafficParking fp)) {
+            return;
+        }
+        var infoLinksRelStruct = source.getInfoLinks();
+        if (infoLinksRelStruct == null) {
+            return;
+        }
+        List<InfoLinkStructure> netexLinks = infoLinksRelStruct.getInfoLink();
+        if (netexLinks == null || netexLinks.isEmpty()) {
+            return;
+        }
+
+        List<FintrafficInfoLink> converted = new ArrayList<>();
+        for (InfoLinkStructure link : netexLinks) {
+            if (link.getValue() == null || link.getValue().isBlank()) {
+                continue;
+            }
+            String typeValue = null;
+            var types = link.getTypeOfInfoLink();
+            if (types != null && !types.isEmpty()) {
+                typeValue = types.getFirst().value();
+            }
+            converted.add(new FintrafficInfoLink(link.getValue(), typeValue));
+        }
+        fp.setInfoLinks(converted);
+    }
+
+    private void mapInfoLinksToNetex(FintrafficParking source,
+                                      org.rutebanken.netex.model.Parking target) {
+        var links = source.getInfoLinks();
+        if (links.isEmpty()) {
+            return;
+        }
+
+        var relStruct = new org.rutebanken.netex.model.GroupOfEntities_VersionStructure.InfoLinks();
+        for (FintrafficInfoLink link : links) {
+            InfoLinkStructure netexLink = new InfoLinkStructure();
+            netexLink.setValue(link.getUri());
+            if (link.getTypeOfInfoLink() != null) {
+                try {
+                    netexLink.getTypeOfInfoLink().add(
+                            org.rutebanken.netex.model.TypeOfInfolinkEnumeration.fromValue(link.getTypeOfInfoLink()));
+                } catch (IllegalArgumentException ignored) {
+                    // stored value no longer valid — skip type
+                }
+            }
+            relStruct.getInfoLink().add(netexLink);
+        }
+        target.setInfoLinks(relStruct);
+    }
 }
+

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributor.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributor.java
@@ -1,9 +1,13 @@
 package org.rutebanken.tiamat.ext.fintraffic.importer;
 
 import ma.glasnost.orika.MappingContext;
+import org.rutebanken.netex.model.EntranceEnumeration;
 import org.rutebanken.netex.model.InfoLinkStructure;
+import org.rutebanken.netex.model.ParkingEntranceForVehicles;
+import org.rutebanken.netex.model.ParkingEntrancesForVehicles_RelStructure;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParkingEntranceForVehicles;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
 import org.rutebanken.tiamat.netex.mapping.mapper.ParkingMapperContributor;
 import org.springframework.context.annotation.Profile;
@@ -35,6 +39,7 @@ public class FintrafficParkingMapperContributor implements ParkingMapperContribu
                              MappingContext context) {
         mapPaymentMethodsFromNetex(source, target);
         mapInfoLinksFromNetex(source, target);
+        mapVehicleEntrancesFromNetex(source, target);
     }
 
     @Override
@@ -46,6 +51,7 @@ public class FintrafficParkingMapperContributor implements ParkingMapperContribu
         }
         mapPaymentMethodsToNetex(fp, target);
         mapInfoLinksToNetex(fp, target);
+        mapVehicleEntrancesToNetex(fp, target);
     }
 
     // --- paymentMethods ---
@@ -137,6 +143,72 @@ public class FintrafficParkingMapperContributor implements ParkingMapperContribu
             relStruct.getInfoLink().add(netexLink);
         }
         target.setInfoLinks(relStruct);
+    }
+
+    // --- vehicleEntrances ---
+
+    private void mapVehicleEntrancesFromNetex(org.rutebanken.netex.model.Parking source,
+                                               org.rutebanken.tiamat.model.Parking target) {
+        if (!(target instanceof FintrafficParking fp)) {
+            return;
+        }
+        ParkingEntrancesForVehicles_RelStructure relStruct = source.getVehicleEntrances();
+        if (relStruct == null) {
+            return;
+        }
+        List<Object> items = relStruct.getParkingEntranceForVehiclesRefOrParkingEntranceForVehicles();
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+
+        List<FintrafficParkingEntranceForVehicles> converted = new ArrayList<>();
+        for (Object item : items) {
+            if (!(item instanceof ParkingEntranceForVehicles entrance)) {
+                continue;
+            }
+            String label = entrance.getLabel() != null ? entrance.getLabel().getValue() : null;
+            String entranceType = entrance.getEntranceType() != null ? entrance.getEntranceType().value() : null;
+            converted.add(new FintrafficParkingEntranceForVehicles(
+                    label,
+                    entranceType,
+                    entrance.getWidth(),
+                    entrance.getHeight(),
+                    entrance.isIsEntry(),
+                    entrance.isIsExit(),
+                    entrance.getPublicCode()
+            ));
+        }
+        fp.setFintrafficVehicleEntrances(converted);
+    }
+
+    private void mapVehicleEntrancesToNetex(FintrafficParking source,
+                                             org.rutebanken.netex.model.Parking target) {
+        var entrances = source.getFintrafficVehicleEntrances();
+        if (entrances.isEmpty()) {
+            return;
+        }
+
+        ParkingEntrancesForVehicles_RelStructure relStruct = new ParkingEntrancesForVehicles_RelStructure();
+        for (FintrafficParkingEntranceForVehicles entrance : entrances) {
+            ParkingEntranceForVehicles netexEntrance = new ParkingEntranceForVehicles();
+            if (entrance.getLabel() != null) {
+                netexEntrance.setLabel(new org.rutebanken.netex.model.MultilingualString().withValue(entrance.getLabel()));
+            }
+            if (entrance.getEntranceType() != null) {
+                try {
+                    netexEntrance.setEntranceType(EntranceEnumeration.fromValue(entrance.getEntranceType()));
+                } catch (IllegalArgumentException ignored) {
+                    // stored value no longer valid — skip type
+                }
+            }
+            netexEntrance.setWidth(entrance.getWidth());
+            netexEntrance.setHeight(entrance.getHeight());
+            netexEntrance.setIsEntry(entrance.getIsEntry());
+            netexEntrance.setIsExit(entrance.getIsExit());
+            netexEntrance.setPublicCode(entrance.getPublicCode());
+            relStruct.getParkingEntranceForVehiclesRefOrParkingEntranceForVehicles().add(netexEntrance);
+        }
+        target.setVehicleEntrances(relStruct);
     }
 }
 

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributor.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributor.java
@@ -1,0 +1,67 @@
+package org.rutebanken.tiamat.ext.fintraffic.importer;
+
+import ma.glasnost.orika.MappingContext;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+import org.rutebanken.tiamat.netex.mapping.mapper.ParkingMapperContributor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fintraffic extension of {@link ParkingMapperContributor} that wires
+ * {@code paymentMethods} through the NeTEx ↔ Tiamat mapping in both directions.
+ *
+ * <p><b>Import ({@link #mapFromNetex}):</b> copies the NeTEx
+ * {@code paymentMethods} list onto the Tiamat {@link org.rutebanken.tiamat.model.Parking}
+ * {@code @Transient} field so that the
+ * {@link FintrafficMergingParkingImporter#mergeExtendedFields} hook can persist it.
+ *
+ * <p><b>Export ({@link #mapToNetex}):</b> reads {@code paymentMethods} from a
+ * {@link FintrafficParking} and writes it back into the NeTEx output so that the
+ * field survives the export roundtrip.
+ */
+@Profile("fintraffic")
+@Component
+public class FintrafficParkingMapperContributor implements ParkingMapperContributor {
+
+    @Override
+    public void mapFromNetex(org.rutebanken.netex.model.Parking source,
+                             org.rutebanken.tiamat.model.Parking target,
+                             MappingContext context) {
+        var netexMethods = source.getPaymentMethods();
+        if (netexMethods == null || netexMethods.isEmpty()) {
+            return;
+        }
+        var targetMethods = target.getPaymentMethods();
+        targetMethods.clear();
+        for (var netexMethod : netexMethods) {
+            try {
+                targetMethods.add(PaymentMethodEnumeration.fromValue(netexMethod.value()));
+            } catch (IllegalArgumentException ignored) {
+                // skip unknown values
+            }
+        }
+    }
+
+    @Override
+    public void mapToNetex(org.rutebanken.tiamat.model.Parking source,
+                           org.rutebanken.netex.model.Parking target,
+                           MappingContext context) {
+        if (!(source instanceof FintrafficParking fp)) {
+            return;
+        }
+        var methods = fp.getPaymentMethods();
+        if (methods.isEmpty()) {
+            return;
+        }
+        var targetMethods = target.getPaymentMethods();
+        targetMethods.clear();
+        for (var method : methods) {
+            try {
+                targetMethods.add(org.rutebanken.netex.model.PaymentMethodEnumeration.fromValue(method.value()));
+            } catch (IllegalArgumentException ignored) {
+                // skip unknown values
+            }
+        }
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributor.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/importer/FintrafficParkingMapperContributor.java
@@ -40,6 +40,7 @@ public class FintrafficParkingMapperContributor implements ParkingMapperContribu
         mapPaymentMethodsFromNetex(source, target);
         mapInfoLinksFromNetex(source, target);
         mapVehicleEntrancesFromNetex(source, target);
+        mapLightingFromNetex(source, target);
     }
 
     @Override
@@ -52,6 +53,49 @@ public class FintrafficParkingMapperContributor implements ParkingMapperContribu
         mapPaymentMethodsToNetex(fp, target);
         mapInfoLinksToNetex(fp, target);
         mapVehicleEntrancesToNetex(fp, target);
+        mapLightingToNetex(fp, target);
+    }
+
+    // --- lighting ---
+
+    /**
+     * {@code Lighting} is declared on {@link org.rutebanken.netex.model.SiteElement_VersionStructure},
+     * an ancestor of NeTEx's {@link org.rutebanken.netex.model.Parking}, so it is a valid NeTEx
+     * element for parking (confirmed via {@code Parking.withLighting(LightingEnumeration)}).
+     * The core {@link org.rutebanken.tiamat.model.Parking#getLighting()}/{@code setLighting(...)}
+     * accessors are only overridden (non-transient) on {@link FintrafficParking}, so this
+     * contributor is the only place that carries the value across the NeTEx boundary in either
+     * direction — without it, lighting set via GraphQL/persisted in
+     * {@code parking_fintraffic_lighting} would silently be dropped from NeTEx export and the
+     * Fintraffic Read API output.
+     */
+    private void mapLightingFromNetex(org.rutebanken.netex.model.Parking source,
+                                       org.rutebanken.tiamat.model.Parking target) {
+        if (!(target instanceof FintrafficParking fp)) {
+            return;
+        }
+        var lighting = source.getLighting();
+        if (lighting == null) {
+            return;
+        }
+        try {
+            fp.setLighting(org.rutebanken.tiamat.model.LightingEnumeration.fromValue(lighting.value()));
+        } catch (IllegalArgumentException ignored) {
+            // unknown value — skip
+        }
+    }
+
+    private void mapLightingToNetex(FintrafficParking source,
+                                     org.rutebanken.netex.model.Parking target) {
+        var lighting = source.getLighting();
+        if (lighting == null) {
+            return;
+        }
+        try {
+            target.setLighting(org.rutebanken.netex.model.LightingEnumeration.fromValue(lighting.value()));
+        } catch (IllegalArgumentException ignored) {
+            // stored value no longer valid — skip
+        }
     }
 
     // --- paymentMethods ---

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficInfoLink.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficInfoLink.java
@@ -1,0 +1,72 @@
+package org.rutebanken.tiamat.ext.fintraffic.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.util.Objects;
+
+/**
+ * Embeddable value object for a single NeTEx {@code InfoLink} entry.
+ * <p>
+ * Persisted in the {@code parking_info_links} collection table owned by
+ * {@link FintrafficParking}.  Only the {@code uri} (the link target) and
+ * {@code typeOfInfoLink} (the first declared type from the NeTEx list) are
+ * stored.  {@code targetPlatform} is intentionally not persisted in this
+ * increment.
+ */
+@Embeddable
+public class FintrafficInfoLink {
+
+    @Column(name = "uri", nullable = false, length = 512)
+    private String uri;
+
+    /**
+     * Stores the first {@code typeOfInfoLink} value from the NeTEx element as a
+     * plain string (e.g. {@code "resource"}, {@code "info"}).  Nullable because
+     * the attribute is optional in the NeTEx schema.
+     */
+    @Column(name = "type_of_info_link", length = 64)
+    private String typeOfInfoLink;
+
+    public FintrafficInfoLink() {
+    }
+
+    public FintrafficInfoLink(String uri, String typeOfInfoLink) {
+        this.uri = uri;
+        this.typeOfInfoLink = typeOfInfoLink;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public String getTypeOfInfoLink() {
+        return typeOfInfoLink;
+    }
+
+    public void setTypeOfInfoLink(String typeOfInfoLink) {
+        this.typeOfInfoLink = typeOfInfoLink;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FintrafficInfoLink that)) return false;
+        return Objects.equals(uri, that.uri) &&
+               Objects.equals(typeOfInfoLink, that.typeOfInfoLink);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uri, typeOfInfoLink);
+    }
+
+    @Override
+    public String toString() {
+        return "FintrafficInfoLink{uri='" + uri + "', typeOfInfoLink='" + typeOfInfoLink + "'}";
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParking.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParking.java
@@ -1,0 +1,50 @@
+package org.rutebanken.tiamat.ext.fintraffic.model;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fintraffic extension of the core {@link Parking} entity.
+ * <p>
+ * Persists fields that are {@code @Transient} in the core model, using a
+ * separate collection table so Entur's core DDL remains unmodified.
+ * Activated when the {@code fintraffic} Spring profile is active via
+ * {@link FintrafficParkingEntityFactory}.
+ */
+@Entity
+@DiscriminatorValue("FintrafficParking")
+public class FintrafficParking extends Parking {
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(
+            name = "parking_payment_methods",
+            joinColumns = @JoinColumn(name = "parking_id")
+    )
+    @Column(name = "payment_method")
+    private List<PaymentMethodEnumeration> paymentMethods;
+
+    @Override
+    public List<PaymentMethodEnumeration> getPaymentMethods() {
+        if (paymentMethods == null) {
+            paymentMethods = new ArrayList<>();
+        }
+        return paymentMethods;
+    }
+
+    public void setPaymentMethods(List<PaymentMethodEnumeration> value) {
+        this.paymentMethods = value;
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParking.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParking.java
@@ -43,6 +43,13 @@ public class FintrafficParking extends Parking {
     )
     private List<FintrafficInfoLink> infoLinks;
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+            name = "parking_vehicle_entrances",
+            joinColumns = @JoinColumn(name = "parking_id")
+    )
+    private List<FintrafficParkingEntranceForVehicles> fintrafficVehicleEntrances;
+
     @Override
     public List<PaymentMethodEnumeration> getPaymentMethods() {
         if (paymentMethods == null) {
@@ -64,6 +71,17 @@ public class FintrafficParking extends Parking {
 
     public void setInfoLinks(List<FintrafficInfoLink> infoLinks) {
         this.infoLinks = infoLinks;
+    }
+
+    public List<FintrafficParkingEntranceForVehicles> getFintrafficVehicleEntrances() {
+        if (fintrafficVehicleEntrances == null) {
+            fintrafficVehicleEntrances = new ArrayList<>();
+        }
+        return fintrafficVehicleEntrances;
+    }
+
+    public void setFintrafficVehicleEntrances(List<FintrafficParkingEntranceForVehicles> vehicleEntrances) {
+        this.fintrafficVehicleEntrances = vehicleEntrances;
     }
 }
 

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParking.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParking.java
@@ -19,10 +19,10 @@ import java.util.List;
 /**
  * Fintraffic extension of the core {@link Parking} entity.
  * <p>
- * Persists fields that are {@code @Transient} in the core model. Scalar fields
- * (e.g. {@code lighting}) are added as columns on the shared {@code parking} table
- * (populated only for {@code dtype = 'FintrafficParking'} rows).  Collection fields
- * use separate collection tables so Entur's core DDL remains unmodified.
+ * Persists fields that are {@code @Transient} in the core model. All ext fields
+ * use separate collection tables so Entur's core DDL (the {@code parking} table) remains
+ * unmodified — this prevents Hibernate from selecting ext columns in core tests that do
+ * not run the Fintraffic Flyway migrations.
  * Activated when the {@code fintraffic} Spring profile is active via
  * {@link FintrafficParkingEntityFactory}.
  */
@@ -30,9 +30,14 @@ import java.util.List;
 @DiscriminatorValue("FintrafficParking")
 public class FintrafficParking extends Parking {
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+            name = "parking_fintraffic_lighting",
+            joinColumns = @JoinColumn(name = "parking_id")
+    )
     @Column(name = "lighting")
     @Enumerated(EnumType.STRING)
-    private LightingEnumeration lighting;
+    private List<LightingEnumeration> lightingList = new ArrayList<>();
 
     @ElementCollection(fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
@@ -59,12 +64,12 @@ public class FintrafficParking extends Parking {
 
     @Override
     public LightingEnumeration getLighting() {
-        return lighting;
+        return lightingList.isEmpty() ? null : lightingList.get(0);
     }
 
     @Override
     public void setLighting(LightingEnumeration value) {
-        this.lighting = value;
+        this.lightingList = value == null ? new ArrayList<>() : new ArrayList<>(List.of(value));
     }
 
     @Override

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParking.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParking.java
@@ -36,6 +36,13 @@ public class FintrafficParking extends Parking {
     @Column(name = "payment_method")
     private List<PaymentMethodEnumeration> paymentMethods;
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+            name = "parking_info_links",
+            joinColumns = @JoinColumn(name = "parking_id")
+    )
+    private List<FintrafficInfoLink> infoLinks;
+
     @Override
     public List<PaymentMethodEnumeration> getPaymentMethods() {
         if (paymentMethods == null) {
@@ -47,4 +54,16 @@ public class FintrafficParking extends Parking {
     public void setPaymentMethods(List<PaymentMethodEnumeration> value) {
         this.paymentMethods = value;
     }
+
+    public List<FintrafficInfoLink> getInfoLinks() {
+        if (infoLinks == null) {
+            infoLinks = new ArrayList<>();
+        }
+        return infoLinks;
+    }
+
+    public void setInfoLinks(List<FintrafficInfoLink> infoLinks) {
+        this.infoLinks = infoLinks;
+    }
 }
+

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParking.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParking.java
@@ -9,6 +9,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
+import org.rutebanken.tiamat.model.LightingEnumeration;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
 
@@ -18,14 +19,20 @@ import java.util.List;
 /**
  * Fintraffic extension of the core {@link Parking} entity.
  * <p>
- * Persists fields that are {@code @Transient} in the core model, using a
- * separate collection table so Entur's core DDL remains unmodified.
+ * Persists fields that are {@code @Transient} in the core model. Scalar fields
+ * (e.g. {@code lighting}) are added as columns on the shared {@code parking} table
+ * (populated only for {@code dtype = 'FintrafficParking'} rows).  Collection fields
+ * use separate collection tables so Entur's core DDL remains unmodified.
  * Activated when the {@code fintraffic} Spring profile is active via
  * {@link FintrafficParkingEntityFactory}.
  */
 @Entity
 @DiscriminatorValue("FintrafficParking")
 public class FintrafficParking extends Parking {
+
+    @Column(name = "lighting")
+    @Enumerated(EnumType.STRING)
+    private LightingEnumeration lighting;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
@@ -49,6 +56,16 @@ public class FintrafficParking extends Parking {
             joinColumns = @JoinColumn(name = "parking_id")
     )
     private List<FintrafficParkingEntranceForVehicles> fintrafficVehicleEntrances;
+
+    @Override
+    public LightingEnumeration getLighting() {
+        return lighting;
+    }
+
+    @Override
+    public void setLighting(LightingEnumeration value) {
+        this.lighting = value;
+    }
 
     @Override
     public List<PaymentMethodEnumeration> getPaymentMethods() {

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactory.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactory.java
@@ -12,9 +12,10 @@ import java.util.List;
  * Fintraffic override of {@link ParkingEntityFactory}.
  * <p>
  * Active when the {@code fintraffic} Spring profile is present. Tells the
- * core to instantiate {@link FintrafficParking} instead of {@link Parking},
- * and removes {@code paymentMethods} from the Orika exclusion list so the
- * field is mapped during NeTEx import and export.
+ * core to instantiate {@link FintrafficParking} instead of {@link Parking}.
+ * {@code paymentMethods} is kept in the exclusion list because the enum types
+ * differ between the NeTEx and Tiamat models; {@link org.rutebanken.tiamat.ext.fintraffic.importer.FintrafficParkingMapperContributor}
+ * handles the conversion instead.
  */
 @Primary
 @Component
@@ -33,7 +34,6 @@ public class FintrafficParkingEntityFactory extends ParkingEntityFactory {
 
     @Override
     public List<String> getMappingExclusions() {
-        // paymentMethods intentionally absent — it is persisted by FintrafficParking
-        return List.of("cardsAccepted", "currenciesAccepted", "accessModes");
+        return List.of("paymentMethods", "cardsAccepted", "currenciesAccepted", "accessModes");
     }
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactory.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactory.java
@@ -34,6 +34,6 @@ public class FintrafficParkingEntityFactory extends ParkingEntityFactory {
 
     @Override
     public List<String> getMappingExclusions() {
-        return List.of("paymentMethods", "cardsAccepted", "currenciesAccepted", "accessModes");
+        return List.of("paymentMethods", "cardsAccepted", "currenciesAccepted", "accessModes", "infoLinks");
     }
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactory.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactory.java
@@ -1,0 +1,39 @@
+package org.rutebanken.tiamat.ext.fintraffic.model;
+
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.factory.ParkingEntityFactory;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Fintraffic override of {@link ParkingEntityFactory}.
+ * <p>
+ * Active when the {@code fintraffic} Spring profile is present. Tells the
+ * core to instantiate {@link FintrafficParking} instead of {@link Parking},
+ * and removes {@code paymentMethods} from the Orika exclusion list so the
+ * field is mapped during NeTEx import and export.
+ */
+@Primary
+@Component
+@Profile("fintraffic")
+public class FintrafficParkingEntityFactory extends ParkingEntityFactory {
+
+    @Override
+    public Parking create() {
+        return new FintrafficParking();
+    }
+
+    @Override
+    public Class<? extends Parking> getEntityClass() {
+        return FintrafficParking.class;
+    }
+
+    @Override
+    public List<String> getMappingExclusions() {
+        // paymentMethods intentionally absent — it is persisted by FintrafficParking
+        return List.of("cardsAccepted", "currenciesAccepted", "accessModes");
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactory.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntityFactory.java
@@ -34,6 +34,6 @@ public class FintrafficParkingEntityFactory extends ParkingEntityFactory {
 
     @Override
     public List<String> getMappingExclusions() {
-        return List.of("paymentMethods", "cardsAccepted", "currenciesAccepted", "accessModes", "infoLinks");
+        return List.of("paymentMethods", "cardsAccepted", "currenciesAccepted", "accessModes", "infoLinks", "vehicleEntrances");
     }
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntranceForVehicles.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/model/FintrafficParkingEntranceForVehicles.java
@@ -1,0 +1,106 @@
+package org.rutebanken.tiamat.ext.fintraffic.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Embeddable value object for a single NeTEx {@code ParkingEntranceForVehicles} entry.
+ * <p>
+ * Persisted in the {@code parking_vehicle_entrances} collection table owned by
+ * {@link FintrafficParking}.  Only the scalar fields that Abzu can display and edit
+ * are stored; geometry (centroid) is omitted in this increment.
+ */
+@Embeddable
+public class FintrafficParkingEntranceForVehicles {
+
+    /** Human-readable label from the NeTEx {@code MultilingualString.value}. */
+    @Column(name = "label", length = 255)
+    private String label;
+
+    /**
+     * NeTEx {@code EntranceEnumeration} value string (e.g. {@code "door"}, {@code "gate"}).
+     * Nullable because the attribute is optional in the NeTEx schema.
+     */
+    @Column(name = "entrance_type", length = 64)
+    private String entranceType;
+
+    @Column(name = "width", precision = 10, scale = 2)
+    private BigDecimal width;
+
+    @Column(name = "height", precision = 10, scale = 2)
+    private BigDecimal height;
+
+    @Column(name = "is_entry")
+    private Boolean isEntry;
+
+    @Column(name = "is_exit")
+    private Boolean isExit;
+
+    @Column(name = "public_code", length = 64)
+    private String publicCode;
+
+    public FintrafficParkingEntranceForVehicles() {
+    }
+
+    public FintrafficParkingEntranceForVehicles(String label, String entranceType, BigDecimal width,
+                                                BigDecimal height, Boolean isEntry, Boolean isExit,
+                                                String publicCode) {
+        this.label = label;
+        this.entranceType = entranceType;
+        this.width = width;
+        this.height = height;
+        this.isEntry = isEntry;
+        this.isExit = isExit;
+        this.publicCode = publicCode;
+    }
+
+    public String getLabel() { return label; }
+    public void setLabel(String label) { this.label = label; }
+
+    public String getEntranceType() { return entranceType; }
+    public void setEntranceType(String entranceType) { this.entranceType = entranceType; }
+
+    public BigDecimal getWidth() { return width; }
+    public void setWidth(BigDecimal width) { this.width = width; }
+
+    public BigDecimal getHeight() { return height; }
+    public void setHeight(BigDecimal height) { this.height = height; }
+
+    public Boolean getIsEntry() { return isEntry; }
+    public void setIsEntry(Boolean isEntry) { this.isEntry = isEntry; }
+
+    public Boolean getIsExit() { return isExit; }
+    public void setIsExit(Boolean isExit) { this.isExit = isExit; }
+
+    public String getPublicCode() { return publicCode; }
+    public void setPublicCode(String publicCode) { this.publicCode = publicCode; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FintrafficParkingEntranceForVehicles that)) return false;
+        return Objects.equals(label, that.label) &&
+               Objects.equals(entranceType, that.entranceType) &&
+               Objects.equals(width, that.width) &&
+               Objects.equals(height, that.height) &&
+               Objects.equals(isEntry, that.isEntry) &&
+               Objects.equals(isExit, that.isExit) &&
+               Objects.equals(publicCode, that.publicCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(label, entranceType, width, height, isEntry, isExit, publicCode);
+    }
+
+    @Override
+    public String toString() {
+        return "FintrafficParkingEntranceForVehicles{" +
+               "label='" + label + "', entranceType='" + entranceType + "', " +
+               "width=" + width + ", height=" + height + ", " +
+               "isEntry=" + isEntry + ", isExit=" + isExit + ", publicCode='" + publicCode + "'}";
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingGraphQLTypeContributor.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingGraphQLTypeContributor.java
@@ -5,6 +5,7 @@ import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
+import org.rutebanken.netex.model.EntranceEnumeration;
 import org.rutebanken.netex.model.TypeOfInfolinkEnumeration;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
 import org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes;
@@ -12,6 +13,8 @@ import org.rutebanken.tiamat.rest.graphql.types.ParkingGraphQLTypeContributor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+import static graphql.Scalars.GraphQLBoolean;
+import static graphql.Scalars.GraphQLFloat;
 import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
@@ -23,6 +26,7 @@ import static graphql.schema.GraphQLInputObjectType.newInputObject;
  * <ul>
  *   <li>{@code paymentMethods} — list of {@link PaymentMethodEnumeration} values</li>
  *   <li>{@code infoLinks} — list of info link objects with {@code uri} and {@code typeOfInfoLink}</li>
+ *   <li>{@code vehicleEntrances} — list of vehicle entrance objects</li>
  * </ul>
  */
 @Profile("fintraffic")
@@ -37,12 +41,26 @@ public class FintrafficParkingGraphQLTypeContributor implements ParkingGraphQLTy
     static final String TYPE_OF_INFO_LINK_ENUM = "TypeOfInfoLinkEnum";
     static final String URI = "uri";
     static final String TYPE_OF_INFO_LINK = "typeOfInfoLink";
+    static final String VEHICLE_ENTRANCES = "vehicleEntrances";
+    static final String VEHICLE_ENTRANCE_OUTPUT_TYPE = "FintrafficVehicleEntrance";
+    static final String VEHICLE_ENTRANCE_INPUT_TYPE = "FintrafficVehicleEntranceInput";
+    static final String ENTRANCE_TYPE_ENUM = "EntranceTypeEnum";
+    static final String VEHICLE_ENTRANCE_LABEL = "label";
+    static final String ENTRANCE_TYPE = "entranceType";
+    static final String WIDTH = "width";
+    static final String HEIGHT = "height";
+    static final String IS_ENTRY = "isEntry";
+    static final String IS_EXIT = "isExit";
+    static final String PUBLIC_CODE = "publicCode";
 
     static final GraphQLEnumType paymentMethodEnum =
             CustomGraphQLTypes.createCustomEnumType(PAYMENT_METHOD_ENUM, PaymentMethodEnumeration.class);
 
     static final GraphQLEnumType typeOfInfoLinkEnum =
             CustomGraphQLTypes.createCustomEnumType(TYPE_OF_INFO_LINK_ENUM, TypeOfInfolinkEnumeration.class);
+
+    static final GraphQLEnumType entranceTypeEnum =
+            CustomGraphQLTypes.createCustomEnumType(ENTRANCE_TYPE_ENUM, EntranceEnumeration.class);
 
     static final GraphQLObjectType infoLinkOutputType = newObject()
             .name(INFO_LINK_OUTPUT_TYPE)
@@ -54,6 +72,28 @@ public class FintrafficParkingGraphQLTypeContributor implements ParkingGraphQLTy
             .name(INFO_LINK_INPUT_TYPE)
             .field(newInputObjectField().name(URI).type(GraphQLNonNull.nonNull(GraphQLString)))
             .field(newInputObjectField().name(TYPE_OF_INFO_LINK).type(typeOfInfoLinkEnum))
+            .build();
+
+    static final GraphQLObjectType vehicleEntranceOutputType = newObject()
+            .name(VEHICLE_ENTRANCE_OUTPUT_TYPE)
+            .field(newFieldDefinition().name(VEHICLE_ENTRANCE_LABEL).type(GraphQLString))
+            .field(newFieldDefinition().name(ENTRANCE_TYPE).type(entranceTypeEnum))
+            .field(newFieldDefinition().name(WIDTH).type(GraphQLFloat))
+            .field(newFieldDefinition().name(HEIGHT).type(GraphQLFloat))
+            .field(newFieldDefinition().name(IS_ENTRY).type(GraphQLBoolean))
+            .field(newFieldDefinition().name(IS_EXIT).type(GraphQLBoolean))
+            .field(newFieldDefinition().name(PUBLIC_CODE).type(GraphQLString))
+            .build();
+
+    static final GraphQLInputObjectType vehicleEntranceInputType = newInputObject()
+            .name(VEHICLE_ENTRANCE_INPUT_TYPE)
+            .field(newInputObjectField().name(VEHICLE_ENTRANCE_LABEL).type(GraphQLString))
+            .field(newInputObjectField().name(ENTRANCE_TYPE).type(entranceTypeEnum))
+            .field(newInputObjectField().name(WIDTH).type(GraphQLFloat))
+            .field(newInputObjectField().name(HEIGHT).type(GraphQLFloat))
+            .field(newInputObjectField().name(IS_ENTRY).type(GraphQLBoolean))
+            .field(newInputObjectField().name(IS_EXIT).type(GraphQLBoolean))
+            .field(newInputObjectField().name(PUBLIC_CODE).type(GraphQLString))
             .build();
 
     @Override
@@ -85,6 +125,35 @@ public class FintrafficParkingGraphQLTypeContributor implements ParkingGraphQLTy
                             })
                             .collect(java.util.stream.Collectors.toList());
                 }));
+        builder.field(newFieldDefinition()
+                .name(VEHICLE_ENTRANCES)
+                .type(new GraphQLList(vehicleEntranceOutputType))
+                .dataFetcher(env -> {
+                    Object source = env.getSource();
+                    if (!(source instanceof org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking fp)) {
+                        return java.util.List.of();
+                    }
+                    return fp.getFintrafficVehicleEntrances().stream()
+                            .map(entrance -> {
+                                var m = new java.util.HashMap<String, Object>();
+                                m.put(VEHICLE_ENTRANCE_LABEL, entrance.getLabel());
+                                if (entrance.getEntranceType() != null) {
+                                    try {
+                                        m.put(ENTRANCE_TYPE,
+                                                EntranceEnumeration.fromValue(entrance.getEntranceType()));
+                                    } catch (IllegalArgumentException ignored) {
+                                        // stored value no longer valid; skip
+                                    }
+                                }
+                                m.put(WIDTH, entrance.getWidth() != null ? entrance.getWidth().doubleValue() : null);
+                                m.put(HEIGHT, entrance.getHeight() != null ? entrance.getHeight().doubleValue() : null);
+                                m.put(IS_ENTRY, entrance.getIsEntry());
+                                m.put(IS_EXIT, entrance.getIsExit());
+                                m.put(PUBLIC_CODE, entrance.getPublicCode());
+                                return m;
+                            })
+                            .collect(java.util.stream.Collectors.toList());
+                }));
     }
 
     @Override
@@ -95,6 +164,9 @@ public class FintrafficParkingGraphQLTypeContributor implements ParkingGraphQLTy
         builder.field(newInputObjectField()
                 .name(INFO_LINKS)
                 .type(new GraphQLList(infoLinkInputType)));
+        builder.field(newInputObjectField()
+                .name(VEHICLE_ENTRANCES)
+                .type(new GraphQLList(vehicleEntranceInputType)));
     }
 }
 

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingGraphQLTypeContributor.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingGraphQLTypeContributor.java
@@ -7,6 +7,7 @@ import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
 import org.rutebanken.netex.model.EntranceEnumeration;
 import org.rutebanken.netex.model.TypeOfInfolinkEnumeration;
+import org.rutebanken.tiamat.model.LightingEnumeration;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
 import org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes;
 import org.rutebanken.tiamat.rest.graphql.types.ParkingGraphQLTypeContributor;
@@ -24,6 +25,7 @@ import static graphql.schema.GraphQLInputObjectType.newInputObject;
 /**
  * Contributes Fintraffic-specific fields to the GraphQL parking types:
  * <ul>
+ *   <li>{@code lighting} — {@link LightingEnumeration} scalar</li>
  *   <li>{@code paymentMethods} — list of {@link PaymentMethodEnumeration} values</li>
  *   <li>{@code infoLinks} — list of info link objects with {@code uri} and {@code typeOfInfoLink}</li>
  *   <li>{@code vehicleEntrances} — list of vehicle entrance objects</li>
@@ -33,6 +35,7 @@ import static graphql.schema.GraphQLInputObjectType.newInputObject;
 @Component
 public class FintrafficParkingGraphQLTypeContributor implements ParkingGraphQLTypeContributor {
 
+    static final String LIGHTING = "lighting";
     static final String PAYMENT_METHODS = "paymentMethods";
     static final String PAYMENT_METHOD_ENUM = "PaymentMethodEnum";
     static final String INFO_LINKS = "infoLinks";
@@ -99,6 +102,16 @@ public class FintrafficParkingGraphQLTypeContributor implements ParkingGraphQLTy
     @Override
     public void contributeToOutputType(GraphQLObjectType.Builder builder) {
         builder.field(newFieldDefinition()
+                .name(LIGHTING)
+                .type(CustomGraphQLTypes.lightingEnumType)
+                .dataFetcher(env -> {
+                    Object source = env.getSource();
+                    if (!(source instanceof org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking fp)) {
+                        return null;
+                    }
+                    return fp.getLighting();
+                }));
+        builder.field(newFieldDefinition()
                 .name(PAYMENT_METHODS)
                 .type(new GraphQLList(paymentMethodEnum)));
         builder.field(newFieldDefinition()
@@ -158,6 +171,9 @@ public class FintrafficParkingGraphQLTypeContributor implements ParkingGraphQLTy
 
     @Override
     public void contributeToInputType(GraphQLInputObjectType.Builder builder) {
+        builder.field(newInputObjectField()
+                .name(LIGHTING)
+                .type(CustomGraphQLTypes.lightingEnumType));
         builder.field(newInputObjectField()
                 .name(PAYMENT_METHODS)
                 .type(new GraphQLList(paymentMethodEnum)));

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingGraphQLTypeContributor.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingGraphQLTypeContributor.java
@@ -3,23 +3,27 @@ package org.rutebanken.tiamat.ext.fintraffic.rest.graphql;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLObjectType;
+import org.rutebanken.netex.model.TypeOfInfolinkEnumeration;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
 import org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes;
 import org.rutebanken.tiamat.rest.graphql.types.ParkingGraphQLTypeContributor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
+import static graphql.schema.GraphQLObjectType.newObject;
+import static graphql.schema.GraphQLInputObjectType.newInputObject;
 
 /**
  * Contributes Fintraffic-specific fields to the GraphQL parking types:
  * <ul>
- *   <li>{@code paymentMethods} — list of {@link PaymentMethodEnumeration} values,
- *       added to both the output (query) and input (mutation) parking types.</li>
+ *   <li>{@code paymentMethods} — list of {@link PaymentMethodEnumeration} values</li>
+ *   <li>{@code infoLinks} — list of info link objects with {@code uri} and {@code typeOfInfoLink}</li>
  * </ul>
- * This field is only present in the schema when the Fintraffic ext package is on the classpath.
  */
 @Profile("fintraffic")
 @Component
@@ -27,15 +31,60 @@ public class FintrafficParkingGraphQLTypeContributor implements ParkingGraphQLTy
 
     static final String PAYMENT_METHODS = "paymentMethods";
     static final String PAYMENT_METHOD_ENUM = "PaymentMethodEnum";
+    static final String INFO_LINKS = "infoLinks";
+    static final String INFO_LINK_OUTPUT_TYPE = "FintrafficInfoLink";
+    static final String INFO_LINK_INPUT_TYPE = "FintrafficInfoLinkInput";
+    static final String TYPE_OF_INFO_LINK_ENUM = "TypeOfInfoLinkEnum";
+    static final String URI = "uri";
+    static final String TYPE_OF_INFO_LINK = "typeOfInfoLink";
 
     static final GraphQLEnumType paymentMethodEnum =
             CustomGraphQLTypes.createCustomEnumType(PAYMENT_METHOD_ENUM, PaymentMethodEnumeration.class);
+
+    static final GraphQLEnumType typeOfInfoLinkEnum =
+            CustomGraphQLTypes.createCustomEnumType(TYPE_OF_INFO_LINK_ENUM, TypeOfInfolinkEnumeration.class);
+
+    static final GraphQLObjectType infoLinkOutputType = newObject()
+            .name(INFO_LINK_OUTPUT_TYPE)
+            .field(newFieldDefinition().name(URI).type(GraphQLNonNull.nonNull(GraphQLString)))
+            .field(newFieldDefinition().name(TYPE_OF_INFO_LINK).type(typeOfInfoLinkEnum))
+            .build();
+
+    static final GraphQLInputObjectType infoLinkInputType = newInputObject()
+            .name(INFO_LINK_INPUT_TYPE)
+            .field(newInputObjectField().name(URI).type(GraphQLNonNull.nonNull(GraphQLString)))
+            .field(newInputObjectField().name(TYPE_OF_INFO_LINK).type(typeOfInfoLinkEnum))
+            .build();
 
     @Override
     public void contributeToOutputType(GraphQLObjectType.Builder builder) {
         builder.field(newFieldDefinition()
                 .name(PAYMENT_METHODS)
                 .type(new GraphQLList(paymentMethodEnum)));
+        builder.field(newFieldDefinition()
+                .name(INFO_LINKS)
+                .type(new GraphQLList(infoLinkOutputType))
+                .dataFetcher(env -> {
+                    Object source = env.getSource();
+                    if (!(source instanceof org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking fp)) {
+                        return java.util.List.of();
+                    }
+                    return fp.getInfoLinks().stream()
+                            .map(link -> {
+                                var m = new java.util.HashMap<String, Object>();
+                                m.put(URI, link.getUri());
+                                if (link.getTypeOfInfoLink() != null) {
+                                    try {
+                                        m.put(TYPE_OF_INFO_LINK,
+                                                TypeOfInfolinkEnumeration.fromValue(link.getTypeOfInfoLink()));
+                                    } catch (IllegalArgumentException ignored) {
+                                        // stored value no longer valid; skip
+                                    }
+                                }
+                                return m;
+                            })
+                            .collect(java.util.stream.Collectors.toList());
+                }));
     }
 
     @Override
@@ -43,5 +92,9 @@ public class FintrafficParkingGraphQLTypeContributor implements ParkingGraphQLTy
         builder.field(newInputObjectField()
                 .name(PAYMENT_METHODS)
                 .type(new GraphQLList(paymentMethodEnum)));
+        builder.field(newInputObjectField()
+                .name(INFO_LINKS)
+                .type(new GraphQLList(infoLinkInputType)));
     }
 }
+

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingGraphQLTypeContributor.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingGraphQLTypeContributor.java
@@ -1,0 +1,47 @@
+package org.rutebanken.tiamat.ext.fintraffic.rest.graphql;
+
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLObjectType;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+import org.rutebanken.tiamat.rest.graphql.types.CustomGraphQLTypes;
+import org.rutebanken.tiamat.rest.graphql.types.ParkingGraphQLTypeContributor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
+
+/**
+ * Contributes Fintraffic-specific fields to the GraphQL parking types:
+ * <ul>
+ *   <li>{@code paymentMethods} — list of {@link PaymentMethodEnumeration} values,
+ *       added to both the output (query) and input (mutation) parking types.</li>
+ * </ul>
+ * This field is only present in the schema when the Fintraffic ext package is on the classpath.
+ */
+@Profile("fintraffic")
+@Component
+public class FintrafficParkingGraphQLTypeContributor implements ParkingGraphQLTypeContributor {
+
+    static final String PAYMENT_METHODS = "paymentMethods";
+    static final String PAYMENT_METHOD_ENUM = "PaymentMethodEnum";
+
+    static final GraphQLEnumType paymentMethodEnum =
+            CustomGraphQLTypes.createCustomEnumType(PAYMENT_METHOD_ENUM, PaymentMethodEnumeration.class);
+
+    @Override
+    public void contributeToOutputType(GraphQLObjectType.Builder builder) {
+        builder.field(newFieldDefinition()
+                .name(PAYMENT_METHODS)
+                .type(new GraphQLList(paymentMethodEnum)));
+    }
+
+    @Override
+    public void contributeToInputType(GraphQLInputObjectType.Builder builder) {
+        builder.field(newInputObjectField()
+                .name(PAYMENT_METHODS)
+                .type(new GraphQLList(paymentMethodEnum)));
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingUpdater.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingUpdater.java
@@ -7,6 +7,7 @@ import jakarta.persistence.PersistenceContext;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParkingEntranceForVehicles;
+import org.rutebanken.tiamat.model.LightingEnumeration;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
 import org.rutebanken.tiamat.rest.graphql.fetchers.ParkingUpdater;
@@ -20,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.INFO_LINKS;
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.LIGHTING;
 import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.PAYMENT_METHODS;
 import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.TYPE_OF_INFO_LINK;
 import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.URI;
@@ -69,6 +71,12 @@ public class FintrafficParkingUpdater extends ParkingUpdater {
         }
 
         boolean changed = false;
+
+        LightingEnumeration lighting = (LightingEnumeration) input.get(LIGHTING);
+        if (lighting != null && !lighting.equals(target.getLighting())) {
+            target.setLighting(lighting);
+            changed = true;
+        }
 
         @SuppressWarnings("unchecked")
         List<PaymentMethodEnumeration> incomingMethods = (List<PaymentMethodEnumeration>) input.get(PAYMENT_METHODS);
@@ -150,6 +158,7 @@ public class FintrafficParkingUpdater extends ParkingUpdater {
     @Override
     protected void preserveExtendedFields(Parking existingVersion, Parking copy) {
         if (existingVersion instanceof FintrafficParking source && copy instanceof FintrafficParking target) {
+            target.setLighting(source.getLighting());
             target.setPaymentMethods(new ArrayList<>(source.getPaymentMethods()));
             target.setInfoLinks(new ArrayList<>(source.getInfoLinks()));
             target.setFintrafficVehicleEntrances(new ArrayList<>(source.getFintrafficVehicleEntrances()));

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingUpdater.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingUpdater.java
@@ -13,6 +13,7 @@ import org.rutebanken.tiamat.rest.graphql.fetchers.ParkingUpdater;
 import org.springframework.context.annotation.Profile;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -124,8 +125,8 @@ public class FintrafficParkingUpdater extends ParkingUpdater {
                 converted.add(new FintrafficParkingEntranceForVehicles(
                         labelObj != null ? labelObj.toString() : null,
                         entranceTypeStr,
-                        widthObj instanceof java.math.BigDecimal bd ? bd : null,
-                        heightObj instanceof java.math.BigDecimal bd ? bd : null,
+                        toBigDecimal(widthObj),
+                        toBigDecimal(heightObj),
                         isEntryObj instanceof Boolean b ? b : null,
                         isExitObj instanceof Boolean b ? b : null,
                         publicCodeObj != null ? publicCodeObj.toString() : null
@@ -154,5 +155,14 @@ public class FintrafficParkingUpdater extends ParkingUpdater {
             target.setFintrafficVehicleEntrances(new ArrayList<>(source.getFintrafficVehicleEntrances()));
         }
     }
-}
 
+    private static BigDecimal toBigDecimal(Object value) {
+        if (value instanceof BigDecimal bd) {
+            return bd;
+        }
+        if (value instanceof Number number) {
+            return BigDecimal.valueOf(number.doubleValue());
+        }
+        return null;
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingUpdater.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingUpdater.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParkingEntranceForVehicles;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
 import org.rutebanken.tiamat.rest.graphql.fetchers.ParkingUpdater;
@@ -21,6 +22,14 @@ import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkin
 import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.PAYMENT_METHODS;
 import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.TYPE_OF_INFO_LINK;
 import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.URI;
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.VEHICLE_ENTRANCES;
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.ENTRANCE_TYPE;
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.VEHICLE_ENTRANCE_LABEL;
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.WIDTH;
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.HEIGHT;
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.IS_ENTRY;
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.IS_EXIT;
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.PUBLIC_CODE;
 
 /**
  * Fintraffic extension of {@link ParkingUpdater} that handles the
@@ -92,6 +101,42 @@ public class FintrafficParkingUpdater extends ParkingUpdater {
             }
         }
 
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> incomingEntrances = (List<Map<String, Object>>) input.get(VEHICLE_ENTRANCES);
+        if (incomingEntrances != null) {
+            List<FintrafficParkingEntranceForVehicles> converted = new ArrayList<>();
+            for (Map<String, Object> entranceInput : incomingEntrances) {
+                Object labelObj = entranceInput.get(VEHICLE_ENTRANCE_LABEL);
+                Object typeObj = entranceInput.get(ENTRANCE_TYPE);
+                Object widthObj = entranceInput.get(WIDTH);
+                Object heightObj = entranceInput.get(HEIGHT);
+                Object isEntryObj = entranceInput.get(IS_ENTRY);
+                Object isExitObj = entranceInput.get(IS_EXIT);
+                Object publicCodeObj = entranceInput.get(PUBLIC_CODE);
+
+                String entranceTypeStr = null;
+                if (typeObj instanceof org.rutebanken.netex.model.EntranceEnumeration enumVal) {
+                    entranceTypeStr = enumVal.value();
+                } else if (typeObj != null) {
+                    entranceTypeStr = typeObj.toString();
+                }
+
+                converted.add(new FintrafficParkingEntranceForVehicles(
+                        labelObj != null ? labelObj.toString() : null,
+                        entranceTypeStr,
+                        widthObj instanceof java.math.BigDecimal bd ? bd : null,
+                        heightObj instanceof java.math.BigDecimal bd ? bd : null,
+                        isEntryObj instanceof Boolean b ? b : null,
+                        isExitObj instanceof Boolean b ? b : null,
+                        publicCodeObj != null ? publicCodeObj.toString() : null
+                ));
+            }
+            if (!converted.equals(target.getFintrafficVehicleEntrances())) {
+                target.setFintrafficVehicleEntrances(converted);
+                changed = true;
+            }
+        }
+
         return changed;
     }
 
@@ -106,6 +151,7 @@ public class FintrafficParkingUpdater extends ParkingUpdater {
         if (existingVersion instanceof FintrafficParking source && copy instanceof FintrafficParking target) {
             target.setPaymentMethods(new ArrayList<>(source.getPaymentMethods()));
             target.setInfoLinks(new ArrayList<>(source.getInfoLinks()));
+            target.setFintrafficVehicleEntrances(new ArrayList<>(source.getFintrafficVehicleEntrances()));
         }
     }
 }

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingUpdater.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingUpdater.java
@@ -1,0 +1,91 @@
+package org.rutebanken.tiamat.ext.fintraffic.rest.graphql;
+
+import graphql.schema.DataFetchingEnvironment;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
+import org.rutebanken.tiamat.rest.graphql.fetchers.ParkingUpdater;
+import org.springframework.context.annotation.Profile;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.PAYMENT_METHODS;
+
+/**
+ * Fintraffic extension of {@link ParkingUpdater} that handles the
+ * {@code paymentMethods} input field contributed by
+ * {@link FintrafficParkingGraphQLTypeContributor}.
+ */
+@Profile("fintraffic")
+@Transactional
+public class FintrafficParkingUpdater extends ParkingUpdater {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /**
+     * Extends the parent's {@code get()} to flush pending collection inserts and
+     * refresh entities before the transaction closes.  This ensures that
+     * {@code @ElementCollection} fields (e.g. {@code paymentMethods}) on newly
+     * persisted {@link FintrafficParking} instances are fully loaded from the
+     * database and not left in Hibernate's "pending-insert" state, which would
+     * cause them to appear empty when the GraphQL response is serialised.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object get(DataFetchingEnvironment environment) {
+        List<Parking> parkings = (List<Parking>) super.get(environment);
+        if (parkings != null) {
+            entityManager.flush();
+            parkings.stream()
+                    .filter(Objects::nonNull)
+                    .filter(entityManager::contains)
+                    .forEach(entityManager::refresh);
+        }
+        return parkings;
+    }
+
+    @Override
+    protected boolean populateExtendedFields(Map input, Parking parking) {
+        if (!(parking instanceof FintrafficParking target)) {
+            return false;
+        }
+
+        @SuppressWarnings("unchecked")
+        List<PaymentMethodEnumeration> incoming = (List<PaymentMethodEnumeration>) input.get(PAYMENT_METHODS);
+        if (incoming == null) {
+            return false;
+        }
+
+        if (incoming.equals(target.getPaymentMethods())) {
+            return false;
+        }
+
+        target.setPaymentMethods(List.copyOf(incoming));
+        return true;
+    }
+
+    /**
+     * Copies extended fields that Orika does not transfer from the existing version into
+     * the newly created version copy.  Called by the parent's update path immediately
+     * after {@link org.rutebanken.tiamat.versioning.VersionCreator#createCopy}, before
+     * {@link #populateExtendedFields} overwrites them with the GraphQL input values.
+     * <p>
+     * This ensures that fields omitted from the update mutation (e.g. the caller did not
+     * include {@code paymentMethods} in the input) retain their current values rather than
+     * being silently reset to the default.
+     */
+    @Override
+    protected void preserveExtendedFields(Parking existingVersion, Parking copy) {
+        if (existingVersion instanceof FintrafficParking source && copy instanceof FintrafficParking target) {
+            target.setPaymentMethods(new ArrayList<>(source.getPaymentMethods()));
+        }
+    }
+}

--- a/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingUpdater.java
+++ b/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/rest/graphql/FintrafficParkingUpdater.java
@@ -4,6 +4,7 @@ import graphql.schema.DataFetchingEnvironment;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficInfoLink;
 import org.rutebanken.tiamat.ext.fintraffic.model.FintrafficParking;
 import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.PaymentMethodEnumeration;
@@ -16,11 +17,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.INFO_LINKS;
 import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.PAYMENT_METHODS;
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.TYPE_OF_INFO_LINK;
+import static org.rutebanken.tiamat.ext.fintraffic.rest.graphql.FintrafficParkingGraphQLTypeContributor.URI;
 
 /**
  * Fintraffic extension of {@link ParkingUpdater} that handles the
- * {@code paymentMethods} input field contributed by
+ * {@code paymentMethods} and {@code infoLinks} input fields contributed by
  * {@link FintrafficParkingGraphQLTypeContributor}.
  */
 @Profile("fintraffic")
@@ -32,11 +36,7 @@ public class FintrafficParkingUpdater extends ParkingUpdater {
 
     /**
      * Extends the parent's {@code get()} to flush pending collection inserts and
-     * refresh entities before the transaction closes.  This ensures that
-     * {@code @ElementCollection} fields (e.g. {@code paymentMethods}) on newly
-     * persisted {@link FintrafficParking} instances are fully loaded from the
-     * database and not left in Hibernate's "pending-insert" state, which would
-     * cause them to appear empty when the GraphQL response is serialised.
+     * refresh entities before the transaction closes.
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -58,18 +58,41 @@ public class FintrafficParkingUpdater extends ParkingUpdater {
             return false;
         }
 
+        boolean changed = false;
+
         @SuppressWarnings("unchecked")
-        List<PaymentMethodEnumeration> incoming = (List<PaymentMethodEnumeration>) input.get(PAYMENT_METHODS);
-        if (incoming == null) {
-            return false;
+        List<PaymentMethodEnumeration> incomingMethods = (List<PaymentMethodEnumeration>) input.get(PAYMENT_METHODS);
+        if (incomingMethods != null && !incomingMethods.equals(target.getPaymentMethods())) {
+            target.setPaymentMethods(List.copyOf(incomingMethods));
+            changed = true;
         }
 
-        if (incoming.equals(target.getPaymentMethods())) {
-            return false;
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> incomingLinks = (List<Map<String, Object>>) input.get(INFO_LINKS);
+        if (incomingLinks != null) {
+            List<FintrafficInfoLink> converted = new ArrayList<>();
+            for (Map<String, Object> linkInput : incomingLinks) {
+                Object uriObj = linkInput.get(URI);
+                if (uriObj == null) {
+                    continue;
+                }
+                String uri = uriObj.toString();
+                Object typeObj = linkInput.get(TYPE_OF_INFO_LINK);
+                String type = null;
+                if (typeObj instanceof org.rutebanken.netex.model.TypeOfInfolinkEnumeration enumVal) {
+                    type = enumVal.value();
+                } else if (typeObj != null) {
+                    type = typeObj.toString();
+                }
+                converted.add(new FintrafficInfoLink(uri, type));
+            }
+            if (!converted.equals(target.getInfoLinks())) {
+                target.setInfoLinks(converted);
+                changed = true;
+            }
         }
 
-        target.setPaymentMethods(List.copyOf(incoming));
-        return true;
+        return changed;
     }
 
     /**
@@ -77,15 +100,13 @@ public class FintrafficParkingUpdater extends ParkingUpdater {
      * the newly created version copy.  Called by the parent's update path immediately
      * after {@link org.rutebanken.tiamat.versioning.VersionCreator#createCopy}, before
      * {@link #populateExtendedFields} overwrites them with the GraphQL input values.
-     * <p>
-     * This ensures that fields omitted from the update mutation (e.g. the caller did not
-     * include {@code paymentMethods} in the input) retain their current values rather than
-     * being silently reset to the default.
      */
     @Override
     protected void preserveExtendedFields(Parking existingVersion, Parking copy) {
         if (existingVersion instanceof FintrafficParking source && copy instanceof FintrafficParking target) {
             target.setPaymentMethods(new ArrayList<>(source.getPaymentMethods()));
+            target.setInfoLinks(new ArrayList<>(source.getInfoLinks()));
         }
     }
 }
+


### PR DESCRIPTION
> **Note:** This implementation would benefit from a proper multi-module Maven structure that separates the Fintraffic extension from the core module. Without module isolation, `FintrafficParking` is always on the Hibernate classpath even in core test contexts, requiring the extension to use separate collection tables (rather than simpler scalar columns) to avoid selecting non-existent columns in core tests. See the related proposal: [#416 – refactor: introduce multi-module Maven structure (Phase 1)](https://github.com/entur/tiamat/pull/416).

> **Note:** This change is proposed as a Fintraffic extension rather than a core change because `SiteElement.lighting` is `@Transient` in the core JPA model — there is no existing persistence for `Parking.lighting`. If adding a `lighting` column to the core `parking` table is acceptable, the implementation can be easily moved to `src/main/` (add `@Column` directly on a `Parking` subclass or override in `Parking`, add a core Flyway migration, and wire in `ParkingUpdater` / `CustomGraphQLTypes` — no structural changes needed).

> **Note:** This PR depends on the vehicle entrances ext PR (`feat/ext-fintraffic-vehicle-entrances`) being merged first.

### Summary

- Exposes `lighting` as a readable and mutable field on the parking GraphQL types when the `fintraffic` Spring profile is active.
- Adds a persistent `parking_fintraffic_lighting` collection table via ext Flyway migration V6.
- Handles `lighting` in `FintrafficParkingUpdater`: written on mutation, preserved on version update when not included in input.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

`SiteElement.lighting` is annotated `@Transient` in the core model, so `Parking.lighting` is never written to or read from the database. This PR addresses the gap for the Fintraffic deployment by:

- Subclassing `Parking` as `FintrafficParking` (already in place) and adding a `lightingList` field mapped via `@ElementCollection` to a separate `parking_fintraffic_lighting` collection table (same pattern as `paymentMethods`, `infoLinks`, `vehicleEntrances`). Using a separate table prevents Hibernate from selecting an ext column in core tests that do not run the Fintraffic Flyway migrations.
- Running a Flyway Java migration (`V6__FintrafficParkingLighting`) to create the `parking_fintraffic_lighting` table.
- Wiring `lighting` into `FintrafficParkingGraphQLTypeContributor` (output + input) using the existing `CustomGraphQLTypes.lightingEnumType`.
- Reading and writing the field in `FintrafficParkingUpdater.populateExtendedFields` / `preserveExtendedFields`.

The `LightingEnumeration` Java enum and `lightingEnumType` GraphQL enum type already exist in core and are reused unchanged.

### Unit tests

Three integration tests added to `FintrafficGraphQLParkingIntegrationTest`:

- `mutateParking_lighting_persistedAndReturnedInResponse` — mutates parking with `lighting: wellLit`, asserts mutation response and DB entity.
- `mutateParking_lighting_persistedAndReadBack_viaQuery` — separate `parking(id: …)` query after mutation proves the value survives a round-trip, not just an echo.
- `mutateParking_updateWithoutLighting_preservesExistingLighting` — update mutation without `lighting` field leaves the previously stored value intact.

All tests pass.

### Documentation

`FintrafficParking` Javadoc updated to describe the separate-table pattern and its rationale.