### PR TITLE
Extracts stop place mutation validation into a shared validator

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/StopPlaceUpdater.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/fetchers/StopPlaceUpdater.java
@@ -16,16 +16,14 @@
 package org.rutebanken.tiamat.rest.graphql.fetchers;
 
 import com.google.api.client.util.Preconditions;
-import com.google.common.base.Strings;
 import graphql.language.Field;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.rutebanken.tiamat.lock.MutateLock;
-import org.rutebanken.tiamat.model.ModificationEnumeration;
 import org.rutebanken.tiamat.model.StopPlace;
-import org.rutebanken.tiamat.repository.StopPlaceRepository;
 import org.rutebanken.tiamat.rest.graphql.helpers.CleanupHelper;
 import org.rutebanken.tiamat.rest.graphql.mappers.StopPlaceMapper;
+import org.rutebanken.tiamat.rest.validation.StopPlaceMutationValidator;
 import org.rutebanken.tiamat.versioning.VersionCreator;
 import org.rutebanken.tiamat.versioning.save.StopPlaceVersionedSaverService;
 import org.slf4j.Logger;
@@ -58,10 +56,10 @@ class StopPlaceUpdater implements DataFetcher {
     private StopPlaceVersionedSaverService stopPlaceVersionedSaverService;
 
     @Autowired
-    private StopPlaceRepository stopPlaceRepository;
+    private StopPlaceMapper stopPlaceMapper;
 
     @Autowired
-    private StopPlaceMapper stopPlaceMapper;
+    private StopPlaceMutationValidator stopPlaceMutationValidator;
 
     @Autowired
     private MutateLock mutateLock;
@@ -91,7 +89,7 @@ class StopPlaceUpdater implements DataFetcher {
 
     private StopPlace createOrUpdateStopPlace(DataFetchingEnvironment environment, boolean mutateParent) {
         StopPlace updatedStopPlace;
-        StopPlace existingVersion = null;
+        StopPlace existingStopPlace = null;
 
         Map input = environment.getArgument(OUTPUT_TYPE_STOPPLACE);
         if (input == null) {
@@ -105,24 +103,8 @@ class StopPlaceUpdater implements DataFetcher {
 
                 logger.info("About to update StopPlace {}", netexId);
 
-                existingVersion = findAndVerify(netexId);
-
-                if (existingVersion.getModificationEnumeration() != null && existingVersion.getModificationEnumeration().equals(ModificationEnumeration.DELETE)) {
-                    throw new IllegalArgumentException("Attempting to update/reactivate terminated StopPlace: " + existingVersion);
-                }
-
-                if (mutateParent) {
-                    Preconditions.checkArgument(existingVersion.isParentStopPlace(),
-                            "Attempting to update StopPlace as parent [id = %s], but StopPlace is not a parent", netexId);
-                } else {
-                    Preconditions.checkArgument(!existingVersion.isParentStopPlace(),
-                            "Attempting to update parent StopPlace [id = %s] with incorrect mutation. Use %s", netexId, MUTATE_PARENT_STOPPLACE);
-
-                    Preconditions.checkArgument(existingVersion.getParentSiteRef() == null,
-                            "Attempting to update stop place which has parent [id = %s]. Edit the parent instead. (Parent %s)", netexId, existingVersion.getParentSiteRef());
-                }
-
-                updatedStopPlace = versionCreator.createCopy(existingVersion, StopPlace.class);
+                existingStopPlace = stopPlaceMutationValidator.validateStopPlaceUpdate(netexId, mutateParent);
+                updatedStopPlace = versionCreator.createCopy(existingStopPlace, StopPlace.class);
 
             } else {
                 Preconditions.checkArgument(!mutateParent,
@@ -144,17 +126,15 @@ class StopPlaceUpdater implements DataFetcher {
                 }
 
                 if (hasValuesChanged) {
-                    if (updatedStopPlace.getName() == null || Strings.isNullOrEmpty(updatedStopPlace.getName().getValue())) {
-                        throw new IllegalArgumentException("Updated stop place must have name set: " + updatedStopPlace);
-                    }
+                    stopPlaceMutationValidator.validateStopPlaceName(updatedStopPlace);
 
-                    updatedStopPlace = stopPlaceVersionedSaverService.saveNewVersion(existingVersion, updatedStopPlace, childStopsUpdated);
+                    updatedStopPlace = stopPlaceVersionedSaverService.saveNewVersion(existingStopPlace, updatedStopPlace, childStopsUpdated);
 
                     return updatedStopPlace;
                 }
             }
         }
-        return existingVersion;
+        return existingStopPlace;
     }
 
     private Set<String> handleChildStops(Map input, StopPlace updatedParentStopPlace) {
@@ -174,10 +154,10 @@ class StopPlaceUpdater implements DataFetcher {
 
                 logger.info("Finding existing child stop place from parent: {}", updatedParentStopPlace.getNetexId());
                 StopPlace existingChildStopPlace = updatedParentStopPlace.getChildren().stream().filter(c -> c.getNetexId().equals(childNetexId)).findFirst().orElse(null);
-                verifyStopPlaceNotNull(existingChildStopPlace, childNetexId);
+                stopPlaceMutationValidator.verifyStopPlaceNotNull(existingChildStopPlace, childNetexId);
 
                 // Next line is not strictly required. As the child will always belong to the parent.
-                verifyCorrectParentSet(existingChildStopPlace, updatedParentStopPlace);
+                stopPlaceMutationValidator.validateChildBelongsToParent(existingChildStopPlace, updatedParentStopPlace);
 
                 logger.info("Populating changes for child stop {} (parent: {})", childNetexId, updatedParentStopPlace.getNetexId());
                 boolean wasUpdated = stopPlaceMapper.populateStopPlaceFromInput((Map) childStopMap, existingChildStopPlace);;
@@ -190,30 +170,5 @@ class StopPlaceUpdater implements DataFetcher {
             logger.info("Applied changes for {} child stops. Parent stop contains {} child stops", childStopsUpdated.size(), updatedParentStopPlace.getChildren().size());
         }
         return childStopsUpdated;
-    }
-
-    private StopPlace findAndVerify(String netexId) {
-        StopPlace existingStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(netexId);
-        verifyStopPlaceNotNull(existingStopPlace, netexId);
-        return existingStopPlace;
-    }
-
-    private void verifyStopPlaceNotNull(StopPlace existingStopPlace, String netexId) {
-        Preconditions.checkArgument(existingStopPlace != null, "Attempting to update StopPlace [id = %s], but StopPlace does not exist.", netexId);
-    }
-
-    private void verifyCorrectParentSet(StopPlace existingChildStop, StopPlace existingParentStop) {
-        Preconditions.checkArgument(existingChildStop.getParentSiteRef() != null,
-                "Attempting to update StopPlace child [id = %s], but it does not belong to any parent.", existingChildStop.getNetexId());
-
-        Preconditions.checkArgument(existingChildStop.getParentSiteRef().getRef().equals(existingParentStop.getNetexId()),
-                "Attempting to update StopPlace child [id = %s], but it does not belong to parent %s.", existingChildStop.getNetexId(), existingParentStop.getNetexId());
-
-        Preconditions.checkArgument(existingChildStop.getParentSiteRef().getVersion().equals(String.valueOf(existingParentStop.getVersion())),
-                "Attempting to update StopPlace child [id = %s], but it does not refer to parent %s in correct version: %s.",
-                existingChildStop.getNetexId(),
-                existingParentStop.getNetexId(),
-                existingParentStop.getVersion());
-
     }
 }

--- a/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/StopPlaceMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/graphql/mappers/StopPlaceMapper.java
@@ -21,7 +21,6 @@ import org.rutebanken.tiamat.model.BusSubmodeEnumeration;
 import org.rutebanken.tiamat.model.FunicularSubmodeEnumeration;
 import org.rutebanken.tiamat.model.InterchangeWeightingEnumeration;
 import org.rutebanken.tiamat.model.MetroSubmodeEnumeration;
-import org.rutebanken.tiamat.model.PostalAddress;
 import org.rutebanken.tiamat.model.PrivateCodeStructure;
 import org.rutebanken.tiamat.model.RailSubmodeEnumeration;
 import org.rutebanken.tiamat.model.SiteFacilitySet;
@@ -62,31 +61,12 @@ import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.URL;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VALID_BETWEEN;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.VALUE;
 import static org.rutebanken.tiamat.rest.graphql.GraphQLNames.WEIGHTING;
+import static org.rutebanken.tiamat.rest.validation.StopPlaceMutationValidator.validateStopPlaceTypeForTransportMode;
 
 @Component
 public class StopPlaceMapper {
 
     private static final Logger logger = LoggerFactory.getLogger(StopPlaceMapper.class);
-
-    private static final Map<VehicleModeEnumeration, Set<StopTypeEnumeration>> VALID_STOP_TYPES_FOR_MODE;
-
-    static {
-        Map<VehicleModeEnumeration, Set<StopTypeEnumeration>> map = new EnumMap<>(VehicleModeEnumeration.class);
-        map.put(VehicleModeEnumeration.AIR,         EnumSet.of(StopTypeEnumeration.AIRPORT,        StopTypeEnumeration.OTHER));
-        map.put(VehicleModeEnumeration.BUS,         EnumSet.of(StopTypeEnumeration.ONSTREET_BUS,   StopTypeEnumeration.BUS_STATION,    StopTypeEnumeration.OTHER));
-        map.put(VehicleModeEnumeration.CABLEWAY,    EnumSet.of(StopTypeEnumeration.LIFT_STATION,   StopTypeEnumeration.OTHER));
-        map.put(VehicleModeEnumeration.COACH,       EnumSet.of(StopTypeEnumeration.COACH_STATION,  StopTypeEnumeration.OTHER));
-        map.put(VehicleModeEnumeration.FERRY,       EnumSet.of(StopTypeEnumeration.FERRY_PORT,     StopTypeEnumeration.FERRY_STOP,     StopTypeEnumeration.HARBOUR_PORT, StopTypeEnumeration.OTHER));
-        map.put(VehicleModeEnumeration.FUNICULAR,   EnumSet.of(StopTypeEnumeration.LIFT_STATION,   StopTypeEnumeration.OTHER));
-        map.put(VehicleModeEnumeration.LIFT,        EnumSet.of(StopTypeEnumeration.LIFT_STATION,   StopTypeEnumeration.OTHER));
-        map.put(VehicleModeEnumeration.METRO,       EnumSet.of(StopTypeEnumeration.METRO_STATION,  StopTypeEnumeration.OTHER));
-        map.put(VehicleModeEnumeration.RAIL,        EnumSet.of(StopTypeEnumeration.RAIL_STATION,   StopTypeEnumeration.VEHICLE_RAIL_INTERCHANGE, StopTypeEnumeration.OTHER));
-        map.put(VehicleModeEnumeration.TRAM,        EnumSet.of(StopTypeEnumeration.ONSTREET_TRAM,  StopTypeEnumeration.TRAM_STATION,   StopTypeEnumeration.OTHER));
-        map.put(VehicleModeEnumeration.TROLLEY_BUS, EnumSet.of(StopTypeEnumeration.ONSTREET_BUS,   StopTypeEnumeration.BUS_STATION,    StopTypeEnumeration.OTHER));
-        map.put(VehicleModeEnumeration.WATER,       EnumSet.of(StopTypeEnumeration.HARBOUR_PORT,   StopTypeEnumeration.FERRY_PORT,     StopTypeEnumeration.FERRY_STOP,   StopTypeEnumeration.OTHER));
-        map.put(VehicleModeEnumeration.OTHER,       EnumSet.of(StopTypeEnumeration.OTHER));
-        VALID_STOP_TYPES_FOR_MODE = Collections.unmodifiableMap(map);
-    }
 
     @Autowired
     private QuayMapper quayMapper;
@@ -259,22 +239,6 @@ public class StopPlaceMapper {
             return true;
         }
         return false;
-    }
-
-    private void validateStopPlaceTypeForTransportMode(StopPlace stopPlace) {
-        VehicleModeEnumeration transportMode = stopPlace.getTransportMode();
-        StopTypeEnumeration stopPlaceType = stopPlace.getStopPlaceType();
-
-        if (transportMode == null || stopPlaceType == null) {
-            return;
-        }
-
-        Set<StopTypeEnumeration> validTypes = VALID_STOP_TYPES_FOR_MODE.get(transportMode);
-        Preconditions.checkArgument(
-                validTypes != null && validTypes.contains(stopPlaceType),
-                "StopPlaceType %s is not valid for TransportMode %s. Valid types are: %s",
-                stopPlaceType, transportMode, validTypes
-        );
     }
 
     private boolean setFacilities(StopPlace stopPlace, Object facilitiesListObject) {

--- a/src/main/java/org/rutebanken/tiamat/rest/validation/StopPlaceMutationValidator.java
+++ b/src/main/java/org/rutebanken/tiamat/rest/validation/StopPlaceMutationValidator.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.rest.validation;
+
+import com.google.api.client.util.Preconditions;
+import com.google.api.client.util.Strings;
+import org.rutebanken.tiamat.model.ModificationEnumeration;
+import org.rutebanken.tiamat.model.StopPlace;
+import org.rutebanken.tiamat.model.StopTypeEnumeration;
+import org.rutebanken.tiamat.model.VehicleModeEnumeration;
+import org.rutebanken.tiamat.repository.StopPlaceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class StopPlaceMutationValidator {
+
+    private final StopPlaceRepository stopPlaceRepository;
+
+    private static final Map<VehicleModeEnumeration, Set<StopTypeEnumeration>> VALID_STOP_TYPES_FOR_MODE;
+
+    static {
+        Map<VehicleModeEnumeration, Set<StopTypeEnumeration>> map = new EnumMap<>(VehicleModeEnumeration.class);
+        map.put(VehicleModeEnumeration.AIR,         EnumSet.of(StopTypeEnumeration.AIRPORT,        StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.BUS,         EnumSet.of(StopTypeEnumeration.ONSTREET_BUS,   StopTypeEnumeration.BUS_STATION,    StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.CABLEWAY,    EnumSet.of(StopTypeEnumeration.LIFT_STATION,   StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.COACH,       EnumSet.of(StopTypeEnumeration.COACH_STATION,  StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.FERRY,       EnumSet.of(StopTypeEnumeration.FERRY_PORT,     StopTypeEnumeration.FERRY_STOP,     StopTypeEnumeration.HARBOUR_PORT, StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.FUNICULAR,   EnumSet.of(StopTypeEnumeration.LIFT_STATION,   StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.LIFT,        EnumSet.of(StopTypeEnumeration.LIFT_STATION,   StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.METRO,       EnumSet.of(StopTypeEnumeration.METRO_STATION,  StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.RAIL,        EnumSet.of(StopTypeEnumeration.RAIL_STATION,   StopTypeEnumeration.VEHICLE_RAIL_INTERCHANGE, StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.TRAM,        EnumSet.of(StopTypeEnumeration.ONSTREET_TRAM,  StopTypeEnumeration.TRAM_STATION,   StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.TROLLEY_BUS, EnumSet.of(StopTypeEnumeration.ONSTREET_BUS,   StopTypeEnumeration.BUS_STATION,    StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.WATER,       EnumSet.of(StopTypeEnumeration.HARBOUR_PORT,   StopTypeEnumeration.FERRY_PORT,     StopTypeEnumeration.FERRY_STOP,   StopTypeEnumeration.OTHER));
+        map.put(VehicleModeEnumeration.OTHER,       EnumSet.of(StopTypeEnumeration.OTHER));
+        VALID_STOP_TYPES_FOR_MODE = Collections.unmodifiableMap(map);
+    }
+
+    @Autowired
+    public StopPlaceMutationValidator(StopPlaceRepository stopPlaceRepository) {
+        this.stopPlaceRepository = stopPlaceRepository;
+    }
+
+    public StopPlace validateStopPlaceUpdate(String netexId, boolean isParentMutation) throws IllegalArgumentException {
+        StopPlace existingStopPlace = findAndVerifyExists(netexId);
+        validateNotDeleted(existingStopPlace);
+        validateParentChildType(existingStopPlace, isParentMutation, netexId);
+        return existingStopPlace;
+    }
+
+    public void validateStopPlaceName(StopPlace stopPlace) throws IllegalArgumentException {
+        Preconditions.checkArgument(
+                stopPlace.getName() != null && !Strings.isNullOrEmpty(stopPlace.getName().getValue()),
+                "Stop place must have name set: %s", stopPlace.getNetexId()
+        );
+    }
+
+    public void validateStopPlaceMutation(StopPlace mutatedStopPlace) throws IllegalArgumentException {
+        validateStopPlaceName(mutatedStopPlace);
+        validateStopPlaceTypeForTransportMode(mutatedStopPlace);
+    }
+
+    public void validateChildBelongsToParent(StopPlace child, StopPlace parent) throws IllegalArgumentException {
+        Preconditions.checkArgument(
+                child.getParentSiteRef() != null,
+                "Child stop [id = %s] does not belong to any parent", child.getNetexId()
+        );
+
+        Preconditions.checkArgument(
+                child.getParentSiteRef().getRef().equals(parent.getNetexId()),
+                "Child stop [id = %s] does not belong to parent %s",
+                child.getNetexId(), parent.getNetexId()
+        );
+
+        Preconditions.checkArgument(
+                child.getParentSiteRef().getVersion().equals(String.valueOf(parent.getVersion())),
+                "Child stop [id = %s] does not refer to parent %s in correct version: %s",
+                child.getNetexId(), parent.getNetexId(), parent.getVersion()
+        );
+    }
+
+    public void verifyStopPlaceNotNull(StopPlace stopPlace, String netexId) throws IllegalArgumentException {
+        Preconditions.checkArgument(stopPlace != null, "Attempting to update StopPlace [id = %s], but StopPlace does not exist.", netexId);
+    }
+
+    public static void validateStopPlaceTypeForTransportMode(StopPlace stopPlace) {
+        VehicleModeEnumeration transportMode = stopPlace.getTransportMode();
+        StopTypeEnumeration stopPlaceType = stopPlace.getStopPlaceType();
+
+        if (transportMode == null || stopPlaceType == null) {
+            return;
+        }
+
+        Set<StopTypeEnumeration> validTypes = VALID_STOP_TYPES_FOR_MODE.get(transportMode);
+        Preconditions.checkArgument(
+                validTypes != null && validTypes.contains(stopPlaceType),
+                "StopPlaceType %s is not valid for TransportMode %s. Valid types are: %s",
+                stopPlaceType, transportMode, validTypes
+        );
+    }
+
+    private StopPlace findAndVerifyExists(String netexId) {
+        StopPlace stopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(netexId);
+        Preconditions.checkArgument(
+                stopPlace != null,
+                "Stop place [id = %s] does not exist", netexId
+        );
+        return stopPlace;
+    }
+
+    private void validateNotDeleted(StopPlace stopPlace) {
+        Preconditions.checkArgument(
+                stopPlace.getModificationEnumeration() == null ||
+                        !stopPlace.getModificationEnumeration().equals(ModificationEnumeration.DELETE),
+                "Cannot update/reactivate terminated stop place: %s", stopPlace.getNetexId()
+        );
+    }
+
+    private void validateParentChildType(StopPlace stopPlace, boolean isParentMutation, String netexId) {
+        if (isParentMutation) {
+            Preconditions.checkArgument(
+                    stopPlace.isParentStopPlace(),
+                    "Cannot update Stop place [id = %s] as parent when it is not a parent", netexId
+            );
+        } else {
+            Preconditions.checkArgument(
+                    !stopPlace.isParentStopPlace(),
+                    "Cannot update parent stop place [id = %s] with this mutation", netexId
+            );
+
+            Preconditions.checkArgument(
+                    stopPlace.getParentSiteRef() == null,
+                    "Cannot update stop place [id = %s] which has parent. Edit parent instead: %s",
+                    netexId, stopPlace.getParentSiteRef()
+            );
+        }
+    }
+}
+

--- a/src/test/java/org/rutebanken/tiamat/rest/validation/StopPlaceMutationValidatorTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/validation/StopPlaceMutationValidatorTest.java
@@ -1,0 +1,270 @@
+package org.rutebanken.tiamat.rest.validation;
+
+import org.junit.Test;
+import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
+import org.rutebanken.tiamat.model.ModificationEnumeration;
+import org.rutebanken.tiamat.model.SiteRefStructure;
+import org.rutebanken.tiamat.model.StopPlace;
+import org.rutebanken.tiamat.model.StopTypeEnumeration;
+import org.rutebanken.tiamat.model.VehicleModeEnumeration;
+import org.rutebanken.tiamat.repository.StopPlaceRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class StopPlaceMutationValidatorTest {
+
+    private final StopPlaceRepository stopPlaceRepository = mock(StopPlaceRepository.class);
+
+    private final StopPlaceMutationValidator stopPlaceMutationValidator = new StopPlaceMutationValidator(stopPlaceRepository);
+
+    @Test
+    public void givenStopPlaceWithName_whenValidateStopPlaceName_thenPassValidation() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setName(new EmbeddableMultilingualString("name", "en"));
+
+        assertThatCode(() -> stopPlaceMutationValidator.validateStopPlaceName(stopPlace))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void givenStopPlaceWithoutName_whenValidateStopPlaceName_thenThrowException() {
+        StopPlace stopPlace = new StopPlace();
+        assertThatThrownBy(() -> stopPlaceMutationValidator.validateStopPlaceName(stopPlace))
+                .hasMessageContaining("Stop place must have name set");
+    }
+
+    @Test
+    public void givenNullStopPlace_whenVerifyStopPlaceNotNull_thenThrowException() {
+        assertThatThrownBy(() -> stopPlaceMutationValidator.verifyStopPlaceNotNull(null, "test-id"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Attempting to update StopPlace [id = test-id], but StopPlace does not exist.");
+    }
+
+    @Test
+    public void givenNonNullStopPlace_whenVerifyStopPlaceNBotNull_thenPassValidation() {
+        assertThatCode(() -> stopPlaceMutationValidator.verifyStopPlaceNotNull(new StopPlace(), "test-id"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void givenValidParentChildRelation_whenValidateChildBelongsToParent_thenPassValidation() {
+        StopPlace parent = new StopPlace();
+        parent.setNetexId("parent-id");
+        parent.setVersion(1L);
+
+        StopPlace child = new StopPlace();
+        child.setNetexId("child-id");
+        child.setParentSiteRef(new SiteRefStructure(parent.getNetexId(), String.valueOf(parent.getVersion())));
+
+        assertThatCode(() -> stopPlaceMutationValidator.validateChildBelongsToParent(child, parent))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void givenChildStopDoesNotHaveParentSiteRef_whenValidateChildBelongsToParent_thenThrowException() {
+        StopPlace parent = new StopPlace();
+        parent.setNetexId("parent-id");
+        StopPlace child = new StopPlace();
+        child.setNetexId("child-id");
+
+        assertThatThrownBy(() -> stopPlaceMutationValidator.validateChildBelongsToParent(child, parent))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Child stop [id = child-id] does not belong to any parent");
+    }
+
+    @Test
+    public void givenChildStopDoesNotReferenceCorrectParent_whenValidateChildBelongsToParent_thenThrowException() {
+        StopPlace parent = new StopPlace();
+        parent.setNetexId("parent-id");
+        StopPlace child = new StopPlace();
+        child.setNetexId("child-id");
+        child.setParentSiteRef(new SiteRefStructure("another-parent", "1"));
+
+        assertThatThrownBy(() -> stopPlaceMutationValidator.validateChildBelongsToParent(child, parent))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Child stop [id = child-id] does not belong to parent parent-id");
+    }
+
+    @Test
+    public void givenChildStopParentReferenceVersionDoesNotMatchParent_whenValidateChildBelongsToParent_thenThrowException() {
+        StopPlace parent = new StopPlace();
+        parent.setNetexId("parent-id");
+        parent.setVersion(2L);
+        StopPlace child = new StopPlace();
+        child.setNetexId("child-id");
+        child.setParentSiteRef(new SiteRefStructure(parent.getNetexId(), "1"));
+
+        assertThatThrownBy(() -> stopPlaceMutationValidator.validateChildBelongsToParent(child, parent))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Child stop [id = child-id] does not refer to parent parent-id in correct version: 2");
+    }
+
+    @Test
+    public void givenValidStopPlaceUpdate_whenValidateStopPlaceUpdate_thenPassValidationAndReturnExistingStopPlace() {
+        StopPlace existingStopPlace = new StopPlace();
+        existingStopPlace.setNetexId("id");
+        existingStopPlace.setModificationEnumeration(ModificationEnumeration.NEW);
+        existingStopPlace.setParentStopPlace(false);
+
+        when(stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc("id")).thenReturn(existingStopPlace);
+
+        StopPlace result = stopPlaceMutationValidator.validateStopPlaceUpdate(existingStopPlace.getNetexId(), false);
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    public void givenValidParentStopPlaceUpdate_whenValidateStopPlaceUpdate_thenPassValidationAndReturnExistingStopPlace() {
+        StopPlace existingStopPlace = new StopPlace();
+        existingStopPlace.setNetexId("id");
+        existingStopPlace.setModificationEnumeration(ModificationEnumeration.NEW);
+        existingStopPlace.setParentStopPlace(true);
+
+        when(stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc("id")).thenReturn(existingStopPlace);
+
+        StopPlace result = stopPlaceMutationValidator.validateStopPlaceUpdate(existingStopPlace.getNetexId(), true);
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    public void givenNonExistentStopPlace_whenValidateStopPlaceUpdate_thenThrowException() {
+        assertThatThrownBy(() -> stopPlaceMutationValidator.validateStopPlaceUpdate("non-existent", false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Stop place [id = non-existent] does not exist");
+    }
+
+    @Test
+    public void givenDeletedStopPlace_whenValidateStopPlaceUpdate_thenThrowException() {
+        StopPlace existingStopPlace = new StopPlace();
+        existingStopPlace.setNetexId("id");
+        existingStopPlace.setModificationEnumeration(ModificationEnumeration.DELETE);
+
+        when(stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc("id")).thenReturn(existingStopPlace);
+
+        assertThatThrownBy(() -> stopPlaceMutationValidator.validateStopPlaceUpdate(existingStopPlace.getNetexId(), false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot update/reactivate terminated stop place")
+                .as("the existing stop place may belong to someone else, so only its id may be surfaced")
+                .hasMessageNotContaining("StopPlace{");
+    }
+
+    @Test
+    public void givenIsParentStopPlaceFalseForParentMutationTrue_whenValidateStopPlaceUpdate_thenThrowException() {
+        StopPlace existingStopPlace = new StopPlace();
+        existingStopPlace.setNetexId("id");
+        existingStopPlace.setModificationEnumeration(ModificationEnumeration.NEW);
+        existingStopPlace.setParentStopPlace(false);
+
+        when(stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc("id")).thenReturn(existingStopPlace);
+
+        assertThatThrownBy(() -> stopPlaceMutationValidator.validateStopPlaceUpdate(existingStopPlace.getNetexId(), true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot update Stop place [id = id] as parent when it is not a parent");
+    }
+
+    @Test
+    public void givenIsParentStopPlaceTrueForParentMutationFalse_whenValidateStopPlaceUpdate_thenThrowException() {
+        StopPlace existingStopPlace = new StopPlace();
+        existingStopPlace.setNetexId("id");
+        existingStopPlace.setModificationEnumeration(ModificationEnumeration.NEW);
+        existingStopPlace.setParentStopPlace(true);
+
+        when(stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc("id")).thenReturn(existingStopPlace);
+
+        assertThatThrownBy(() -> stopPlaceMutationValidator.validateStopPlaceUpdate(existingStopPlace.getNetexId(), false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot update parent stop place [id = id] with this mutation");
+    }
+
+    @Test
+    public void givenParentSiteReference_whenValidateStopPlaceUpdate_thenThrowException() {
+        StopPlace existingStopPlace = new StopPlace();
+        existingStopPlace.setNetexId("id");
+        existingStopPlace.setModificationEnumeration(ModificationEnumeration.NEW);
+        existingStopPlace.setParentStopPlace(false);
+        existingStopPlace.setParentSiteRef(new SiteRefStructure("parent-ref", "1"));
+
+        when(stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc("id")).thenReturn(existingStopPlace);
+
+        assertThatThrownBy(() -> stopPlaceMutationValidator.validateStopPlaceUpdate(existingStopPlace.getNetexId(), false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot update stop place [id = id] which has parent. Edit parent instead");
+    }
+
+    @Test
+    public void givenMutationWithNameAndValidStopTypeModeCombination_whenValidateStopPlaceMutation_thenPassValidation() {
+        StopPlace mutatedStopPlace = new StopPlace();
+        mutatedStopPlace.setNetexId("id");
+        mutatedStopPlace.setName(new EmbeddableMultilingualString("name", "en"));
+        mutatedStopPlace.setStopPlaceType(StopTypeEnumeration.BUS_STATION);
+        mutatedStopPlace.setTransportMode(VehicleModeEnumeration.BUS);
+
+        assertThatCode(() -> stopPlaceMutationValidator.validateStopPlaceMutation(mutatedStopPlace))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void givenMutationWithoutName_whenValidateStopPlaceMutation_thenThrowException() {
+        StopPlace mutatedStopPlace = new StopPlace();
+        mutatedStopPlace.setNetexId("id");
+
+        assertThatThrownBy(() -> stopPlaceMutationValidator.validateStopPlaceMutation(mutatedStopPlace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Stop place must have name set: id")
+                .as("the failure reason is surfaced to the caller, so it must identify the stop place without dumping the entity")
+                .hasMessageNotContaining("StopPlace{");
+    }
+
+    @Test
+    public void givenMutationWithInvalidStopTypeModeCombination_whenValidateStopPlaceMutation_thenThrowException() {
+        StopPlace mutatedStopPlace = new StopPlace();
+        mutatedStopPlace.setNetexId("id");
+        mutatedStopPlace.setName(new EmbeddableMultilingualString("name", "en"));
+        mutatedStopPlace.setStopPlaceType(StopTypeEnumeration.BUS_STATION);
+        mutatedStopPlace.setTransportMode(VehicleModeEnumeration.RAIL);
+
+        assertThatThrownBy(() -> stopPlaceMutationValidator.validateStopPlaceMutation(mutatedStopPlace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("StopPlaceType BUS_STATION is not valid for TransportMode RAIL. Valid types are: [RAIL_STATION, VEHICLE_RAIL_INTERCHANGE, OTHER]");
+    }
+
+    @Test
+    public void givenNoTypeOrMode_whenValidateStopPlaceTypeForTransportMode_thenPassValidation() {
+        StopPlace stopPlace = new StopPlace();
+
+        assertThatCode(() -> StopPlaceMutationValidator.validateStopPlaceTypeForTransportMode(stopPlace))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void givenOnlyMode_whenValidateStopPlaceTypeForTransportMode_thenPassValidation() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setTransportMode(VehicleModeEnumeration.BUS);
+
+        assertThatCode(() -> StopPlaceMutationValidator.validateStopPlaceTypeForTransportMode(stopPlace))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void givenOnlyType_whenValidateStopPlaceTypeForTransportMode_thenPassValidation() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setStopPlaceType(StopTypeEnumeration.BUS_STATION);
+
+        assertThatCode(() -> StopPlaceMutationValidator.validateStopPlaceTypeForTransportMode(stopPlace))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void givenInvalidStopTypeModeCombination_whenValidateStopPlaceTypeForTransportMode_thenThrowException() {
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setStopPlaceType(StopTypeEnumeration.BUS_STATION);
+        stopPlace.setTransportMode(VehicleModeEnumeration.RAIL);
+
+        assertThatThrownBy(() -> StopPlaceMutationValidator.validateStopPlaceTypeForTransportMode(stopPlace))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("StopPlaceType BUS_STATION is not valid for TransportMode RAIL. Valid types are: [RAIL_STATION, VEHICLE_RAIL_INTERCHANGE, OTHER]");
+    }
+}


### PR DESCRIPTION
### Summary

Stop place mutation validation lived inline in `rest/graphql/fetchers/StopPlaceUpdater` and `rest/graphql/mappers/StopPlaceMapper`. This moves it into `rest/validation/StopPlaceMutationValidator` and adds tests for it.

The refactor is behaviour preserving: the same checks run in the same order, against the same objects, still throwing `IllegalArgumentException`. The validator has no dependency on anything outside the existing model and repository layers.

Split out of #318, where it was entangled with the async write API. It stands on its own, and reviewing it separately means #318 no longer needs to touch the GraphQL mutation path at all.

### What a reviewer should look at

**Around seven failure messages are worded differently.** These are user visible: Abzu renders them verbatim in its snackbar (`snackbarReducer.js:60` → `SnackbarWrapper`). It never parses or branches on them — it uses its own `MutationErrorCodes` keyed on which mutation failed — so nothing breaks functionally, but the wording a user sees changes.

**Two messages previously interpolated the stop place object itself**, so its `toString()` ended up in the failure text:

```
Stop place must have name set: StopPlace{netexId=id, version=0, keyValues={}, quays=[], isParentStopPlace=false, children=0}
```

For `validateNotDeleted` that object is the *existing persisted* stop place, which the caller may not own. Both now identify the stop place by netex id, consistent with every other message in the validator. Since these are shown to users in Abzu, this is a readability improvement as well as a disclosure one.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [x] Other: refactoring, plus one disclosure fix in the messages

### Unit tests

`StopPlaceMutationValidatorTest` adds 22 tests for validation logic that previously had no direct coverage.

Full suite run locally against a PostGIS Testcontainer:

| | Result |
|---|---|
| master baseline | 1018 tests, 0 failures |
| this branch | 1040 tests, 0 failures |

The difference is exactly the 22 new tests: no existing test was changed, lost or duplicated. `GraphQLResourceStopPlaceIntegrationTest` passes 57/57 unchanged, which is the evidence for behaviour preservation.

The branch also compiles with no write API code on the classpath, confirming the validator is genuinely independent of #318 rather than only appearing to be.

### Notes

Explicit imports were restored in `StopPlaceUpdater`, where they had been collapsed to `java.util.*` and `GraphQLNames.*`. That is unrelated churn in a diff whose whole claim is that nothing else changed; without it the diff reads as 81 changed lines rather than the 12 insertions and 93 deletions it actually is.
