### PR TITLE
Asserts id mapping csv per line instead of on a hardcoded newline

### DIFF
--- a/src/test/java/org/rutebanken/tiamat/rest/dto/DtoResourceIntegrationTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/dto/DtoResourceIntegrationTest.java
@@ -77,13 +77,15 @@ public class DtoResourceIntegrationTest extends TiamatIntegrationTest {
 
         String responseWithoutStopPlaceType = getIdMapping(PATH_MAPPING_QUAY);
 
-        assertThat(responseWithoutStopPlaceType).contains(originalId + "," + q1.getNetexId() + "\n");
-        assertThat(responseWithoutStopPlaceType).contains(originalId2 + "," + q1.getNetexId() + "\n");
-        assertThat(responseWithoutStopPlaceType).contains(originalId3 + "," + q1.getNetexId() + "\n");
+        assertThat(responseWithoutStopPlaceType.lines()).contains(
+                originalId + "," + q1.getNetexId(),
+                originalId2 + "," + q1.getNetexId(),
+                originalId3 + "," + q1.getNetexId());
         assertThat(responseWithoutStopPlaceType).doesNotContain(spOrigId);
 
         String responseWithStopPlaceType = getIdMapping(PATH_MAPPING_QUAY + "?includeStopType=true");
-        assertThat(responseWithStopPlaceType).contains(originalId + "," + StopTypeEnumeration.AIRPORT.value() + "," + q1.getNetexId() + "\n");
+        assertThat(responseWithStopPlaceType.lines()).contains(
+                originalId + "," + StopTypeEnumeration.AIRPORT.value() + "," + q1.getNetexId());
     }
 
     @Test
@@ -112,11 +114,9 @@ public class DtoResourceIntegrationTest extends TiamatIntegrationTest {
 
         String response = getIdMapping(PATH_MAPPING_JBV_CODE);
 
-        assertThat(response)
-                .contains(jbvCode1 + ":" + quay.getPublicCode() + "," + quay.getNetexId() + "\n")
-                .contains(jbvCode1 + ":" + quay.getPublicCode() + "," + quay.getNetexId() + "\n")
-                .contains(jbvCode1 + ":" + quay.getPublicCode() + "," + quay.getNetexId() + "\n")
-                .contains(jbvCode1 + "," + stopPlace.getNetexId() + "\n");
+        assertThat(response.lines()).contains(
+                jbvCode1 + ":" + quay.getPublicCode() + "," + quay.getNetexId(),
+                jbvCode1 + "," + stopPlace.getNetexId());
 
     }
 
@@ -146,15 +146,17 @@ public class DtoResourceIntegrationTest extends TiamatIntegrationTest {
 
         String responseWithoutStopPlaceType = getIdMapping(PATH_MAPPING_STOP_PLACE);
 
-        assertThat(responseWithoutStopPlaceType).contains(originalId + "," + stopPlace.getNetexId() + "\n");
-        assertThat(responseWithoutStopPlaceType).contains(originalId2 + "," + stopPlace.getNetexId() + "\n");
+        assertThat(responseWithoutStopPlaceType.lines()).contains(
+                originalId + "," + stopPlace.getNetexId(),
+                originalId2 + "," + stopPlace.getNetexId());
         assertThat(responseWithoutStopPlaceType).doesNotContain(quayOrigId);
         assertThat(responseWithoutStopPlaceType).doesNotContain(quayOrigId2);
 
         String responseWithStopPlaceType = getIdMapping(PATH_MAPPING_STOP_PLACE +"?includeStopType=true");
 
-        assertThat(responseWithStopPlaceType).contains(originalId + ",," + stopPlace.getNetexId() + "\n");
-        assertThat(responseWithStopPlaceType).contains(originalId2 + ",," + stopPlace.getNetexId() + "\n");
+        assertThat(responseWithStopPlaceType.lines()).contains(
+                originalId + ",," + stopPlace.getNetexId(),
+                originalId2 + ",," + stopPlace.getNetexId());
     }
 
 


### PR DESCRIPTION
### Summary

`DtoResourceIntegrationTest` asserted that the id mapping csv contained entries ending in `\n`. The resources write the csv with `PrintWriter.println` (`DtoQuayResource`, `DtoStopPlaceResource`, `DtoJbvCodeMappingResource`), which emits the **platform** line separator, so the tests fail on a platform where that is not `\n`.

Asserts against the lines of the response instead of against the raw string with a hardcoded separator.

Split out of #318, where it was picked up incidentally while working on something unrelated. It has nothing to do with that feature.

### Why not simply drop the trailing `\n`

That was the original workaround, and it makes the assertions weaker: `contains(originalId + "," + quay.getNetexId())` on the whole response body is a substring match, so it passes for `NSR:Quay:1` when the response only ever contained `NSR:Quay:10`.

Asserting on `response.lines()` is independent of the line separator **and** matches whole lines, so it is stricter than the original rather than looser.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Unit tests

Test-only change. `DtoResourceIntegrationTest` passes 3/3.

Verified the rewritten assertions are not vacuous: introducing a deliberately wrong expected value fails the test, so they still catch a bad mapping.

### Notes

`testQuayJbvCodeMapping` contained the same assertion three times. That looks like a copy paste rather than three distinct expectations, so it is now asserted once alongside the other expected line.
