### PR TITLE
Resets generated id state on every live hazelcast instance in tests

### DIFF
--- a/src/test/java/org/rutebanken/tiamat/TiamatIntegrationTest.java
+++ b/src/test/java/org/rutebanken/tiamat/TiamatIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package org.rutebanken.tiamat;
 
+import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -62,6 +63,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.rutebanken.tiamat.netex.id.GaplessIdGeneratorService.INITIAL_LAST_ID;
 
@@ -235,10 +237,18 @@ public abstract class TiamatIntegrationTest {
         EntityTransaction transaction = entityManager.getTransaction();
         transaction.begin();
 
-        generatedIdState.getRegisteredEntityNames().forEach(entityName -> {
-            hazelcastInstance.getQueue(entityName).clear();
-            generatedIdState.setLastIdForEntity(entityName, INITIAL_LAST_ID);
-            generatedIdState.getClaimedIdListForEntity(entityName).clear();
+        // Several Spring test contexts stay alive in the same JVM, and each one builds its own
+        // HazelcastInstance. The GaplessIdGeneratorService that actually assigns ids is not
+        // necessarily the one from this test's context, so resetting only the injected instance
+        // silently leaves the generator's pre-fetched id queue (DEFAULT_FETCH_SIZE entries)
+        // untouched. Reset the id state on every live instance.
+        Hazelcast.getAllHazelcastInstances().forEach(instance -> {
+            Set<String> registeredEntityNames = instance.getSet(GeneratedIdState.ENTITY_NAMES_REGISTERED);
+            registeredEntityNames.forEach(entityName -> {
+                instance.getQueue(entityName).clear();
+                instance.getMap(GeneratedIdState.LAST_IDS_FOR_ENTITY).put(entityName, INITIAL_LAST_ID);
+                instance.getSet(GeneratedIdState.CLAIMED_IDS_FOR_ENTITY_PREFIX + "-" + entityName).clear();
+            });
         });
 
         int updated = entityManager.createNativeQuery("DELETE FROM id_generator").executeUpdate();


### PR DESCRIPTION
### Summary

`TiamatIntegrationTest.clearIdGeneration()` has never actually reset the NeTEx id generator's state. It cleared the id structures on the `HazelcastInstance` injected into the test's own Spring context, but several test contexts stay alive in the same JVM and each builds its own instance. The `GaplessIdGeneratorService` that actually assigns ids is frequently bound to a different one, so its pre-fetched queue of `DEFAULT_FETCH_SIZE` (2000) ids survived the reset and ids leaked across test classes.

This fix resets the id state on every live Hazelcast instance instead of only the injected one.

### How it was found

While bringing #318 up to date with master, `GroupOfStopPlacesSaverServiceTest.saveNewVersion` began failing deterministically in the full suite while passing in isolation:

```
expected: "NSR:PurposeOfGrouping:1"
 but was: "NSR:PurposeOfGrouping:3"
```

Instrumenting both sides showed the harness and the generator reading different instances:

```
TiamatIntegrationTest     : hz=trusting_robinson  purposeQueueSize=0
GaplessIdGeneratorService : hz=sweet_robinson     queueAfter=1998  lastId=2000
```

The harness cleared an empty queue on the wrong instance while the generator popped from a 2000-id batch on another. `lastId=2000` matches `GaplessIdGeneratorService.DEFAULT_FETCH_SIZE` exactly.

This is a long-standing latent problem, not a regression. It only became visible because #318 adds test contexts, taking the JVM from two Hazelcast instances to four, which changed which instance the generator bound to.

### Impact

Id isolation between integration test classes has been broken repo-wide, not just for `PurposeOfGrouping`. Any test asserting on absolute generated ids has been passing on luck of execution order.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Unit tests

Test-only change; no production code touched. Full suite run locally against a PostGIS Testcontainer:

| Branch | Result |
|---|---|
| This branch (master + fix) | 1018 tests, 0 failures |
| master (baseline, unmodified) | 1018 tests, 0 failures |
| #318 branch with this fix | 1148 tests, 0 failures (twice, clean runs) |
| #318 branch without this fix | 1148 tests, 1 failure |

Verified on master as well as on #318, since on master the bug does not manifest and the change is purely additional cleanup there.

### Notes

Split out of #318 so it can land independently — the write API only exposed this; it did not cause it.
