### PR TITLE
Farezone poller

### DIFF
--- a/helm/tiamat/env/values-kub-ent-dev.yaml
+++ b/helm/tiamat/env/values-kub-ent-dev.yaml
@@ -9,6 +9,11 @@ envVars:
   BLOBSTORE_GCS_PROJECT_ID: ent-tiamat-dev
   SPRING_CLOUD_GCP_PROJECT_ID: ent-tiamat-dev
   FAREZONE_EXTERNALVERSIONING: "true"
+  GROUPOFTARIFFZONES_EXTERNALVERSIONING: "true"
+  IGNORETARIFFZONEIMPORT: "true"
+  NETEX_FAREZONEPOLLER_ENABLED: "true"
+  # Set explicitly: the code default is the production feed, which this environment must not pull.
+  NETEX_FAREZONEPOLLER_URL: "https://api.dev.entur.io/distance/netex/fare-zones"
   TIAMAT_USER_PERMISSION_REST_SERVICE_URL: http://baba.dev.entur.internal/services/organisations/users
   TIAMAT_OAUTH2_RESOURCESERVER_AUTH0_ENTUR_PARTNER_JWT_ISSUER_URI: https://partner.dev.entur.org/
   TIAMAT_OAUTH2_RESOURCESERVER_AUTH0_ENTUR_PARTNER_JWT_AUDIENCE: https://api.dev.entur.io

--- a/helm/tiamat/env/values-kub-ent-prd.yaml
+++ b/helm/tiamat/env/values-kub-ent-prd.yaml
@@ -8,7 +8,14 @@ envVars:
   BLOBSTORE_GCS_BUCKET_NAME: ror-tiamat-gcp2-prd
   BLOBSTORE_GCS_PROJECT_ID: ent-tiamat-prd
   SPRING_CLOUD_GCP_PROJECT_ID: ent-tiamat-prd
+  # Kept off until the poller has been validated in dev/tst. These are not inert while the poller is
+  # disabled: they change what a manual NeTEx import does to production data - a delivery carrying
+  # FareZones would prune the ones it omits, and TariffZones in any delivery would be dropped. Flip
+  # them together with NETEX_FAREZONEPOLLER_ENABLED at cutover.
   FAREZONE_EXTERNALVERSIONING: "false"
+  GROUPOFTARIFFZONES_EXTERNALVERSIONING: "false"
+  IGNORETARIFFZONEIMPORT: "false"
+  NETEX_FAREZONEPOLLER_ENABLED: "false"
   TIAMAT_USER_PERMISSION_REST_SERVICE_URL: http://baba.prd.entur.internal/services/organisations/users
   TIAMAT_OAUTH2_RESOURCESERVER_AUTH0_ENTUR_PARTNER_JWT_ISSUER_URI: https://partner.entur.org/
   TIAMAT_OAUTH2_RESOURCESERVER_AUTH0_ENTUR_PARTNER_JWT_AUDIENCE: https://api.entur.io

--- a/helm/tiamat/env/values-kub-ent-tst.yaml
+++ b/helm/tiamat/env/values-kub-ent-tst.yaml
@@ -9,6 +9,11 @@ envVars:
   BLOBSTORE_GCS_PROJECT_ID: ent-tiamat-tst
   SPRING_CLOUD_GCP_PROJECT_ID: ent-tiamat-tst
   FAREZONE_EXTERNALVERSIONING: "true"
+  GROUPOFTARIFFZONES_EXTERNALVERSIONING: "true"
+  IGNORETARIFFZONEIMPORT: "true"
+  NETEX_FAREZONEPOLLER_ENABLED: "true"
+  # Set explicitly: the code default is the production feed, which this environment must not pull.
+  NETEX_FAREZONEPOLLER_URL: "https://api.staging.entur.io/distance/netex/fare-zones"
   TIAMAT_USER_PERMISSION_REST_SERVICE_URL: http://baba.tst.entur.internal/services/organisations/users
   TIAMAT_OAUTH2_RESOURCESERVER_AUTH0_ENTUR_PARTNER_JWT_ISSUER_URI: https://partner.staging.entur.org/
   TIAMAT_OAUTH2_RESOURCESERVER_AUTH0_ENTUR_PARTNER_JWT_AUDIENCE: https://api.staging.entur.io

--- a/src/main/java/org/rutebanken/tiamat/auth/DefaultAuthorizationService.java
+++ b/src/main/java/org/rutebanken/tiamat/auth/DefaultAuthorizationService.java
@@ -49,6 +49,9 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
     @Override
     public boolean canEditAllEntities() {
+        if(SystemImportContext.isActive()) {
+            return true;
+        }
         if(hasNoAuthentications()) {
             return false;
         }
@@ -68,28 +71,43 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
     @Override
     public boolean canEditEntities(Collection<? extends EntityStructure> entities) {
+        if(SystemImportContext.isActive()) {
+            return true;
+        }
         return dataScopedAuthorizationService.isAuthorized(ROLE_EDIT_STOPS, entities);
     }
 
 
     @Override
     public void verifyCanEditEntities(Collection<? extends EntityStructure> entities) {
+        if(SystemImportContext.isActive()) {
+            return;
+        }
         dataScopedAuthorizationService.assertAuthorized(ROLE_EDIT_STOPS, entities);
     }
 
     @Override
     public void verifyCanDeleteEntities(Collection<? extends EntityStructure> entities) {
+        if(SystemImportContext.isActive()) {
+            return;
+        }
         dataScopedAuthorizationService.assertAuthorized(ROLE_DELETE_STOPS, entities);
 
     }
 
     @Override
     public boolean canDeleteEntity(EntityStructure entity) {
+        if(SystemImportContext.isActive()) {
+            return true;
+        }
         return canEditDeleteEntity(entity, ROLE_DELETE_STOPS);
     }
 
     @Override
     public boolean canEditEntity(EntityStructure entity) {
+        if(SystemImportContext.isActive()) {
+            return true;
+        }
         return canEditDeleteEntity(entity, ROLE_EDIT_STOPS);
     }
 

--- a/src/main/java/org/rutebanken/tiamat/auth/SystemImportContext.java
+++ b/src/main/java/org/rutebanken/tiamat/auth/SystemImportContext.java
@@ -1,0 +1,44 @@
+package org.rutebanken.tiamat.auth;
+
+import java.util.Objects;
+
+/**
+ * Thread-scoped marker for a trusted in-process "system import": a write triggered by internal code
+ * (for example {@code FareZonePoller} pulling a fixed, operator-configured feed) rather than by an
+ * authenticated end-user request.
+ *
+ * <p>When active on the current thread, {@link DefaultAuthorizationService} treats edit/delete
+ * checks as granted, so a background job with no user principal can write without a service-account
+ * token, and {@link UsernameFetcher} attributes the write to {@link #username()} instead of looking
+ * the actor up in the user registry - there is no registry entry for it. The system actor is
+ * represented by this context alone; no JWT is fabricated for it.
+ *
+ * <p>The flag can only be toggled from within this package (via
+ * {@link SystemSecurityContextService}), so it is not reachable from user-facing request handling.
+ */
+public final class SystemImportContext {
+
+    private static final ThreadLocal<String> SYSTEM_USERNAME = new ThreadLocal<>();
+
+    private SystemImportContext() {
+    }
+
+    public static boolean isActive() {
+        return SYSTEM_USERNAME.get() != null;
+    }
+
+    /**
+     * The name to attribute writes to while a system import runs on this thread, or null outside one.
+     */
+    public static String username() {
+        return SYSTEM_USERNAME.get();
+    }
+
+    static void activate(String username) {
+        SYSTEM_USERNAME.set(Objects.requireNonNull(username, "System import username must be set"));
+    }
+
+    static void clear() {
+        SYSTEM_USERNAME.remove();
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/auth/SystemSecurityContextService.java
+++ b/src/main/java/org/rutebanken/tiamat/auth/SystemSecurityContextService.java
@@ -1,0 +1,55 @@
+package org.rutebanken.tiamat.auth;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.function.Supplier;
+
+/**
+ * Runs a unit of work as a trusted in-process "system import" for internal jobs that have no
+ * end-user request behind them (for example {@code FareZonePoller} pulling a fixed feed).
+ *
+ * <p>For the duration of the work it activates {@link SystemImportContext}, which makes
+ * {@link DefaultAuthorizationService} grant the edit/delete checks along the import path - no
+ * service-account token required - and makes {@link UsernameFetcher} report the configured system
+ * name, so saved entities get a non-null {@code changedBy} for audit.
+ *
+ * <p>No JWT is fabricated: an issuer-less synthetic token is rejected by the deployed
+ * {@code UserInfoExtractor}, which resolves the actor against the Baba user registry where the
+ * system actor does not exist. The security context is emptied instead, so nothing downstream can
+ * mistake the system import for an authenticated user or inherit a principal left on this thread by
+ * an earlier request.
+ *
+ * <p>Both the context and the flag are restored afterwards, including on exception.
+ */
+@Service
+public class SystemSecurityContextService {
+
+    private final String systemUsername;
+
+    public SystemSecurityContextService(
+            @Value("${tiamat.system.import.username:tiamat-system}") String systemUsername) {
+        this.systemUsername = systemUsername;
+    }
+
+    public <T> T runAsSystemImport(Supplier<T> action) {
+        SecurityContext previous = SecurityContextHolder.getContext();
+        try {
+            SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext());
+            SystemImportContext.activate(systemUsername);
+            return action.get();
+        } finally {
+            SystemImportContext.clear();
+            SecurityContextHolder.setContext(previous);
+        }
+    }
+
+    public void runAsSystemImport(Runnable action) {
+        runAsSystemImport(() -> {
+            action.run();
+            return null;
+        });
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/auth/UsernameFetcher.java
+++ b/src/main/java/org/rutebanken/tiamat/auth/UsernameFetcher.java
@@ -38,6 +38,11 @@ public class UsernameFetcher {
      */
     @Nullable
     public String getUserNameForAuthenticatedUser() {
+        // A system import has no user principal and no entry in the user registry, so it is
+        // attributed to its configured name rather than resolved through the extractor.
+        if (SystemImportContext.isActive()) {
+            return SystemImportContext.username();
+        }
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if(authentication == null
                 || authentication.getPrincipal() == null

--- a/src/main/java/org/rutebanken/tiamat/config/FareZonePollerConfig.java
+++ b/src/main/java/org/rutebanken/tiamat/config/FareZonePollerConfig.java
@@ -1,0 +1,66 @@
+package org.rutebanken.tiamat.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * Settings for {@link org.rutebanken.tiamat.importer.fetch.FareZonePoller}. Grouped here so the
+ * poller does not carry a long list of {@code @Value} constructor parameters.
+ *
+ * <p>There is deliberately no import-type or versioning setting: the poller applies the feed through
+ * {@link org.rutebanken.tiamat.importer.fetch.FareZoneSnapshotImporter}, which is always an
+ * authoritative full replace. Combinations that silently did nothing while still recording the feed
+ * as imported (an ID_MATCH import, or polling with external versioning switched off) are therefore
+ * not expressible.
+ */
+@Component
+public class FareZonePollerConfig {
+
+    private final boolean enabled;
+    private final String url;
+    private final Duration initialDelay;
+    private final Duration interval;
+    private final Duration connectTimeout;
+    private final Duration requestTimeout;
+
+    public FareZonePollerConfig(
+            @Value("${netex.fareZonePoller.enabled:false}") boolean enabled,
+            @Value("${netex.fareZonePoller.url:https://api.entur.io/distance/netex/fare-zones}") String url,
+            @Value("${netex.fareZonePoller.initialDelaySeconds:60}") long initialDelaySeconds,
+            @Value("${netex.fareZonePoller.intervalSeconds:3600}") long intervalSeconds,
+            @Value("${netex.fareZonePoller.connectTimeoutSeconds:30}") long connectTimeoutSeconds,
+            @Value("${netex.fareZonePoller.requestTimeoutSeconds:180}") long requestTimeoutSeconds) {
+        this.enabled = enabled;
+        this.url = url;
+        this.initialDelay = Duration.ofSeconds(initialDelaySeconds);
+        this.interval = Duration.ofSeconds(intervalSeconds);
+        this.connectTimeout = Duration.ofSeconds(connectTimeoutSeconds);
+        this.requestTimeout = Duration.ofSeconds(requestTimeoutSeconds);
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public Duration getInitialDelay() {
+        return initialDelay;
+    }
+
+    public Duration getInterval() {
+        return interval;
+    }
+
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public Duration getRequestTimeout() {
+        return requestTimeout;
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/importer/FareZoneImporter.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/FareZoneImporter.java
@@ -27,7 +27,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 
@@ -59,24 +58,21 @@ public class FareZoneImporter {
                     org.rutebanken.tiamat.model.FareZone saved;
 
                     if (fareZoneConfig.isExternalVersioning()) {
+                        // Throws on an invalid zone, failing the import rather than dropping the zone
+                        // from the set of ids to keep - which would delete the stored copy.
                         saved = fareZoneSaverService.saveWithExternalVersioning(incomingFareZone);
-                        if (saved != null) {
-                            logger.debug("Saved FareZone {} with external versioning", saved.getNetexId());
-                        } else {
-                            logger.warn("FareZone {} was not saved due to validation failure", incomingFareZone.getNetexId());
-                        }
+                        logger.debug("Saved FareZone {} with external versioning", saved.getNetexId());
                     } else {
                         saved = fareZoneSaverService.saveNewVersion(incomingFareZone);
                         logger.debug("Saved FareZone {} with default versioning", saved.getNetexId());
                     }
 
-                    if (saved != null && saved.getNetexId() != null) {
+                    if (saved.getNetexId() != null) {
                         importedNetexIds.add(saved.getNetexId());
                     }
 
                     return saved;
                 })
-                .filter(Objects::nonNull) // Filter out validation failures
                 .map(savedFareZone -> netexMapper.getFacade().map(savedFareZone, FareZone.class))
                 .toList();
 

--- a/src/main/java/org/rutebanken/tiamat/importer/PublicationDeliveryFareFrameImporter.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/PublicationDeliveryFareFrameImporter.java
@@ -29,6 +29,8 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -49,6 +51,7 @@ public class PublicationDeliveryFareFrameImporter {
     private final BackgroundJobs backgroundJobs;
     private final FareZoneConfig fareZoneConfig;
     private final FareZoneSaverService fareZoneSaverService;
+    private final TransactionTemplate transactionTemplate;
 
     @Autowired
     public PublicationDeliveryFareFrameImporter(
@@ -57,13 +60,15 @@ public class PublicationDeliveryFareFrameImporter {
             TariffZoneImportHandler tariffZoneImportHandler,
             BackgroundJobs backgroundJobs,
             FareZoneConfig fareZoneConfig,
-            FareZoneSaverService fareZoneSaverService) {
+            FareZoneSaverService fareZoneSaverService,
+            PlatformTransactionManager transactionManager) {
         this.publicationDeliveryHelper = publicationDeliveryHelper;
         this.publicationDeliveryCreator = publicationDeliveryCreator;
         this.tariffZoneImportHandler = tariffZoneImportHandler;
         this.backgroundJobs = backgroundJobs;
         this.fareZoneConfig = fareZoneConfig;
         this.fareZoneSaverService = fareZoneSaverService;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
     }
 
     public PublicationDeliveryStructure importPublicationDelivery(
@@ -114,19 +119,27 @@ public class PublicationDeliveryFareFrameImporter {
             FareFrame responseFareFrame = new FareFrame();
             responseFareFrame.withId(requestId + "-response").withVersion("1");
 
-            // Import fare zones from FareFrame and collect imported netexIds
-            Set<String> importedNetexIds = tariffZoneImportHandler.handleFareZonesFromFareFrame(
-                    netexFareFrame,
-                    importParams,
-                    fareZoneCounter,
-                    responseFareFrame
-            );
+            // Import and orphan cleanup share one transaction: with external versioning they are a
+            // single authoritative replacement, so a rejected zone must not leave the zones already
+            // written committed while the rest of the delivery is discarded.
+            final ImportParams finalImportParams = importParams;
+            transactionTemplate.executeWithoutResult(transactionStatus -> {
+                // Before the import writes anything, so the prune safety floor is measured against
+                // the register as it stands rather than as this delivery leaves it.
+                long fareZonesBeforeImport = fareZoneSaverService.countDistinctStoredNetexIds();
 
-            // Cleanup orphaned FareZones if external versioning is enabled
-            if (fareZoneConfig.isExternalVersioning() && !importedNetexIds.isEmpty()) {
-                int deletedCount = fareZoneSaverService.deleteAllExcept(importedNetexIds);
-                logger.info("External versioning cleanup: deleted {} orphaned FareZones", deletedCount);
-            }
+                Set<String> imported = tariffZoneImportHandler.handleFareZonesFromFareFrame(
+                        netexFareFrame,
+                        finalImportParams,
+                        fareZoneCounter,
+                        responseFareFrame
+                );
+
+                if (fareZoneConfig.isExternalVersioning() && !imported.isEmpty()) {
+                    int deletedCount = fareZoneSaverService.deleteAllExcept(imported, fareZonesBeforeImport);
+                    logger.info("External versioning cleanup: deleted {} orphaned FareZones", deletedCount);
+                }
+            });
 
             // Trigger background job if zones were imported
             if (responseFareFrame.getFareZones() != null) {

--- a/src/main/java/org/rutebanken/tiamat/importer/PublicationDeliveryImporter.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/PublicationDeliveryImporter.java
@@ -44,6 +44,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Timer;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -163,27 +164,35 @@ public class PublicationDeliveryImporter {
 
             // Import fare zones carried in an accompanying FareFrame, so that a GroupOfTariffZones
             // in the SiteFrame can reference them within the same delivery.
-            final Set<String> fareFrameZoneIds;
-            if (netexFareFrame != null) {
-                FareFrame responseFareFrame = new FareFrame().withId(requestId + "-fareframe-response").withVersion("1");
-                fareFrameZoneIds = tariffZoneImportHandler.handleFareZonesFromFareFrame(netexFareFrame, importParams, tariffZoneCounter, responseFareFrame);
-                } else {
-                fareFrameZoneIds = Collections.emptySet();
-            }
-
-            // Run the external versioning FareZone cleanup and the GroupOfTariffZones import in a single
-            // transaction, so that a failed group member validation rolls back the deletes instead of
-            // leaving FareZones permanently removed by a rejected import.
+            //
+            // The FareZone import, the external versioning cleanup and the GroupOfTariffZones import
+            // share one transaction: together they are a single authoritative replacement, so a
+            // rejected group membership or an invalid zone must not leave a half-applied snapshot -
+            // updated and newly inserted zones committed, with the rest of the delivery discarded.
             final ImportParams finalImportParams = importParams;
-            transactionTemplate.executeWithoutResult(transactionStatus -> {
-                // With external versioning the import is a full replace: prune FareZones not present in this delivery.
-                if (fareZoneConfig.isExternalVersioning() && !fareFrameZoneIds.isEmpty()) {
-                    int deletedCount = fareZoneSaverService.deleteAllExcept(fareFrameZoneIds);
-                    logger.info("External versioning cleanup: deleted {} orphaned FareZones", deletedCount);
-                }
+            final Set<String> fareFrameZoneIds = Objects.requireNonNullElse(
+                    transactionTemplate.execute(transactionStatus -> {
+                        // Before the import writes anything, so the prune safety floor is measured
+                        // against the register as it stands rather than as this delivery leaves it.
+                        long fareZonesBeforeImport = fareZoneSaverService.countDistinctStoredNetexIds();
 
-                groupOfTariffZonesImportHandler.handleGroupOfTariffZones(netexSiteFrame, finalImportParams, responseSiteFrame, fareFrameZoneIds);
-            });
+                        Set<String> importedZoneIds = Collections.emptySet();
+                        if (netexFareFrame != null) {
+                            FareFrame responseFareFrame = new FareFrame().withId(requestId + "-fareframe-response").withVersion("1");
+                            importedZoneIds = tariffZoneImportHandler.handleFareZonesFromFareFrame(
+                                    netexFareFrame, finalImportParams, tariffZoneCounter, responseFareFrame);
+                        }
+
+                        // With external versioning the import is a full replace: prune FareZones not present in this delivery.
+                        if (fareZoneConfig.isExternalVersioning() && !importedZoneIds.isEmpty()) {
+                            int deletedCount = fareZoneSaverService.deleteAllExcept(importedZoneIds, fareZonesBeforeImport);
+                            logger.info("External versioning cleanup: deleted {} orphaned FareZones", deletedCount);
+                        }
+
+                        groupOfTariffZonesImportHandler.handleGroupOfTariffZones(netexSiteFrame, finalImportParams, responseSiteFrame, importedZoneIds);
+                        return importedZoneIds;
+                    }),
+                    Collections.emptySet());
             stopPlaceImportHandler.handleStops(netexSiteFrame, importParams, stopPlaceCounter, responseSiteFrame);
             parkingsImportHandler.handleParkings(netexSiteFrame, importParams, parkingCounter, responseSiteFrame);
             pathLinkImportHandler.handlePathLinks(netexSiteFrame, importParams, pathLinkCounter, responseSiteFrame);

--- a/src/main/java/org/rutebanken/tiamat/importer/fetch/FareZonePoller.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/fetch/FareZonePoller.java
@@ -1,0 +1,208 @@
+package org.rutebanken.tiamat.importer.fetch;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.rutebanken.netex.model.PublicationDeliveryStructure;
+import org.rutebanken.tiamat.auth.SystemSecurityContextService;
+import org.rutebanken.tiamat.config.FareZonePollerConfig;
+import org.rutebanken.tiamat.lock.PostgresAdvisoryLock;
+import org.rutebanken.tiamat.rest.netex.publicationdelivery.PublicationDeliveryUnmarshaller;
+import org.rutebanken.tiamat.service.batch.BackgroundJobs;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Periodically pulls a NeTEx fare-zone feed from an external HTTP endpoint and applies it, so that
+ * Tiamat acts as a replica of an external fare-zone master (see
+ * {@code https://api.entur.io/distance/netex/fare-zones}).
+ *
+ * <p>The delivery is applied by {@link FareZoneSnapshotImporter}: an authoritative full replace of
+ * the FareZones and GroupOfTariffZones, in one transaction, rejecting a delivery that carries
+ * anything else. It deliberately does not go through the general publication delivery importer,
+ * which would let unexpected feed content be written to the rest of the register.
+ *
+ * <p>The import has no end-user request behind it, so it runs as a trusted system import
+ * ({@link SystemSecurityContextService}). Tiamat runs several replicas, so a poll is serialised
+ * across them by a {@link PostgresAdvisoryLock} - a database lock rather than a Hazelcast one,
+ * because the replicas do not form a Hazelcast cluster. The lock is taken before the fetch, so only
+ * one replica pulls the feed per tick and a slow response cannot be applied on top of a newer
+ * snapshot that another replica imported meanwhile. The SHA-256 of the last applied body is recorded
+ * in the database alongside the data it describes, so an unchanged feed is not re-imported.
+ *
+ * <p>Disabled by default; enable with {@code netex.fareZonePoller.enabled=true}.
+ */
+@Component
+public class FareZonePoller {
+
+    private static final Logger logger = LoggerFactory.getLogger(FareZonePoller.class);
+
+    public enum PollResult {IMPORTED, SKIPPED, FAILED, DISABLED}
+
+    static final String LOCK_NAME = "fare-zone-poller";
+
+    /**
+     * Advisory lock id for {@link #LOCK_NAME}. Arbitrary but fixed: it is the identity of the lock
+     * across replicas, and shows up as this number in {@code pg_locks}.
+     */
+    public static final long LOCK_KEY = 4_198_231_057L;
+
+    private final FareZonePollerConfig config;
+    private final PublicationDeliveryUnmarshaller unmarshaller;
+    private final FareZoneSnapshotImporter fareZoneSnapshotImporter;
+    private final SystemSecurityContextService systemSecurityContextService;
+    private final PostgresAdvisoryLock postgresAdvisoryLock;
+    private final BackgroundJobs backgroundJobs;
+    private final HttpClient httpClient;
+
+    private final ScheduledExecutorService scheduler =
+            Executors.newSingleThreadScheduledExecutor(runnable -> new Thread(runnable, "fare-zone-poller"));
+
+    private final AtomicLong runCounter = new AtomicLong();
+
+    public FareZonePoller(FareZonePollerConfig config,
+                          PublicationDeliveryUnmarshaller unmarshaller,
+                          FareZoneSnapshotImporter fareZoneSnapshotImporter,
+                          SystemSecurityContextService systemSecurityContextService,
+                          PostgresAdvisoryLock postgresAdvisoryLock,
+                          BackgroundJobs backgroundJobs) {
+        this.config = config;
+        this.unmarshaller = unmarshaller;
+        this.fareZoneSnapshotImporter = fareZoneSnapshotImporter;
+        this.systemSecurityContextService = systemSecurityContextService;
+        this.postgresAdvisoryLock = postgresAdvisoryLock;
+        this.backgroundJobs = backgroundJobs;
+        this.httpClient = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .connectTimeout(config.getConnectTimeout())
+                .build();
+    }
+
+    @PostConstruct
+    public void scheduleFareZonePolling() {
+        if (!config.isEnabled()) {
+            logger.info("FareZone poller disabled (netex.fareZonePoller.enabled=false)");
+            return;
+        }
+        logger.info("Scheduling FareZone poller: url={}, initialDelay={}, interval={}",
+                config.getUrl(), config.getInitialDelay(), config.getInterval());
+        scheduler.scheduleWithFixedDelay(this::pollSafely,
+                config.getInitialDelay().toSeconds(), config.getInterval().toSeconds(), TimeUnit.SECONDS);
+    }
+
+    private void pollSafely() {
+        try {
+            pollOnce();
+        } catch (Throwable t) {
+            // Never let an exception escape and cancel the recurring schedule.
+            logger.error("Unexpected error during FareZone poll", t);
+        }
+    }
+
+    /**
+     * Fetch and apply the feed once, under the cluster lock. Safe to call manually (for example from
+     * a test or an on-demand trigger). Serialised in-process, and across replicas by the lock.
+     */
+    public synchronized PollResult pollOnce() {
+        if (!config.isEnabled()) {
+            return PollResult.DISABLED;
+        }
+        long run = runCounter.incrementAndGet();
+
+        return postgresAdvisoryLock.tryWithLock(LOCK_KEY, LOCK_NAME, () -> fetchAndImport(run))
+                .orElseGet(() -> {
+                    logger.info("FareZone poller lock held by another instance, skipping (run {})", run);
+                    return PollResult.SKIPPED;
+                });
+    }
+
+    private PollResult fetchAndImport(long run) {
+        final byte[] body;
+        final String hash;
+        try {
+            body = fetch();
+            hash = sha256(body);
+        } catch (Exception e) {
+            logger.error("FareZone fetch failed on run {}: {}", run, e.getMessage(), e);
+            return PollResult.FAILED;
+        }
+
+        if (hash.equals(fareZoneSnapshotImporter.lastImportedHash())) {
+            logger.info("FareZone feed unchanged (hash {}), skipping import (run {})", shortHash(hash), run);
+            return PollResult.SKIPPED;
+        }
+
+        final PublicationDeliveryStructure delivery;
+        try (InputStream inputStream = new ByteArrayInputStream(body)) {
+            delivery = unmarshaller.unmarshal(inputStream);
+        } catch (Exception e) {
+            logger.error("Failed to unmarshal FareZone feed on run {}: {}", run, e.getMessage(), e);
+            return PollResult.FAILED;
+        }
+
+        try {
+            // The hash is recorded in the same transaction as the snapshot, so a failure leaves the
+            // previous hash in place and the next tick retries.
+            systemSecurityContextService.runAsSystemImport(
+                    () -> fareZoneSnapshotImporter.replaceSnapshot(delivery, hash));
+        } catch (Exception e) {
+            logger.error("FareZone import failed on run {}: {}", run, e.getMessage(), e);
+            return PollResult.FAILED;
+        }
+
+        // Stop places reference fare zones, so they are repopulated after the snapshot is committed.
+        backgroundJobs.triggerStopPlaceUpdate();
+
+        logger.info("Imported FareZone feed ({} bytes, hash {}) on run {}", body.length, shortHash(hash), run);
+        return PollResult.IMPORTED;
+    }
+
+    private byte[] fetch() throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(config.getUrl()))
+                .timeout(config.getRequestTimeout())
+                .header("Accept", "application/xml")
+                .GET()
+                .build();
+
+        HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException("Unexpected HTTP status " + response.statusCode() + " fetching " + config.getUrl());
+        }
+        byte[] body = response.body();
+        if (body == null || body.length == 0) {
+            throw new IllegalStateException("Empty response body fetching " + config.getUrl());
+        }
+        return body;
+    }
+
+    private static String sha256(byte[] body) {
+        try {
+            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(body));
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private static String shortHash(String hash) {
+        return hash.length() > 12 ? hash.substring(0, 12) : hash;
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        scheduler.shutdownNow();
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/importer/fetch/FareZoneSnapshotImporter.java
+++ b/src/main/java/org/rutebanken/tiamat/importer/fetch/FareZoneSnapshotImporter.java
@@ -1,0 +1,287 @@
+package org.rutebanken.tiamat.importer.fetch;
+
+import org.rutebanken.netex.model.Common_VersionFrameStructure;
+import org.rutebanken.netex.model.CompositeFrame;
+import org.rutebanken.netex.model.Composite_VersionFrameStructure;
+import org.rutebanken.netex.model.FareFrame;
+import org.rutebanken.netex.model.PublicationDeliveryStructure;
+import org.rutebanken.netex.model.SiteFrame;
+import org.rutebanken.tiamat.model.FareZone;
+import org.rutebanken.tiamat.model.FareZonePollerState;
+import org.rutebanken.tiamat.model.GroupOfTariffZones;
+import org.rutebanken.tiamat.model.TariffZoneRef;
+import org.rutebanken.tiamat.model.identification.IdentifiedEntity;
+import org.rutebanken.tiamat.netex.mapping.NetexMapper;
+import org.rutebanken.tiamat.repository.FareZonePollerStateRepository;
+import org.rutebanken.tiamat.versioning.save.FareZoneSaverService;
+import org.rutebanken.tiamat.versioning.save.GroupOffTariffZonesSaverService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.xml.bind.JAXBElement;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Applies an authoritative FareZone snapshot pulled by {@link FareZonePoller}, replacing the stored
+ * FareZones and GroupOfTariffZones with the contents of the delivery.
+ *
+ * <p>Deliberately not the general {@code PublicationDeliveryImporter}. The feed is external, and the
+ * poller runs it with system privileges, so the general importer would let anything the feed happens
+ * to contain - stop places, parkings, path links, topographic places - be written to the register.
+ * This importer only ever touches the FareZone and GroupOfTariffZones repositories, and rejects a
+ * delivery carrying anything else rather than quietly ignoring it, so drift in the feed is surfaced
+ * instead of silently changing scope.
+ *
+ * <p>The snapshot is validated in full before anything is written, and the whole replacement -
+ * upserts, prunes, and the record of what was imported - is one transaction. A snapshot is applied
+ * completely or not at all: a partial application would leave the register describing a state that
+ * no version of the feed ever had, and would record the feed as successfully imported.
+ *
+ * <p>Expected delivery shape: FareZones in a FareFrame, and the GroupOfTariffZones referencing them
+ * in an accompanying SiteFrame. Anything else in the FareFrame (fare products, tariffs) is inert -
+ * nothing here reads it.
+ */
+@Service
+public class FareZoneSnapshotImporter {
+
+    private static final Logger logger = LoggerFactory.getLogger(FareZoneSnapshotImporter.class);
+
+    private final NetexMapper netexMapper;
+    private final FareZoneSaverService fareZoneSaverService;
+    private final GroupOffTariffZonesSaverService groupOffTariffZonesSaverService;
+    private final FareZonePollerStateRepository fareZonePollerStateRepository;
+
+    public FareZoneSnapshotImporter(NetexMapper netexMapper,
+                                    FareZoneSaverService fareZoneSaverService,
+                                    GroupOffTariffZonesSaverService groupOffTariffZonesSaverService,
+                                    FareZonePollerStateRepository fareZonePollerStateRepository) {
+        this.netexMapper = netexMapper;
+        this.fareZoneSaverService = fareZoneSaverService;
+        this.groupOffTariffZonesSaverService = groupOffTariffZonesSaverService;
+        this.fareZonePollerStateRepository = fareZonePollerStateRepository;
+    }
+
+    public record Result(int importedFareZones, int deletedFareZones, int importedGroups, int deletedGroups) {
+    }
+
+    /**
+     * The hash of the snapshot last applied, or null if none has been. Read outside the import
+     * transaction by the poller, which holds the poller lock while it does so.
+     */
+    @Transactional(readOnly = true)
+    public String lastImportedHash() {
+        return fareZonePollerStateRepository.findById(FareZonePollerState.SINGLETON_ID)
+                .map(FareZonePollerState::getLastImportedHash)
+                .orElse(null);
+    }
+
+    /**
+     * Replace the stored FareZones and GroupOfTariffZones with the delivery's, and record
+     * {@code snapshotHash} as applied.
+     *
+     * @throws IllegalArgumentException if the delivery is not a usable FareZone snapshot
+     * @throws IllegalStateException    if the prune would breach the retain floor
+     */
+    @Transactional
+    public Result replaceSnapshot(PublicationDeliveryStructure delivery, String snapshotHash) {
+        FareFrame fareFrame = findFrame(delivery, FareFrame.class)
+                .orElseThrow(() -> new IllegalArgumentException("FareZone snapshot contains no FareFrame"));
+        SiteFrame siteFrame = findFrame(delivery, SiteFrame.class).orElse(null);
+
+        rejectUnsupportedContent(siteFrame);
+
+        List<FareZone> fareZones = mapFareZones(fareFrame);
+        List<GroupOfTariffZones> groups = mapGroups(siteFrame);
+
+        // Everything is checked before the first write, so a rejected snapshot cannot have deleted or
+        // renumbered anything on its way to being rejected.
+        Set<String> snapshotZoneIds = validate(fareZones, groups);
+
+        // Captured before the saves: the prune safety floor asks how much of the stored register this
+        // snapshot retains, which is unanswerable once the snapshot's own zones are in the count.
+        long fareZonesBeforeImport = fareZoneSaverService.countDistinctStoredNetexIds();
+
+        fareZones.forEach(fareZoneSaverService::saveWithExternalVersioning);
+        int deletedFareZones = fareZoneSaverService.deleteAllExcept(snapshotZoneIds, fareZonesBeforeImport);
+
+        groups.forEach(groupOffTariffZonesSaverService::saveWithExternalVersioning);
+        // A snapshot that declares no groups at all is treated as "the feed said nothing about
+        // groups", not as "delete every group" - the same reading the REST import path takes.
+        int deletedGroups = groups.isEmpty()
+                ? 0
+                : groupOffTariffZonesSaverService.deleteAllExcept(netexIds(groups));
+
+        recordImported(snapshotHash);
+
+        Result result = new Result(fareZones.size(), deletedFareZones, groups.size(), deletedGroups);
+        logger.info("Applied FareZone snapshot: {} FareZones ({} pruned), {} GroupOfTariffZones ({} pruned)",
+                result.importedFareZones(), result.deletedFareZones(),
+                result.importedGroups(), result.deletedGroups());
+        return result;
+    }
+
+    private List<FareZone> mapFareZones(FareFrame fareFrame) {
+        if (fareFrame.getFareZones() == null || fareFrame.getFareZones().getFareZone() == null) {
+            return List.of();
+        }
+        return fareFrame.getFareZones().getFareZone().stream()
+                .map(netexMapper::mapToTiamatModel)
+                .collect(Collectors.toList());
+    }
+
+    private List<GroupOfTariffZones> mapGroups(SiteFrame siteFrame) {
+        if (siteFrame == null
+                || siteFrame.getGroupsOfTariffZones() == null
+                || siteFrame.getGroupsOfTariffZones().getGroupOfTariffZones() == null) {
+            return List.of();
+        }
+        return siteFrame.getGroupsOfTariffZones().getGroupOfTariffZones().stream()
+                .map(netexMapper::mapToTiamatModel)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * @return the netexIds the snapshot declares, which are the FareZones to keep
+     */
+    private Set<String> validate(List<FareZone> fareZones, List<GroupOfTariffZones> groups) {
+        if (fareZones.isEmpty()) {
+            // An empty snapshot would prune every stored zone. Treat it as a broken feed, not as an
+            // instruction to empty the register.
+            throw new IllegalArgumentException("FareZone snapshot contains no FareZones");
+        }
+
+        List<String> missingIds = fareZones.stream()
+                .filter(fareZone -> fareZone.getNetexId() == null)
+                .map(fareZone -> String.valueOf(fareZone.getName()))
+                .toList();
+        if (!missingIds.isEmpty()) {
+            throw new IllegalArgumentException("FareZone snapshot contains zones without an id: " + missingIds);
+        }
+
+        Set<String> zoneIds = netexIds(fareZones);
+        if (zoneIds.size() != fareZones.size()) {
+            throw new IllegalArgumentException(
+                    "FareZone snapshot declares the same FareZone more than once: " + duplicates(fareZones));
+        }
+
+        fareZones.forEach(fareZoneSaverService::validateForExternalVersioning);
+
+        // Under authoritative replacement a member not in the snapshot is about to be pruned, so
+        // members must resolve within the snapshot - not merely somewhere in the database.
+        List<String> unresolvedMembers = groups.stream()
+                .flatMap(group -> group.getMembers().stream())
+                .map(TariffZoneRef::getRef)
+                .filter(ref -> !zoneIds.contains(ref))
+                .distinct()
+                .toList();
+        if (!unresolvedMembers.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "FareZone snapshot has GroupOfTariffZones members that it does not declare: " + unresolvedMembers);
+        }
+
+        return zoneIds;
+    }
+
+    /**
+     * Fail on anything in the SiteFrame this importer does not apply. Such content would be written
+     * to the register by the general importer, so accepting the delivery while ignoring it would
+     * quietly widen what the feed is trusted to change.
+     */
+    private void rejectUnsupportedContent(SiteFrame siteFrame) {
+        if (siteFrame == null) {
+            return;
+        }
+
+        List<String> unsupported = new ArrayList<>();
+        if (siteFrame.getStopPlaces() != null && isNotEmpty(siteFrame.getStopPlaces().getStopPlace_())) {
+            unsupported.add("stopPlaces");
+        }
+        if (siteFrame.getParkings() != null && isNotEmpty(siteFrame.getParkings().getParking())) {
+            unsupported.add("parkings");
+        }
+        if (siteFrame.getPathLinks() != null && isNotEmpty(siteFrame.getPathLinks().getPathLink())) {
+            unsupported.add("pathLinks");
+        }
+        if (siteFrame.getTopographicPlaces() != null && isNotEmpty(siteFrame.getTopographicPlaces().getTopographicPlace())) {
+            unsupported.add("topographicPlaces");
+        }
+        if (siteFrame.getTariffZones() != null && isNotEmpty(siteFrame.getTariffZones().getTariffZone())) {
+            unsupported.add("tariffZones (FareZones belong in the FareFrame)");
+        }
+
+        if (!unsupported.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "FareZone snapshot carries content this importer does not apply: " + unsupported
+                            + ". Only FareZones (FareFrame) and GroupOfTariffZones (SiteFrame) are accepted.");
+        }
+    }
+
+    private void recordImported(String snapshotHash) {
+        FareZonePollerState state = fareZonePollerStateRepository
+                .findById(FareZonePollerState.SINGLETON_ID)
+                .orElseGet(FareZonePollerState::new);
+        state.setLastImportedHash(snapshotHash);
+        state.setLastImportedAt(Instant.now());
+        fareZonePollerStateRepository.save(state);
+    }
+
+    private static boolean isNotEmpty(List<?> elements) {
+        return elements != null && !elements.isEmpty();
+    }
+
+    private static Set<String> netexIds(List<? extends IdentifiedEntity> entities) {
+        return entities.stream()
+                .map(IdentifiedEntity::getNetexId)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private static List<String> duplicates(List<FareZone> fareZones) {
+        Set<String> seen = new LinkedHashSet<>();
+        return fareZones.stream()
+                .map(FareZone::getNetexId)
+                .filter(netexId -> !seen.add(netexId))
+                .distinct()
+                .toList();
+    }
+
+    /**
+     * Find a frame of the given type, whether declared directly or inside a CompositeFrame. Unlike
+     * {@code PublicationDeliveryHelper.findSiteFrame} this does not require the frame to be present.
+     */
+    private static <T extends Common_VersionFrameStructure> Optional<T> findFrame(
+            PublicationDeliveryStructure delivery, Class<T> frameType) {
+
+        if (delivery.getDataObjects() == null) {
+            return Optional.empty();
+        }
+        List<JAXBElement<? extends Common_VersionFrameStructure>> frames =
+                delivery.getDataObjects().getCompositeFrameOrCommonFrame();
+
+        return frames.stream()
+                .map(JAXBElement::getValue)
+                .filter(frameType::isInstance)
+                .map(frameType::cast)
+                .findFirst()
+                .or(() -> frames.stream()
+                        .map(JAXBElement::getValue)
+                        .filter(CompositeFrame.class::isInstance)
+                        .map(CompositeFrame.class::cast)
+                        .map(Composite_VersionFrameStructure::getFrames)
+                        .filter(Objects::nonNull)
+                        .flatMap(nested -> nested.getCommonFrame().stream())
+                        .map(JAXBElement::getValue)
+                        .filter(frameType::isInstance)
+                        .map(frameType::cast)
+                        .findFirst());
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/lock/PostgresAdvisoryLock.java
+++ b/src/main/java/org/rutebanken/tiamat/lock/PostgresAdvisoryLock.java
@@ -1,0 +1,89 @@
+package org.rutebanken.tiamat.lock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * A non-blocking mutual exclusion lock shared by every replica, backed by a PostgreSQL session-level
+ * advisory lock.
+ *
+ * <p>Used where the work must happen on exactly one replica and skipping is the right response to
+ * losing the race. Unlike {@link TimeoutMaxLeaseTimeLock}, this does not depend on the replicas
+ * forming a Hazelcast cluster: Hazelcast member discovery is off by default
+ * ({@code tiamat.hazelcast.kubernetes.enabled}) and is not enabled by the deployment, so each pod
+ * runs a single-member cluster and a Hazelcast lock only excludes threads within one pod.
+ *
+ * <p>The lock is held on a dedicated connection for the whole of {@code work}, so it can span
+ * operations that must not run inside a database transaction - a slow HTTP fetch, or several
+ * separate transactions. It is released in a finally block, and the server releases it anyway if the
+ * connection drops, so a replica dying mid-work cannot strand it.
+ */
+@Component
+public class PostgresAdvisoryLock {
+
+    private static final Logger logger = LoggerFactory.getLogger(PostgresAdvisoryLock.class);
+
+    private final DataSource dataSource;
+
+    public PostgresAdvisoryLock(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    /**
+     * Run {@code work} while holding the advisory lock identified by {@code lockKey}.
+     *
+     * @param lockKey  application-wide constant identifying the lock
+     * @param lockName human readable name, for logging only
+     * @param work     the work to run under the lock; must not return null, since an empty result is
+     *                 how this method reports that the lock could not be taken
+     * @return the result of {@code work}, or {@link Optional#empty()} if the lock is held elsewhere
+     */
+    public <T> Optional<T> tryWithLock(long lockKey, String lockName, Supplier<T> work) {
+        try (Connection connection = dataSource.getConnection()) {
+            if (!tryAcquire(connection, lockKey)) {
+                logger.info("Advisory lock {} ({}) is held elsewhere", lockName, lockKey);
+                return Optional.empty();
+            }
+            logger.info("Acquired advisory lock {} ({})", lockName, lockKey);
+            try {
+                return Optional.of(Objects.requireNonNull(work.get(),
+                        "Work under lock " + lockName + " returned null, which is indistinguishable from not holding the lock"));
+            } finally {
+                release(connection, lockKey, lockName);
+            }
+        } catch (SQLException e) {
+            throw new LockException("Failed to obtain advisory lock " + lockName, e);
+        }
+    }
+
+    private boolean tryAcquire(Connection connection, long lockKey) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("SELECT pg_try_advisory_lock(?)")) {
+            statement.setLong(1, lockKey);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next() && resultSet.getBoolean(1);
+            }
+        }
+    }
+
+    private void release(Connection connection, long lockKey, String lockName) {
+        try (PreparedStatement statement = connection.prepareStatement("SELECT pg_advisory_unlock(?)")) {
+            statement.setLong(1, lockKey);
+            statement.execute();
+            logger.info("Released advisory lock {} ({})", lockName, lockKey);
+        } catch (SQLException e) {
+            // An unlock that fails on a live connection is not something Postgres does; the realistic
+            // cause is a dead connection, and the server drops the session's locks with the session.
+            logger.warn("Could not release advisory lock {} ({})", lockName, lockKey, e);
+        }
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/model/FareZonePollerState.java
+++ b/src/main/java/org/rutebanken/tiamat/model/FareZonePollerState.java
@@ -1,0 +1,50 @@
+package org.rutebanken.tiamat.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+/**
+ * Single-row record of what {@code FareZonePoller} last imported, shared by every replica.
+ *
+ * <p>Kept in the database rather than in a Hazelcast map: the replicas do not form a Hazelcast
+ * cluster (see {@link org.rutebanken.tiamat.lock.PostgresAdvisoryLock}), so a map would be per-pod
+ * and every pod would re-import each snapshot once, and it would be lost on restart. Written in the
+ * same transaction as the snapshot it describes, so the record and the data cannot diverge.
+ */
+@Entity
+@Table(name = "fare_zone_poller_state")
+public class FareZonePollerState {
+
+    /** The table holds exactly one row, under this id. */
+    public static final short SINGLETON_ID = 1;
+
+    @Id
+    private short id = SINGLETON_ID;
+
+    private String lastImportedHash;
+
+    private Instant lastImportedAt;
+
+    public short getId() {
+        return id;
+    }
+
+    public String getLastImportedHash() {
+        return lastImportedHash;
+    }
+
+    public void setLastImportedHash(String lastImportedHash) {
+        this.lastImportedHash = lastImportedHash;
+    }
+
+    public Instant getLastImportedAt() {
+        return lastImportedAt;
+    }
+
+    public void setLastImportedAt(Instant lastImportedAt) {
+        this.lastImportedAt = lastImportedAt;
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/netex/mapping/mapper/FareZoneMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/netex/mapping/mapper/FareZoneMapper.java
@@ -15,6 +15,8 @@ import org.rutebanken.netex.model.ScheduledStopPointRefStructure;
 import org.rutebanken.netex.model.ScopingMethodEnumeration;
 import org.rutebanken.tiamat.model.StopPlaceReference;
 import org.rutebanken.tiamat.model.TariffZoneRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.List;
@@ -23,6 +25,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class FareZoneMapper extends CustomMapper<FareZone, org.rutebanken.tiamat.model.FareZone> {
+
+    private static final Logger logger = LoggerFactory.getLogger(FareZoneMapper.class);
 
     final ObjectFactory objectFactory = new ObjectFactory();
 
@@ -41,16 +45,22 @@ public class FareZoneMapper extends CustomMapper<FareZone, org.rutebanken.tiamat
             tiamatFareZone.setNeighbours(tiamatNeighbours);
         }
 
-        if (netexFareZone.getScopingMethod() != null && netexFareZone.getScopingMethod().equals(ScopingMethodEnumeration.EXPLICIT_STOPS)
-                && netexFareZone.getMembers() != null && !netexFareZone.getMembers().getPointRef().isEmpty()) {
+        if (netexFareZone.getScopingMethod() != null && netexFareZone.getScopingMethod().equals(ScopingMethodEnumeration.EXPLICIT_STOPS)) {
+            if (netexFareZone.getMembers() != null && !netexFareZone.getMembers().getPointRef().isEmpty()) {
 
-            var fareZoneMembers = netexFareZone.getMembers().getPointRef().stream()
-                    .map(jaxbElement -> convertScheduledStopPointRefToStopPlaceRef(jaxbElement.getValue().getRef()))
-                    .filter(Objects::nonNull)
-                    .map(StopPlaceReference::new)
-                    .collect(Collectors.toSet());
+                var fareZoneMembers = netexFareZone.getMembers().getPointRef().stream()
+                        .map(jaxbElement -> convertScheduledStopPointRefToStopPlaceRef(jaxbElement.getValue().getRef()))
+                        .filter(Objects::nonNull)
+                        .map(StopPlaceReference::new)
+                        .collect(Collectors.toSet());
 
-            tiamatFareZone.setFareZoneMembers(fareZoneMembers);
+                tiamatFareZone.setFareZoneMembers(fareZoneMembers);
+            } else {
+                // An explicitly scoped zone with no members matches no stops. Surface it so the
+                // upstream data can be raised with the feed owner.
+                logger.warn("FareZone {} is scoped EXPLICIT_STOPS but has no members; it will match no stops. "
+                        + "Raise with the feed owner if this is unexpected.", netexFareZone.getId());
+            }
         }
     }
 

--- a/src/main/java/org/rutebanken/tiamat/repository/FareZonePollerStateRepository.java
+++ b/src/main/java/org/rutebanken/tiamat/repository/FareZonePollerStateRepository.java
@@ -1,0 +1,7 @@
+package org.rutebanken.tiamat.repository;
+
+import org.rutebanken.tiamat.model.FareZonePollerState;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FareZonePollerStateRepository extends JpaRepository<FareZonePollerState, Short> {
+}

--- a/src/main/java/org/rutebanken/tiamat/repository/FareZoneRepository.java
+++ b/src/main/java/org/rutebanken/tiamat/repository/FareZoneRepository.java
@@ -16,8 +16,11 @@
 package org.rutebanken.tiamat.repository;
 
 import org.rutebanken.tiamat.model.FareZone;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FareZoneRepository extends EntityInVersionRepository<FareZone>, FareZoneRepositoryCustom {
 
+    @Query("select count(distinct fareZone.netexId) from FareZone fareZone")
+    long countDistinctNetexIds();
 }
 

--- a/src/main/java/org/rutebanken/tiamat/service/TariffZonesLookupService.java
+++ b/src/main/java/org/rutebanken/tiamat/service/TariffZonesLookupService.java
@@ -37,8 +37,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -57,6 +59,8 @@ public class TariffZonesLookupService {
 
     private final ResettableMemoizer<List<Pair<String, Geometry>>> tariffZones = new ResettableMemoizer<>(getTariffZones());
     private final ResettableMemoizer<List<Pair<String, Geometry>>> fareZones = new ResettableMemoizer<>(getFareZones());
+    private final ResettableMemoizer<Map<String, Set<TariffZoneRef>>> explicitFareZoneRefsByMember =
+            new ResettableMemoizer<>(getExplicitFareZoneRefsByMember());
 
     private final TariffZoneRepository tariffZoneRepository;
     private final FareZoneRepository fareZoneRepository;
@@ -95,14 +99,19 @@ public class TariffZonesLookupService {
 
             Set<TariffZoneRef> allMatches = new HashSet<>(tariffZoneMatches);
 
+            // Spatially projected zones cover the stop geographically.
             Set<TariffZoneRef> fareZoneMatches = findFareZones(stopPlace.getCentroid())
                     .stream()
-                    .filter(fareZone -> stopPlace.getTariffZones().isEmpty() || isNoneMatch(stopPlace, fareZone))
+                    .filter(fareZone -> shouldAttachSpatialFareZone(stopPlace, fareZone))
                     .map(TariffZoneRef::new)
                     .collect(toSet());
 
-
             allMatches.addAll(fareZoneMatches);
+
+            // Explicitly scoped zones list the stop as a member. Resolved separately, because the
+            // spatial lookup would never offer them: it only considers zones that have a geometry and
+            // whose polygon covers the stop, and neither is what defines this scope.
+            allMatches.addAll(explicitFareZoneRefsFor(stopPlace.getNetexId()));
 
             stopPlace.getTariffZones().addAll(allMatches);
 
@@ -113,19 +122,61 @@ public class TariffZonesLookupService {
         return false;
     }
 
-    private boolean isNoneMatch(StopPlace stopPlace, FareZone fareZone) {
-        if (fareZone.getScopingMethod().equals(ScopingMethodEnumeration.IMPLICIT_SPATIAL_PROJECTION)) {
-            return stopPlace.getTariffZones()
-                    .stream()
-                    .noneMatch(tariffZoneRef -> fareZone.getNetexId().equals(tariffZoneRef.getRef()) && tariffZoneRef.getVersion().equals(String.valueOf(fareZone.getVersion())));
+    /**
+     * Decide whether a fare zone whose polygon covers the stop should be attached to it.
+     *
+     * <p>Coverage is only grounds for attaching a zone that is scoped by spatial projection. An
+     * EXPLICIT_STOPS zone is scoped to a listed set of stops, so it is never attached from here, even
+     * when its polygon happens to cover the stop; membership decides, and
+     * {@link #explicitFareZoneRefsFor(String)} handles it.
+     */
+    private boolean shouldAttachSpatialFareZone(StopPlace stopPlace, FareZone fareZone) {
+        if (ScopingMethodEnumeration.EXPLICIT_STOPS.equals(fareZone.getScopingMethod())) {
+            return false;
         }
-        if (fareZone.getScopingMethod().equals(ScopingMethodEnumeration.EXPLICIT_STOPS) && !fareZone.getFareZoneMembers().isEmpty()) {
-            return fareZone.getFareZoneMembers().stream()
-                    .anyMatch(member -> member.getRef().equals(stopPlace.getNetexId()));
-        }
-        return true;
-
+        return stopPlace.getTariffZones()
+                .stream()
+                .noneMatch(tariffZoneRef -> fareZone.getNetexId().equals(tariffZoneRef.getRef())
+                        && tariffZoneRef.getVersion().equals(String.valueOf(fareZone.getVersion())));
     }
+
+    /**
+     * Refs of the EXPLICIT_STOPS fare zones that list this stop place as a member.
+     */
+    private Set<TariffZoneRef> explicitFareZoneRefsFor(String stopPlaceNetexId) {
+        return explicitFareZoneRefsByMember.get().getOrDefault(stopPlaceNetexId, Set.of());
+    }
+
+    /**
+     * Index of EXPLICIT_STOPS fare zones by the stop place they list as a member, so a membership
+     * lookup costs no query per stop. Memoized and reset alongside {@link #fareZones}.
+     */
+    public Supplier<Map<String, Set<TariffZoneRef>>> getExplicitFareZoneRefsByMember() {
+        return () -> {
+            logger.info("Fetching and memoizing explicitly scoped fare zone members from repository");
+            Map<String, Set<TariffZoneRef>> refsByMember = new HashMap<>();
+
+            fareZoneRepository.findAllValidFareZones()
+                    .stream()
+                    .filter(fareZone -> ScopingMethodEnumeration.EXPLICIT_STOPS.equals(fareZone.getScopingMethod()))
+                    .collect(
+                            groupingBy(FareZone::getNetexId,
+                                    maxBy(Comparator.comparingLong(EntityInVersionStructure::getVersion))))
+                    .values()
+                    .stream()
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .forEach(fareZone -> {
+                        TariffZoneRef ref = new TariffZoneRef(fareZone);
+                        fareZone.getFareZoneMembers().forEach(member ->
+                                refsByMember.computeIfAbsent(member.getRef(), key -> new HashSet<>()).add(ref));
+                    });
+
+            logger.debug("Memoized explicitly scoped fare zone members for {} stop places", refsByMember.size());
+            return refsByMember;
+        };
+    }
+
     private Set<String> mapToIdStrings(Set<TariffZoneRef> tariffZoneRefs) {
         return tariffZoneRefs.stream().map(tzr -> tzr.getRef()).collect(toSet());
     }
@@ -193,6 +244,7 @@ public class TariffZonesLookupService {
     }
 
     public void resetFareZone() {
+        explicitFareZoneRefsByMember.reset();
         fareZones.reset();
     }
 

--- a/src/main/java/org/rutebanken/tiamat/versioning/save/FareZoneSaverService.java
+++ b/src/main/java/org/rutebanken/tiamat/versioning/save/FareZoneSaverService.java
@@ -25,10 +25,12 @@ import org.rutebanken.tiamat.versioning.validate.VersionValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -45,19 +47,42 @@ public class FareZoneSaverService {
     private final UsernameFetcher usernameFetcher;
     private final AuthorizationService authorizationService;
 
+    /**
+     * Minimum fraction of currently stored FareZones that must survive a full-replace prune.
+     * Guards against a truncated or partially generated feed wiping the register. A value of
+     * 0.5 means the incoming delivery must retain at least half of the existing zones.
+     */
+    private final double pruneMinRetainRatio;
+
     @Autowired
     public FareZoneSaverService(FareZoneRepository fareZoneRepository,
                                 TariffZonesLookupService tariffZonesLookupService,
                                 DefaultVersionedSaverService defaultVersionedSaverService,
                                 VersionValidator versionValidator,
                                 UsernameFetcher usernameFetcher,
-                                AuthorizationService authorizationService) {
+                                AuthorizationService authorizationService,
+                                @Value("${fareZone.prune.minRetainRatio:0.5}") double pruneMinRetainRatio) {
         this.fareZoneRepository = fareZoneRepository;
         this.tariffZonesLookupService = tariffZonesLookupService;
         this.defaultVersionedSaverService = defaultVersionedSaverService;
         this.versionValidator = versionValidator;
         this.usernameFetcher = usernameFetcher;
         this.authorizationService = authorizationService;
+        this.pruneMinRetainRatio = validateRetainRatio(pruneMinRetainRatio);
+    }
+
+    /**
+     * Fail startup on a ratio that cannot express a retain floor. A non-finite or negative value
+     * makes the comparison permanently false, silently disabling the guard; above 1 rejects every
+     * prune. Both are worse than a wrong-but-usable number, because neither is visible in operation.
+     */
+    private static double validateRetainRatio(double pruneMinRetainRatio) {
+        if (!Double.isFinite(pruneMinRetainRatio) || pruneMinRetainRatio < 0 || pruneMinRetainRatio > 1) {
+            throw new IllegalArgumentException(
+                    "fareZone.prune.minRetainRatio must be a finite fraction between 0 and 1, but was "
+                            + pruneMinRetainRatio);
+        }
+        return pruneMinRetainRatio;
     }
 
     public FareZone saveNewVersion(FareZone newVersion) {
@@ -85,23 +110,20 @@ public class FareZoneSaverService {
      * Used when Tiamat acts as a replica of a master FareZone register.
      *
      * @param incomingFareZone The fare zone to save/update
-     * @return The saved fare zone, or null if validation fails
+     * @return The saved fare zone
+     * @throws IllegalArgumentException if the incoming fare zone is not valid
      */
     public FareZone saveWithExternalVersioning(FareZone incomingFareZone) {
+        // Before anything is touched, so a rejected zone leaves no trace.
+        validateForExternalVersioning(incomingFareZone);
+
         FareZone existingFareZone = null;
 
         if (incomingFareZone.getNetexId() != null) {
-            existingFareZone = fareZoneRepository.findFirstByNetexIdOrderByVersionDesc(incomingFareZone.getNetexId());
+            existingFareZone = findExistingAndDropSupersededVersions(incomingFareZone.getNetexId());
         }
 
         authorizationService.verifyCanEditEntities(Arrays.asList(existingFareZone, incomingFareZone));
-
-        // Validate ValidBetween constraints
-        if (!validateValidBetween(incomingFareZone)) {
-            logger.warn("Ignoring FareZone {} version {} - invalid ValidBetween: fromDate is after toDate",
-                    incomingFareZone.getNetexId(), incomingFareZone.getVersion());
-            return null;
-        }
 
         String username = usernameFetcher.getUserNameForAuthenticatedUser();
         Instant now = Instant.now();
@@ -135,6 +157,48 @@ public class FareZoneSaverService {
     }
 
     /**
+     * Return the row to update in place under external versioning, deleting any other rows for the
+     * same netexId first.
+     *
+     * <p>External versioning keeps a single row per netexId, holding whatever version the master
+     * sent. Rows left behind by earlier default-versioned saves break that: reads resolve a FareZone
+     * by {@code MAX(version)}, so once the surviving row is set to a lower master version an older
+     * sibling becomes the answer. There is also no unique constraint on (netex_id, version), so a
+     * sibling that happens to carry the incoming version would silently duplicate it.
+     *
+     * <p>This makes the first external-versioning save for a netexId the cutover point from
+     * versioned history to a single mastered row.
+     */
+    private FareZone findExistingAndDropSupersededVersions(String netexId) {
+        List<FareZone> existingVersions = fareZoneRepository.findByNetexId(netexId);
+        if (existingVersions.isEmpty()) {
+            return null;
+        }
+
+        FareZone latest = existingVersions.stream()
+                .max(Comparator.comparingLong(FareZone::getVersion))
+                .orElseThrow();
+
+        List<FareZone> superseded = existingVersions.stream()
+                .filter(fareZone -> !fareZone.getId().equals(latest.getId()))
+                .toList();
+
+        if (!superseded.isEmpty()) {
+            String supersededVersions = superseded.stream()
+                    .map(fareZone -> String.valueOf(fareZone.getVersion()))
+                    .collect(Collectors.joining(", "));
+            logger.info("Dropping {} superseded version(s) of FareZone {} on external versioning: {}. Keeping version {}.",
+                    superseded.size(), netexId, supersededVersions, latest.getVersion());
+            fareZoneRepository.deleteAll(superseded);
+            // Flush before the surviving row is renumbered, so the deletes cannot be ordered after
+            // an update that lands on a version one of them still holds.
+            fareZoneRepository.flush();
+        }
+
+        return latest;
+    }
+
+    /**
      * Copy all relevant fields from source to target FareZone.
      * Preserves the target's database ID.
      */
@@ -145,10 +209,16 @@ public class FareZoneSaverService {
         target.setDescription(source.getDescription());
         target.setPrivateCode(source.getPrivateCode());
         target.setPolygon(source.getPolygon());
+        target.setMultiSurface(source.getMultiSurface());
         target.setValidBetween(source.getValidBetween());
         target.setScopingMethod(source.getScopingMethod());
         target.setZoneTopology(source.getZoneTopology());
         target.setTransportOrganisationRef(source.getTransportOrganisationRef());
+
+        // keyValues carries the tzMapping bridge to the legacy TariffZone ids. Without this
+        // the DB keeps stale mappings on every update after create.
+        target.getKeyValues().clear();
+        target.getKeyValues().putAll(source.getKeyValues());
 
         if (source.getNeighbours() != null) {
             target.getNeighbours().clear();
@@ -162,28 +232,39 @@ public class FareZoneSaverService {
     }
 
     /**
-     * Validate ValidBetween constraints for a FareZone.
-     * If both fromDate and toDate are present, fromDate must not be after toDate.
+     * Validate an incoming FareZone against the constraints external versioning requires: if both
+     * fromDate and toDate are present, fromDate must not be after toDate.
+     *
+     * <p>Rejects the whole save rather than skipping the zone. Under external versioning the import
+     * is an authoritative replacement, and a skipped zone is absent from the set of ids to keep - so
+     * silently ignoring it deletes the copy already stored, on the strength of the very record that
+     * failed validation.
      *
      * @param fareZone The fare zone to validate
-     * @return true if validation passes, false if validation fails
+     * @throws IllegalArgumentException if the fare zone is not valid
      */
-    private boolean validateValidBetween(FareZone fareZone) {
+    public void validateForExternalVersioning(FareZone fareZone) {
         if (fareZone.getValidBetween() == null) {
-            return true; // No ValidBetween is acceptable
+            return; // No ValidBetween is acceptable
         }
 
         Instant fromDate = fareZone.getValidBetween().getFromDate();
         Instant toDate = fareZone.getValidBetween().getToDate();
 
-        // If both dates are present, fromDate must not be after toDate
         if (fromDate != null && toDate != null && fromDate.isAfter(toDate)) {
-            logger.warn("FareZone {} has invalid ValidBetween: fromDate {} is after toDate {}",
-                    fareZone.getNetexId(), fromDate, toDate);
-            return false;
+            throw new IllegalArgumentException(String.format(
+                    "FareZone %s version %d has invalid ValidBetween: fromDate %s is after toDate %s",
+                    fareZone.getNetexId(), fareZone.getVersion(), fromDate, toDate));
         }
+    }
 
-        return true;
+    /**
+     * The number of distinct FareZone netexIds currently stored. Callers capture this before an
+     * authoritative import so {@link #deleteAllExcept(Set, long)} can measure its retain floor
+     * against the register as it was, not as the import has already left it.
+     */
+    public long countDistinctStoredNetexIds() {
+        return fareZoneRepository.countDistinctNetexIds();
     }
 
     /**
@@ -191,10 +272,19 @@ public class FareZoneSaverService {
      * Used for cleanup after external versioning import to remove orphaned FareZones.
      * Respects user permissions and logs all deleted netexIds.
      *
-     * @param netexIdsToKeep Set of netexIds to preserve
+     * <p>The retain floor is measured against {@code existingDistinctCount}, taken before the import
+     * wrote anything. Counting the stored zones here instead would count the incoming ones too - they
+     * have already been saved by the time the prune runs - which inflates the denominator by exactly
+     * the zones the feed brought. That makes the floor unreachable in the case it exists for: a feed
+     * that replaces every id retains nothing of the old register, yet lands on the threshold and
+     * passes.
+     *
+     * @param netexIdsToKeep       Set of netexIds to preserve
+     * @param existingDistinctCount distinct netexIds stored before this import began, from
+     *                              {@link #countDistinctStoredNetexIds()}
      * @return Number of FareZones deleted
      */
-    public int deleteAllExcept(Set<String> netexIdsToKeep) {
+    public int deleteAllExcept(Set<String> netexIdsToKeep, long existingDistinctCount) {
         List<FareZone> allFareZones = fareZoneRepository.findAll();
 
         List<FareZone> toDelete = allFareZones.stream()
@@ -204,6 +294,20 @@ public class FareZoneSaverService {
         if (toDelete.isEmpty()) {
             logger.info("No orphaned FareZones to delete");
             return 0;
+        }
+
+        // Every id being deleted pre-dates the import, so the retained count follows from the baseline.
+        long deletingDistinct = toDelete.stream().map(FareZone::getNetexId).distinct().count();
+        long retainedDistinct = existingDistinctCount - deletingDistinct;
+
+        if (existingDistinctCount > 0 && retainedDistinct < existingDistinctCount * pruneMinRetainRatio) {
+            throw new IllegalStateException(String.format(
+                    "Refusing FareZone prune: would keep %d of the %d zones stored before this import (%.1f%%), "
+                            + "below the safety floor of %.1f%%. This usually indicates a truncated or partial feed. "
+                            + "Aborting to avoid mass deletion.",
+                    retainedDistinct, existingDistinctCount,
+                    100.0 * retainedDistinct / existingDistinctCount,
+                    100.0 * pruneMinRetainRatio));
         }
 
         authorizationService.verifyCanEditEntities(toDelete);

--- a/src/main/java/org/rutebanken/tiamat/versioning/save/GroupOffTariffZonesSaverService.java
+++ b/src/main/java/org/rutebanken/tiamat/versioning/save/GroupOffTariffZonesSaverService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -84,7 +85,7 @@ public class GroupOffTariffZonesSaverService {
         GroupOfTariffZones existingGroupOfTariffZones = null;
 
         if (incomingGroupOfTariffZones.getNetexId() != null) {
-            existingGroupOfTariffZones = groupOfTariffZonesRepository.findFirstByNetexIdOrderByVersionDesc(incomingGroupOfTariffZones.getNetexId());
+            existingGroupOfTariffZones = findExistingAndDropSupersededVersions(incomingGroupOfTariffZones.getNetexId());
         }
 
         authorizationService.verifyCanEditEntities(Arrays.asList(existingGroupOfTariffZones, incomingGroupOfTariffZones));
@@ -117,6 +118,45 @@ public class GroupOffTariffZonesSaverService {
                 saved.getNetexId(), saved.getVersion(), username);
 
         return saved;
+    }
+
+    /**
+     * Return the row to update in place under external versioning, deleting any other rows for the
+     * same netexId first.
+     *
+     * <p>External versioning keeps a single row per netexId, holding whatever version the master
+     * sent. Rows left behind by earlier default-versioned saves break that: reads resolve by
+     * highest version, so once the surviving row is set to a lower master version an older sibling
+     * becomes the answer. This makes the first external-versioning save for a netexId the cutover
+     * point from versioned history to a single mastered row.
+     */
+    private GroupOfTariffZones findExistingAndDropSupersededVersions(String netexId) {
+        List<GroupOfTariffZones> existingVersions = groupOfTariffZonesRepository.findByNetexId(netexId);
+        if (existingVersions.isEmpty()) {
+            return null;
+        }
+
+        GroupOfTariffZones latest = existingVersions.stream()
+                .max(Comparator.comparingLong(GroupOfTariffZones::getVersion))
+                .orElseThrow();
+
+        List<GroupOfTariffZones> superseded = existingVersions.stream()
+                .filter(group -> !group.getId().equals(latest.getId()))
+                .toList();
+
+        if (!superseded.isEmpty()) {
+            String supersededVersions = superseded.stream()
+                    .map(group -> String.valueOf(group.getVersion()))
+                    .collect(Collectors.joining(", "));
+            logger.info("Dropping {} superseded version(s) of GroupOfTariffZones {} on external versioning: {}. Keeping version {}.",
+                    superseded.size(), netexId, supersededVersions, latest.getVersion());
+            groupOfTariffZonesRepository.deleteAll(superseded);
+            // Flush before the surviving row is renumbered, so the deletes cannot be ordered after
+            // an update that lands on a version one of them still holds.
+            groupOfTariffZonesRepository.flush();
+        }
+
+        return latest;
     }
 
     /**

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -58,6 +58,15 @@ groupOfTariffZones.externalVersioning=false
 # TariffZones are deprecated. When enabled, plain TariffZones are skipped on import (FareZones and GroupOfTariffZones are still imported)
 ignoreTariffZoneImport=false
 
+# Scheduled poller that pulls the external FareZone master feed and applies it as an authoritative
+# full replace of FareZones and GroupOfTariffZones (disabled by default). The replace is inherent to
+# the poller, so it needs no versioning flags; fareZone.externalVersioning above only governs manual
+# imports.
+netex.fareZonePoller.enabled=false
+netex.fareZonePoller.url=https://api.entur.io/distance/netex/fare-zones
+netex.fareZonePoller.initialDelaySeconds=60
+netex.fareZonePoller.intervalSeconds=3600
+
 debug=true
 
 # Disable feature detection by this undocumented parameter. Check the org.hibernate.engine.jdbc.internal.JdbcServiceImpl.configure method for more details.

--- a/src/main/resources/db/migration/V63__create_fare_zone_poller_state.sql
+++ b/src/main/resources/db/migration/V63__create_fare_zone_poller_state.sql
@@ -1,0 +1,8 @@
+-- Single-row record of the snapshot FareZonePoller last imported, shared by all replicas.
+CREATE TABLE fare_zone_poller_state (
+    id SMALLINT NOT NULL PRIMARY KEY,
+    last_imported_hash VARCHAR(64),
+    last_imported_at TIMESTAMP WITHOUT TIME ZONE
+);
+
+INSERT INTO fare_zone_poller_state (id) VALUES (1);

--- a/src/test/java/org/rutebanken/tiamat/auth/SystemSecurityContextServiceTest.java
+++ b/src/test/java/org/rutebanken/tiamat/auth/SystemSecurityContextServiceTest.java
@@ -1,0 +1,114 @@
+package org.rutebanken.tiamat.auth;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.rutebanken.helper.organisation.user.UserInfoExtractor;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test for the system-import context: within it, authorization edit checks are granted and the
+ * write is attributed to the system name without consulting the user registry; the context is fully
+ * restored afterwards.
+ */
+public class SystemSecurityContextServiceTest {
+
+    private final SystemSecurityContextService service = new SystemSecurityContextService("tiamat-system");
+    private final DefaultAuthorizationService authorizationService =
+            new DefaultAuthorizationService(null, true, null, null, null);
+
+    /**
+     * Stands in for the deployed extractor, which resolves the actor against the Baba user registry.
+     * A system import must never reach it: the system actor has no registry entry, and the lookup
+     * requires JWT claims (issuer) that a system import has no legitimate value for.
+     */
+    private final UserInfoExtractor failingExtractor = new UserInfoExtractor() {
+        @Override
+        public String getPreferredName() {
+            throw new AssertionError("User registry must not be consulted for a system import");
+        }
+
+        @Override
+        public String getPreferredUsername() {
+            throw new AssertionError("User registry must not be consulted for a system import");
+        }
+    };
+
+    private final UsernameFetcher usernameFetcher = new UsernameFetcher(failingExtractor);
+
+    @Before
+    @After
+    public void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void grantsEditChecksWithinSystemImport() {
+        // Outside the system import there is no principal, so edits are denied.
+        assertThat(authorizationService.canEditAllEntities()).isFalse();
+        assertThat(SystemImportContext.isActive()).isFalse();
+
+        AtomicBoolean ran = new AtomicBoolean(false);
+        service.runAsSystemImport(() -> {
+            assertThat(SystemImportContext.isActive()).isTrue();
+            assertThat(authorizationService.canEditAllEntities()).isTrue();
+            // verify* must not throw for a system import
+            authorizationService.verifyCanEditEntities(List.of());
+            authorizationService.verifyCanDeleteEntities(List.of());
+            ran.set(true);
+            return null;
+        });
+
+        assertThat(ran).isTrue();
+    }
+
+    @Test
+    public void attributesWritesToSystemNameWithoutUserLookup() {
+        service.runAsSystemImport(() -> {
+            assertThat(usernameFetcher.getUserNameForAuthenticatedUser()).isEqualTo("tiamat-system");
+            return null;
+        });
+    }
+
+    /**
+     * No principal is installed for a system import. A fabricated JWT would be passed to the
+     * deployed extractor, which requires an issuer claim and a matching user in the registry.
+     */
+    @Test
+    public void installsNoPrincipalForSystemImport() {
+        service.runAsSystemImport(() -> {
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+            return null;
+        });
+    }
+
+    @Test
+    public void restoresContextAndFlagAfterRun() {
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+
+        service.runAsSystemImport(() -> null);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(SystemImportContext.isActive()).isFalse();
+        assertThat(usernameFetcher.getUserNameForAuthenticatedUser()).isNull();
+    }
+
+    @Test
+    public void restoresContextAndFlagEvenOnException() {
+        try {
+            service.runAsSystemImport(() -> {
+                throw new RuntimeException("boom");
+            });
+        } catch (RuntimeException expected) {
+            // ignored
+        }
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(SystemImportContext.isActive()).isFalse();
+    }
+}

--- a/src/test/java/org/rutebanken/tiamat/importer/fetch/FareZonePollerIntegrationTest.java
+++ b/src/test/java/org/rutebanken/tiamat/importer/fetch/FareZonePollerIntegrationTest.java
@@ -1,0 +1,261 @@
+package org.rutebanken.tiamat.importer.fetch;
+
+import com.sun.net.httpserver.HttpServer;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.Marshaller;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.rutebanken.netex.model.FareFrame;
+import org.rutebanken.netex.model.FareZone;
+import org.rutebanken.netex.model.FareZonesInFrame_RelStructure;
+import org.rutebanken.netex.model.GroupOfTariffZones;
+import org.rutebanken.netex.model.GroupsOfTariffZonesInFrame_RelStructure;
+import org.rutebanken.netex.model.MultilingualString;
+import org.rutebanken.netex.model.ObjectFactory;
+import org.rutebanken.netex.model.PublicationDeliveryStructure;
+import org.rutebanken.netex.model.StopPlace;
+import org.rutebanken.netex.model.StopPlacesInFrame_RelStructure;
+import org.rutebanken.netex.model.TariffZoneRef;
+import org.rutebanken.netex.model.TariffZoneRefs_RelStructure;
+import org.rutebanken.tiamat.TiamatIntegrationTest;
+import org.rutebanken.tiamat.auth.SystemSecurityContextService;
+import org.rutebanken.tiamat.config.FareZonePollerConfig;
+import org.rutebanken.tiamat.lock.PostgresAdvisoryLock;
+import org.rutebanken.tiamat.repository.FareZonePollerStateRepository;
+import org.rutebanken.tiamat.rest.netex.publicationdelivery.PublicationDeliveryTestHelper;
+import org.rutebanken.tiamat.rest.netex.publicationdelivery.PublicationDeliveryUnmarshaller;
+import org.rutebanken.tiamat.service.batch.BackgroundJobs;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.sql.DataSource;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FareZonePollerIntegrationTest extends TiamatIntegrationTest {
+
+    @Autowired
+    private PublicationDeliveryUnmarshaller unmarshaller;
+
+    @Autowired
+    private FareZoneSnapshotImporter fareZoneSnapshotImporter;
+
+    @Autowired
+    private SystemSecurityContextService systemSecurityContextService;
+
+    @Autowired
+    private PostgresAdvisoryLock postgresAdvisoryLock;
+
+    @Autowired
+    private BackgroundJobs backgroundJobs;
+
+    @Autowired
+    private FareZonePollerStateRepository fareZonePollerStateRepository;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private PublicationDeliveryTestHelper publicationDeliveryTestHelper;
+
+    private final ObjectFactory objectFactory = new ObjectFactory();
+
+    private HttpServer server;
+    private byte[] feedBytes;
+
+    @Before
+    public void startServer() throws Exception {
+        fareZonePollerStateRepository.deleteAll();
+        fareZonePollerStateRepository.flush();
+        feedBytes = marshal(deliveryWithFareZones("NSR:FareZone:9001"));
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/feed", exchange -> {
+            exchange.getResponseHeaders().add("Content-Type", "application/xml");
+            exchange.sendResponseHeaders(200, feedBytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(feedBytes);
+            }
+        });
+        server.start();
+    }
+
+    @After
+    public void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void pollsFetchesAndImports() {
+        FareZonePoller poller = newPoller(feedUrl());
+
+        assertThat(poller.pollOnce()).isEqualTo(FareZonePoller.PollResult.IMPORTED);
+        assertThat(fareZoneRepository.findFirstByNetexIdOrderByVersionDesc("NSR:FareZone:9001")).isNotNull();
+    }
+
+    @Test
+    public void unchangedFeedIsNotReimported() {
+        FareZonePoller poller = newPoller(feedUrl());
+
+        assertThat(poller.pollOnce()).isEqualTo(FareZonePoller.PollResult.IMPORTED);
+        // Same body on the next tick: skipped by the recorded hash.
+        assertThat(poller.pollOnce()).isEqualTo(FareZonePoller.PollResult.SKIPPED);
+    }
+
+    /**
+     * The record of what was imported is shared, so a second replica does not redo the same import.
+     * A Hazelcast map would be per-pod, since the replicas do not form a cluster.
+     */
+    @Test
+    public void recordedHashIsSharedAcrossPollerInstances() {
+        assertThat(newPoller(feedUrl()).pollOnce()).isEqualTo(FareZonePoller.PollResult.IMPORTED);
+
+        assertThat(newPoller(feedUrl()).pollOnce()).isEqualTo(FareZonePoller.PollResult.SKIPPED);
+    }
+
+    @Test
+    public void httpErrorYieldsFailedAndNoImport() {
+        FareZonePoller poller = newPoller("http://127.0.0.1:" + server.getAddress().getPort() + "/missing");
+
+        assertThat(poller.pollOnce()).isEqualTo(FareZonePoller.PollResult.FAILED);
+        assertThat(fareZoneRepository.findFirstByNetexIdOrderByVersionDesc("NSR:FareZone:9001")).isNull();
+    }
+
+    /**
+     * The lock is held by a separate database session, as another replica would hold it. It is taken
+     * before the fetch, so losing the race means not pulling the feed at all.
+     */
+    @Test
+    public void skipsWhenAnotherInstanceHoldsTheLock() throws Exception {
+        FareZonePoller poller = newPoller(feedUrl());
+
+        try (Connection otherSession = dataSource.getConnection()) {
+            try (PreparedStatement lock = otherSession.prepareStatement("SELECT pg_advisory_lock(?)")) {
+                lock.setLong(1, FareZonePoller.LOCK_KEY);
+                lock.execute();
+            }
+
+            assertThat(poller.pollOnce()).isEqualTo(FareZonePoller.PollResult.SKIPPED);
+            assertThat(fareZoneRepository.findFirstByNetexIdOrderByVersionDesc("NSR:FareZone:9001")).isNull();
+
+            try (PreparedStatement unlock = otherSession.prepareStatement("SELECT pg_advisory_unlock(?)")) {
+                unlock.setLong(1, FareZonePoller.LOCK_KEY);
+                unlock.execute();
+            }
+        }
+
+        // The lock is free again, so the next tick imports.
+        assertThat(poller.pollOnce()).isEqualTo(FareZonePoller.PollResult.IMPORTED);
+    }
+
+    /**
+     * The feed is external and the import runs with system privileges, so a delivery that reaches
+     * beyond fare zones is rejected rather than applied to the rest of the register.
+     */
+    @Test
+    public void rejectsFeedCarryingContentBeyondFareZones() throws Exception {
+        PublicationDeliveryStructure delivery = deliveryWithFareZones("NSR:FareZone:9001");
+        StopPlacesInFrame_RelStructure stopPlaces = new StopPlacesInFrame_RelStructure();
+        stopPlaces.getStopPlace_().add(objectFactory.createStopPlace(new StopPlace()
+                .withId("NSR:StopPlace:9001")
+                .withVersion("1")
+                .withName(new MultilingualString().withValue("Should not be imported"))));
+        publicationDeliveryTestHelper.findSiteFrame(delivery).withStopPlaces(stopPlaces);
+        feedBytes = marshal(delivery);
+
+        assertThat(newPoller(feedUrl()).pollOnce()).isEqualTo(FareZonePoller.PollResult.FAILED);
+        assertThat(fareZoneRepository.findFirstByNetexIdOrderByVersionDesc("NSR:FareZone:9001")).isNull();
+        assertThat(stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc("NSR:StopPlace:9001")).isNull();
+        assertThat(fareZoneSnapshotImporter.lastImportedHash()).isNull();
+    }
+
+    /**
+     * A rejected snapshot must not leave anything behind, including the zones the importer had
+     * already reached before the rejection, and must not be recorded as imported.
+     */
+    @Test
+    public void rejectedSnapshotLeavesStoredZonesUntouched() throws Exception {
+        assertThat(newPoller(feedUrl()).pollOnce()).isEqualTo(FareZonePoller.PollResult.IMPORTED);
+        String hashOfGoodSnapshot = fareZoneSnapshotImporter.lastImportedHash();
+        assertThat(hashOfGoodSnapshot).isNotNull();
+
+        // A snapshot whose group references a zone it does not declare.
+        PublicationDeliveryStructure delivery = deliveryWithFareZones("NSR:FareZone:9001", "NSR:FareZone:9002");
+        publicationDeliveryTestHelper.findSiteFrame(delivery)
+                .withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure()
+                        .withGroupOfTariffZones(groupOfTariffZones("NSR:GroupOfTariffZones:9001", "NSR:FareZone:9003")));
+        feedBytes = marshal(delivery);
+
+        assertThat(newPoller(feedUrl()).pollOnce()).isEqualTo(FareZonePoller.PollResult.FAILED);
+
+        assertThat(fareZoneRepository.findFirstByNetexIdOrderByVersionDesc("NSR:FareZone:9001")).isNotNull();
+        assertThat(fareZoneRepository.findFirstByNetexIdOrderByVersionDesc("NSR:FareZone:9002")).isNull();
+        assertThat(groupOfTariffZonesRepository.findByNetexId("NSR:GroupOfTariffZones:9001")).isEmpty();
+        // Still the previous snapshot, so the next tick retries rather than treating this as applied.
+        assertThat(fareZoneSnapshotImporter.lastImportedHash()).isEqualTo(hashOfGoodSnapshot);
+    }
+
+    @Test
+    public void appliesGroupsReferencingZonesInTheSameSnapshot() throws Exception {
+        PublicationDeliveryStructure delivery = deliveryWithFareZones("NSR:FareZone:9001", "NSR:FareZone:9002");
+        publicationDeliveryTestHelper.findSiteFrame(delivery)
+                .withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure()
+                        .withGroupOfTariffZones(groupOfTariffZones(
+                                "NSR:GroupOfTariffZones:9001", "NSR:FareZone:9001", "NSR:FareZone:9002")));
+        feedBytes = marshal(delivery);
+
+        assertThat(newPoller(feedUrl()).pollOnce()).isEqualTo(FareZonePoller.PollResult.IMPORTED);
+        assertThat(groupOfTariffZonesRepository.findByNetexId("NSR:GroupOfTariffZones:9001")).isNotEmpty();
+    }
+
+    private FareZonePoller newPoller(String url) {
+        FareZonePollerConfig config = new FareZonePollerConfig(true, url, 0, 3600, 30, 180);
+        return new FareZonePoller(config, unmarshaller, fareZoneSnapshotImporter,
+                systemSecurityContextService, postgresAdvisoryLock, backgroundJobs);
+    }
+
+    private String feedUrl() {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + "/feed";
+    }
+
+    private PublicationDeliveryStructure deliveryWithFareZones(String... fareZoneIds) {
+        FareFrame fareFrame = publicationDeliveryTestHelper.fareFrame();
+        fareFrame.setFareZones(new FareZonesInFrame_RelStructure());
+        for (String id : fareZoneIds) {
+            fareFrame.getFareZones().getFareZone().add(new FareZone()
+                    .withId(id)
+                    .withVersion("1")
+                    .withName(new MultilingualString().withValue(id)));
+        }
+
+        return publicationDeliveryTestHelper.publicationDelivery(publicationDeliveryTestHelper.siteFrame(), fareFrame);
+    }
+
+    private GroupOfTariffZones groupOfTariffZones(String groupId, String... memberRefs) {
+        TariffZoneRefs_RelStructure members = new TariffZoneRefs_RelStructure();
+        for (String ref : memberRefs) {
+            members.getTariffZoneRef_().add(objectFactory.createTariffZoneRef(new TariffZoneRef().withRef(ref)));
+        }
+        return new GroupOfTariffZones()
+                .withId(groupId)
+                .withVersion("1")
+                .withName(new MultilingualString().withValue(groupId))
+                .withMembers(members);
+    }
+
+    private byte[] marshal(PublicationDeliveryStructure delivery) throws Exception {
+        JAXBContext jaxbContext = JAXBContext.newInstance("org.rutebanken.netex.model");
+        Marshaller marshaller = jaxbContext.createMarshaller();
+        JAXBElement<PublicationDeliveryStructure> element = new ObjectFactory().createPublicationDelivery(delivery);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        marshaller.marshal(element, outputStream);
+        return outputStream.toByteArray();
+    }
+}

--- a/src/test/java/org/rutebanken/tiamat/netex/mapping/mapper/FareZoneMapperTest.java
+++ b/src/test/java/org/rutebanken/tiamat/netex/mapping/mapper/FareZoneMapperTest.java
@@ -1,0 +1,76 @@
+package org.rutebanken.tiamat.netex.mapping.mapper;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import ma.glasnost.orika.MappingContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.rutebanken.netex.model.FareZone;
+import org.rutebanken.netex.model.ObjectFactory;
+import org.rutebanken.netex.model.PointRefs_RelStructure;
+import org.rutebanken.netex.model.ScheduledStopPointRefStructure;
+import org.rutebanken.netex.model.ScopingMethodEnumeration;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FareZoneMapperTest {
+
+    private final FareZoneMapper fareZoneMapper = new FareZoneMapper();
+
+    private final Logger mapperLogger = (Logger) LoggerFactory.getLogger(FareZoneMapper.class);
+    private final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+
+    @Before
+    public void attachAppender() {
+        logAppender.start();
+        mapperLogger.addAppender(logAppender);
+    }
+
+    @After
+    public void detachAppender() {
+        mapperLogger.detachAppender(logAppender);
+    }
+
+    @Test
+    public void warnsWhenExplicitStopsHasNoMembers() {
+        FareZone netexFareZone = new FareZone()
+                .withId("RUT:FareZone:15")
+                .withScopingMethod(ScopingMethodEnumeration.EXPLICIT_STOPS);
+
+        org.rutebanken.tiamat.model.FareZone tiamatFareZone = new org.rutebanken.tiamat.model.FareZone();
+        fareZoneMapper.mapAtoB(netexFareZone, tiamatFareZone, new MappingContext(new HashMap<>()));
+
+        assertThat(tiamatFareZone.getFareZoneMembers()).isEmpty();
+        assertThat(logAppender.list)
+                .anySatisfy(event -> {
+                    assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                    assertThat(event.getFormattedMessage()).contains("RUT:FareZone:15", "EXPLICIT_STOPS");
+                });
+    }
+
+    @Test
+    public void mapsMembersAndDoesNotWarnWhenExplicitStopsHasMembers() {
+        ObjectFactory objectFactory = new ObjectFactory();
+        FareZone netexFareZone = new FareZone()
+                .withId("RUT:FareZone:16")
+                .withScopingMethod(ScopingMethodEnumeration.EXPLICIT_STOPS)
+                .withMembers(new PointRefs_RelStructure().withPointRef(
+                        objectFactory.createScheduledStopPointRef(
+                                new ScheduledStopPointRefStructure().withRef("NSR:ScheduledStopPoint:S54471"))));
+
+        org.rutebanken.tiamat.model.FareZone tiamatFareZone = new org.rutebanken.tiamat.model.FareZone();
+        fareZoneMapper.mapAtoB(netexFareZone, tiamatFareZone, new MappingContext(new HashMap<>()));
+
+        assertThat(tiamatFareZone.getFareZoneMembers())
+                .extracting(org.rutebanken.tiamat.model.StopPlaceReference::getRef)
+                .containsExactly("NSR:StopPlace:54471");
+        assertThat(logAppender.list).noneSatisfy(event ->
+                assertThat(event.getLevel()).isEqualTo(Level.WARN));
+    }
+}

--- a/src/test/java/org/rutebanken/tiamat/rest/netex/publicationdelivery/FareZoneExternalVersioningTest.java
+++ b/src/test/java/org/rutebanken/tiamat/rest/netex/publicationdelivery/FareZoneExternalVersioningTest.java
@@ -21,6 +21,8 @@ import org.rutebanken.netex.model.FareZone;
 import org.rutebanken.netex.model.FareZonesInFrame_RelStructure;
 import org.rutebanken.netex.model.GroupOfTariffZones;
 import org.rutebanken.netex.model.GroupsOfTariffZonesInFrame_RelStructure;
+import org.rutebanken.netex.model.KeyListStructure;
+import org.rutebanken.netex.model.KeyValueStructure;
 import org.rutebanken.netex.model.MultilingualString;
 import org.rutebanken.netex.model.ObjectFactory;
 import org.rutebanken.netex.model.PublicationDeliveryStructure;
@@ -557,28 +559,221 @@ public class FareZoneExternalVersioningTest extends TiamatIntegrationTest {
             importParams.fareZoneFrameSource = FareZoneFrameSource.FARE_FRAME;
             importParams.importType = ImportType.INITIAL;
 
+            PublicationDeliveryStructure delivery = publicationDeliveryTestHelper.publicationDelivery(
+                    publicationDeliveryTestHelper.siteFrame(), fareFrame);
+
             // WHEN: Import FareZone with invalid date range
-            PublicationDeliveryStructure response =
-                    publicationDeliveryTestHelper.postAndReturnPublicationDelivery(
-                            publicationDeliveryTestHelper.publicationDelivery(fareFrame), importParams);
+            // THEN: the import is rejected rather than the zone being skipped
+            assertThatThrownBy(() -> publicationDeliveryImporter.importPublicationDelivery(delivery, importParams))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("NSR:FareZone:703");
 
-            // THEN: FareZone should be rejected and not saved
-            org.rutebanken.tiamat.model.FareZone savedZone = fareZoneRepository
-                    .findFirstByNetexIdOrderByVersionDesc("NSR:FareZone:703");
-
-            // Validation should reject this - zone should NOT be saved
-            assertThat(savedZone).isNull();
-
-            // Response should not include the invalid zone
-            FareFrame responseFareFrame = publicationDeliveryTestHelper.findFareFrame(response);
-            assertThat(responseFareFrame).isNotNull();
-            if (responseFareFrame.getFareZones() != null) {
-                assertThat(responseFareFrame.getFareZones().getFareZone()).isEmpty();
-            }
+            assertThat(fareZoneRepository.findFirstByNetexIdOrderByVersionDesc("NSR:FareZone:703")).isNull();
 
         } finally {
             ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
         }
+    }
+
+    /**
+     * An invalid zone must not cost us the copy already stored. Skipping it would leave its id out of
+     * the set of zones to keep, so the full-replace prune would delete it - on the strength of the
+     * very record that failed validation.
+     */
+    @Test
+    public void validBetween_invalidZoneDoesNotDeleteTheStoredCopy() {
+        ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", true);
+
+        try {
+            ImportParams importParams = new ImportParams();
+            importParams.importType = ImportType.INITIAL;
+
+            // GIVEN: two zones stored by a valid snapshot
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(
+                            publicationDeliveryTestHelper.siteFrame(),
+                            fareFrameWithFareZones("NSR:FareZone:711", "NSR:FareZone:712")),
+                    importParams);
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:712")).isNotEmpty();
+
+            // WHEN: the next snapshot repeats both, but one now carries an invalid validity
+            FareFrame fareFrame = fareFrameWithFareZones("NSR:FareZone:711");
+            fareFrame.getFareZones().getFareZone().add(new FareZone()
+                    .withId("NSR:FareZone:712")
+                    .withVersion("2")
+                    .withName(new MultilingualString().withValue("NSR:FareZone:712"))
+                    .withValidBetween(new ValidBetween()
+                            .withFromDate(LocalDateTime.now().plusDays(10))
+                            .withToDate(LocalDateTime.now().minusDays(10))));
+
+            PublicationDeliveryStructure delivery = publicationDeliveryTestHelper.publicationDelivery(
+                    publicationDeliveryTestHelper.siteFrame(), fareFrame);
+
+            assertThatThrownBy(() -> publicationDeliveryImporter.importPublicationDelivery(delivery, importParams))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("NSR:FareZone:712");
+
+            // THEN: both stored zones survive - nothing was pruned on the strength of a rejected record
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:711")).isNotEmpty();
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:712")).isNotEmpty();
+        } finally {
+            ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
+        }
+    }
+
+    /**
+     * Cutover from default versioning: the stored history collapses to the single row the master
+     * mastered. Leaving the siblings behind would let an older version win, because reads resolve a
+     * FareZone by highest version and the master's version can be lower than the local one.
+     */
+    @Test
+    public void externalVersioning_cutoverDropsSupersededVersions() {
+        ImportParams importParams = new ImportParams();
+        importParams.importType = ImportType.INITIAL;
+
+        // GIVEN: three default-versioned imports, leaving versions 1, 2 and 3 stored
+        for (int i = 0; i < 3; i++) {
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(
+                            publicationDeliveryTestHelper.siteFrame(),
+                            fareFrameWithFareZones("NSR:FareZone:721")),
+                    importParams);
+        }
+        assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:721")).hasSize(3);
+
+        ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", true);
+        try {
+            // WHEN: the master sends a lower version than the local history reached
+            FareFrame fareFrame = publicationDeliveryTestHelper.fareFrame();
+            fareFrame.setFareZones(new FareZonesInFrame_RelStructure());
+            fareFrame.getFareZones().getFareZone().add(new FareZone()
+                    .withId("NSR:FareZone:721")
+                    .withVersion("2")
+                    .withName(new MultilingualString().withValue("Mastered")));
+
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(
+                            publicationDeliveryTestHelper.siteFrame(), fareFrame),
+                    importParams);
+
+            // THEN: exactly one row remains, and it is the one the master sent
+            List<org.rutebanken.tiamat.model.FareZone> stored =
+                    fareZoneRepository.findByNetexId("NSR:FareZone:721");
+            assertThat(stored).hasSize(1);
+            assertThat(stored.getFirst().getVersion()).isEqualTo(2L);
+            assertThat(stored.getFirst().getName().getValue()).isEqualTo("Mastered");
+
+            // And the version-resolving read agrees, rather than returning a stale sibling
+            assertThat(fareZoneRepository.findFirstByNetexIdOrderByVersionDesc("NSR:FareZone:721")
+                    .getName().getValue()).isEqualTo("Mastered");
+        } finally {
+            ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
+        }
+    }
+
+    /**
+     * On update the incoming keyValues (e.g. the tzMapping bridge to the legacy TariffZone id)
+     * must replace what is stored, not be silently dropped.
+     */
+    @Test
+    public void externalVersioning_updateReplacesKeyValues() throws Exception {
+        ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", true);
+
+        try {
+            ImportParams importParams = new ImportParams();
+            importParams.fareZoneFrameSource = FareZoneFrameSource.FARE_FRAME;
+            importParams.importType = ImportType.INITIAL;
+
+            FareZone create = new FareZone()
+                    .withName(new MultilingualString().withValue("Zone With Mapping"))
+                    .withVersion("1")
+                    .withId("NSR:FareZone:950")
+                    .withKeyList(new KeyListStructure().withKeyValue(
+                            new KeyValueStructure().withKey("tzMapping").withValue("NSR:TariffZone:OLD")));
+
+            FareFrame createFrame = publicationDeliveryTestHelper.fareFrame();
+            createFrame.setFareZones(new FareZonesInFrame_RelStructure());
+            createFrame.getFareZones().getFareZone().add(create);
+
+            PublicationDeliveryStructure createResponse = publicationDeliveryTestHelper.postAndReturnPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(createFrame), importParams);
+            assertThat(tzMappingOf(createResponse)).isEqualTo("NSR:TariffZone:OLD");
+
+            // WHEN: re-import same netexId with an updated tzMapping
+            FareZone update = new FareZone()
+                    .withName(new MultilingualString().withValue("Zone With Mapping"))
+                    .withVersion("2")
+                    .withId("NSR:FareZone:950")
+                    .withKeyList(new KeyListStructure().withKeyValue(
+                            new KeyValueStructure().withKey("tzMapping").withValue("NSR:TariffZone:NEW")));
+
+            FareFrame updateFrame = publicationDeliveryTestHelper.fareFrame();
+            updateFrame.setFareZones(new FareZonesInFrame_RelStructure());
+            updateFrame.getFareZones().getFareZone().add(update);
+
+            PublicationDeliveryStructure updateResponse = publicationDeliveryTestHelper.postAndReturnPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(updateFrame), importParams);
+
+            // THEN: the stored mapping reflects the update instead of the stale original
+            assertThat(tzMappingOf(updateResponse)).isEqualTo("NSR:TariffZone:NEW");
+        } finally {
+            ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
+        }
+    }
+
+    /**
+     * A truncated or partial feed must not be allowed to wipe the register. The prune refuses when
+     * the incoming delivery would drop the stored zone count below the safety floor, and rolls back.
+     */
+    @Test
+    public void externalVersioning_pruneBelowSafetyFloorRejected() {
+        ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", true);
+
+        try {
+            ImportParams importParams = new ImportParams();
+            importParams.importType = ImportType.INITIAL;
+
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(
+                            publicationDeliveryTestHelper.siteFrame(),
+                            fareFrameWithFareZones("NSR:FareZone:960", "NSR:FareZone:961",
+                                    "NSR:FareZone:962", "NSR:FareZone:963", "NSR:FareZone:964")),
+                    importParams);
+            assertThat(distinctFareZoneCount()).isEqualTo(5);
+
+            // WHEN: a truncated feed carrying a single zone (would delete 4 of 5)
+            PublicationDeliveryStructure truncated = publicationDeliveryTestHelper.publicationDelivery(
+                    publicationDeliveryTestHelper.siteFrame(),
+                    fareFrameWithFareZones("NSR:FareZone:960"));
+
+            assertThatThrownBy(() -> publicationDeliveryImporter.importPublicationDelivery(truncated, importParams))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Refusing FareZone prune");
+
+            // THEN: nothing was deleted
+            assertThat(distinctFareZoneCount()).isEqualTo(5);
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:964")).isNotEmpty();
+        } finally {
+            ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
+        }
+    }
+
+    private String tzMappingOf(PublicationDeliveryStructure response) {
+        FareFrame responseFareFrame = publicationDeliveryTestHelper.findFareFrame(response);
+        FareZone fareZone = responseFareFrame.getFareZones().getFareZone().get(0);
+        assertThat(fareZone.getKeyList()).isNotNull();
+        return fareZone.getKeyList().getKeyValue().stream()
+                .filter(kv -> "tzMapping".equals(kv.getKey()))
+                .map(KeyValueStructure::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private long distinctFareZoneCount() {
+        return fareZoneRepository.findAll().stream()
+                .map(org.rutebanken.tiamat.model.FareZone::getNetexId)
+                .distinct()
+                .count();
     }
 
     /**
@@ -630,6 +825,10 @@ public class FareZoneExternalVersioningTest extends TiamatIntegrationTest {
             FareFrame mainFrame = publicationDeliveryTestHelper.fareFrame();
             mainFrame.setFareZones(new FareZonesInFrame_RelStructure());
             mainFrame.getFareZones().getFareZone().add(mainZone);
+            // Include the neighbour zones as well: with external versioning the delivery is a full
+            // replace, so all surviving zones must be present or the prune safety floor rejects it.
+            mainFrame.getFareZones().getFareZone().add(neighbour1);
+            mainFrame.getFareZones().getFareZone().add(neighbour2);
 
             PublicationDeliveryStructure response =
                     publicationDeliveryTestHelper.postAndReturnPublicationDelivery(
@@ -638,7 +837,7 @@ public class FareZoneExternalVersioningTest extends TiamatIntegrationTest {
             // THEN: Import should succeed with neighbour references
             FareFrame responseFareFrame = publicationDeliveryTestHelper.findFareFrame(response);
             assertThat(responseFareFrame).isNotNull();
-            assertThat(responseFareFrame.getFareZones().getFareZone()).hasSize(1);
+            assertThat(responseFareFrame.getFareZones().getFareZone()).hasSize(3);
 
             // Verify in database - neighbours should be stored
             org.rutebanken.tiamat.model.FareZone savedZone = fareZoneRepository
@@ -696,6 +895,124 @@ public class FareZoneExternalVersioningTest extends TiamatIntegrationTest {
             assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:901")).isNotEmpty();
             assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:902")).isNotEmpty();
             assertThat(groupOfTariffZonesRepository.findByNetexId("NSR:GroupOfTariffZones:901")).isEmpty();
+        } finally {
+            ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
+        }
+    }
+
+    /**
+     * The rollback must cover what the delivery wrote, not only what it deleted. The FareZone upserts
+     * used to commit in their own transaction before the prune and the group import ran, so a
+     * rejected delivery left updated and newly inserted zones behind.
+     */
+    @Test
+    public void externalVersioning_failedGroupValidationRollsBackFareZoneWrites() {
+        ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", true);
+
+        try {
+            ImportParams importParams = new ImportParams();
+            importParams.importType = ImportType.INITIAL;
+
+            // GIVEN: two FareZones persisted by a first delivery
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(
+                            publicationDeliveryTestHelper.siteFrame(),
+                            fareFrameWithFareZones("NSR:FareZone:911", "NSR:FareZone:912")),
+                    importParams);
+
+            // WHEN: a later delivery drops one zone, adds a new one, and its group references a zone
+            // that exists nowhere - so the delivery is rejected after the zones have been written.
+            SiteFrame siteFrame = publicationDeliveryTestHelper.siteFrame();
+            siteFrame.withGroupsOfTariffZones(new GroupsOfTariffZonesInFrame_RelStructure()
+                    .withGroupOfTariffZones(groupOfTariffZones("NSR:GroupOfTariffZones:911", "NSR:FareZone:999")));
+
+            PublicationDeliveryStructure delivery = publicationDeliveryTestHelper.publicationDelivery(
+                    siteFrame, fareFrameWithFareZones("NSR:FareZone:911", "NSR:FareZone:913"));
+
+            assertThatThrownBy(() -> publicationDeliveryImporter.importPublicationDelivery(delivery, importParams))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("NSR:FareZone:999");
+
+            // THEN: the insertion is rolled back, and so is the prune of the dropped zone
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:913")).isEmpty();
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:911")).isNotEmpty();
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:912")).isNotEmpty();
+            assertThat(groupOfTariffZonesRepository.findByNetexId("NSR:GroupOfTariffZones:911")).isEmpty();
+        } finally {
+            ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
+        }
+    }
+
+    /**
+     * The retain floor asks how much of the stored register a snapshot keeps. Measuring it after the
+     * snapshot's own zones are saved inflates the denominator by exactly those zones, which lets the
+     * worst case through: a feed that replaces every id retains nothing yet lands on the threshold.
+     */
+    @Test
+    public void externalVersioning_pruneRejectedWhenSnapshotReplacesEveryId() {
+        ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", true);
+
+        try {
+            ImportParams importParams = new ImportParams();
+            importParams.importType = ImportType.INITIAL;
+
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(
+                            publicationDeliveryTestHelper.siteFrame(),
+                            fareFrameWithFareZones("NSR:FareZone:970", "NSR:FareZone:971",
+                                    "NSR:FareZone:972", "NSR:FareZone:973")),
+                    importParams);
+            assertThat(distinctFareZoneCount()).isEqualTo(4);
+
+            // WHEN: a snapshot of the same size, but sharing no id with what is stored
+            PublicationDeliveryStructure replacement = publicationDeliveryTestHelper.publicationDelivery(
+                    publicationDeliveryTestHelper.siteFrame(),
+                    fareFrameWithFareZones("NSR:FareZone:980", "NSR:FareZone:981",
+                            "NSR:FareZone:982", "NSR:FareZone:983"));
+
+            assertThatThrownBy(() -> publicationDeliveryImporter.importPublicationDelivery(replacement, importParams))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Refusing FareZone prune");
+
+            // THEN: nothing was deleted and nothing was inserted
+            assertThat(distinctFareZoneCount()).isEqualTo(4);
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:973")).isNotEmpty();
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:980")).isEmpty();
+        } finally {
+            ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
+        }
+    }
+
+    /**
+     * A snapshot that keeps enough of the register still passes, including when it also brings new
+     * zones - those must not count towards the baseline either.
+     */
+    @Test
+    public void externalVersioning_pruneAllowedWhenEnoughOfTheRegisterIsRetained() {
+        ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", true);
+
+        try {
+            ImportParams importParams = new ImportParams();
+            importParams.importType = ImportType.INITIAL;
+
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(
+                            publicationDeliveryTestHelper.siteFrame(),
+                            fareFrameWithFareZones("NSR:FareZone:990", "NSR:FareZone:991",
+                                    "NSR:FareZone:992", "NSR:FareZone:993")),
+                    importParams);
+
+            // Keeps 3 of 4 and adds 2 new ones
+            publicationDeliveryImporter.importPublicationDelivery(
+                    publicationDeliveryTestHelper.publicationDelivery(
+                            publicationDeliveryTestHelper.siteFrame(),
+                            fareFrameWithFareZones("NSR:FareZone:990", "NSR:FareZone:991",
+                                    "NSR:FareZone:992", "NSR:FareZone:994", "NSR:FareZone:995")),
+                    importParams);
+
+            assertThat(distinctFareZoneCount()).isEqualTo(5);
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:993")).isEmpty();
+            assertThat(fareZoneRepository.findByNetexId("NSR:FareZone:995")).isNotEmpty();
         } finally {
             ReflectionTestUtils.setField(fareZoneConfig, "externalVersioning", false);
         }

--- a/src/test/java/org/rutebanken/tiamat/service/TariffZonesLookupServiceIntegrationTest.java
+++ b/src/test/java/org/rutebanken/tiamat/service/TariffZonesLookupServiceIntegrationTest.java
@@ -346,6 +346,46 @@ public class TariffZonesLookupServiceIntegrationTest extends TiamatIntegrationTe
     }
 
     @Test
+    public void shouldNotPopulateFareZoneWithExplicitStopsWhenNoMembers() {
+        // An EXPLICIT_STOPS fare zone with no members must not be attached to every stop
+        // inside its polygon. Regression guard for school-zone style zones with empty members.
+        TariffZone tariffZone = createTariffZoneWithPolygon("NSR:TariffZone:1", "Tariff Zone A",
+                new Coordinate(10.0, 59.0),
+                new Coordinate(10.0, 60.0),
+                new Coordinate(11.0, 60.0),
+                new Coordinate(11.0, 59.0),
+                new Coordinate(10.0, 59.0));
+        tariffZone = tariffZoneRepository.save(tariffZone);
+
+        FareZone fareZone = createFareZoneWithPolygon("NSR:FareZone:1", "Fare Zone Explicit Empty",
+                ScopingMethodEnumeration.EXPLICIT_STOPS,
+                new Coordinate(10.0, 59.0),
+                new Coordinate(10.0, 60.0),
+                new Coordinate(11.0, 60.0),
+                new Coordinate(11.0, 59.0),
+                new Coordinate(10.0, 59.0));
+        // Deliberately no members added
+        fareZoneRepository.save(fareZone);
+
+        tariffZonesLookupService.resetTariffZone();
+        tariffZonesLookupService.resetFareZone();
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:1");
+        stopPlace.setName(new EmbeddableMultilingualString("Test Stop"));
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(10.5, 59.5)));
+        Set<TariffZoneRef> existingRefs = new HashSet<>();
+        existingRefs.add(new TariffZoneRef(tariffZone));
+        stopPlace.setTariffZones(existingRefs);
+
+        boolean changed = tariffZonesLookupService.populateTariffZone(stopPlace);
+
+        assertThat(changed).isFalse();
+        assertThat(stopPlace.getTariffZones()).hasSize(1);
+        assertThat(stopPlace.getTariffZones().iterator().next().getRef()).isEqualTo("NSR:TariffZone:1");
+    }
+
+    @Test
     public void shouldPopulateFareZoneWithExplicitStopsWhenStopIsMember() {
         FareZone fareZone = createFareZoneWithPolygon("NSR:FareZone:1", "Fare Zone Explicit",
                 ScopingMethodEnumeration.EXPLICIT_STOPS,
@@ -369,6 +409,93 @@ public class TariffZonesLookupServiceIntegrationTest extends TiamatIntegrationTe
         assertThat(changed).isTrue();
         assertThat(stopPlace.getTariffZones()).hasSize(1);
         assertThat(stopPlace.getTariffZones().iterator().next().getRef()).isEqualTo("NSR:FareZone:1");
+    }
+
+    /**
+     * Membership, not geometry, defines an EXPLICIT_STOPS scope. Such a zone need not carry a polygon
+     * at all, and the spatial lookup only ever offers zones that have one.
+     */
+    @Test
+    public void shouldPopulateFareZoneWithExplicitStopsWhenStopIsMemberAndZoneHasNoPolygon() {
+        FareZone fareZone = new FareZone();
+        fareZone.setNetexId("NSR:FareZone:1");
+        fareZone.setName(new EmbeddableMultilingualString("Fare Zone Explicit, No Polygon"));
+        fareZone.setVersion(1L);
+        fareZone.setScopingMethod(ScopingMethodEnumeration.EXPLICIT_STOPS);
+        fareZone.getFareZoneMembers().add(new StopPlaceReference("NSR:StopPlace:1"));
+        fareZoneRepository.save(fareZone);
+
+        tariffZonesLookupService.resetFareZone();
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:1");
+        stopPlace.setName(new EmbeddableMultilingualString("Test Stop"));
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(10.5, 59.5)));
+
+        boolean changed = tariffZonesLookupService.populateTariffZone(stopPlace);
+
+        assertThat(changed).isTrue();
+        assertThat(stopPlace.getTariffZones()).hasSize(1);
+        assertThat(stopPlace.getTariffZones().iterator().next().getRef()).isEqualTo("NSR:FareZone:1");
+    }
+
+    /**
+     * A listed member outside the zone's own polygon is still a member.
+     */
+    @Test
+    public void shouldPopulateFareZoneWithExplicitStopsWhenMemberOutsidePolygon() {
+        FareZone fareZone = createFareZoneWithPolygon("NSR:FareZone:1", "Fare Zone Explicit",
+                ScopingMethodEnumeration.EXPLICIT_STOPS,
+                new Coordinate(10.0, 59.0),
+                new Coordinate(10.0, 60.0),
+                new Coordinate(11.0, 60.0),
+                new Coordinate(11.0, 59.0),
+                new Coordinate(10.0, 59.0));
+        fareZone.getFareZoneMembers().add(new StopPlaceReference("NSR:StopPlace:1"));
+        fareZoneRepository.save(fareZone);
+
+        tariffZonesLookupService.resetFareZone();
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:1");
+        stopPlace.setName(new EmbeddableMultilingualString("Test Stop"));
+        // Far outside the zone polygon
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(20.5, 69.5)));
+
+        boolean changed = tariffZonesLookupService.populateTariffZone(stopPlace);
+
+        assertThat(changed).isTrue();
+        assertThat(stopPlace.getTariffZones()).hasSize(1);
+        assertThat(stopPlace.getTariffZones().iterator().next().getRef()).isEqualTo("NSR:FareZone:1");
+    }
+
+    /**
+     * Coverage alone must not attach an explicitly scoped zone, even though its polygon contains the
+     * stop.
+     */
+    @Test
+    public void shouldNotPopulateFareZoneWithExplicitStopsWhenCoveredButNotMember() {
+        FareZone fareZone = createFareZoneWithPolygon("NSR:FareZone:1", "Fare Zone Explicit",
+                ScopingMethodEnumeration.EXPLICIT_STOPS,
+                new Coordinate(10.0, 59.0),
+                new Coordinate(10.0, 60.0),
+                new Coordinate(11.0, 60.0),
+                new Coordinate(11.0, 59.0),
+                new Coordinate(10.0, 59.0));
+        fareZone.getFareZoneMembers().add(new StopPlaceReference("NSR:StopPlace:2"));
+        fareZoneRepository.save(fareZone);
+
+        tariffZonesLookupService.resetFareZone();
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:1");
+        stopPlace.setName(new EmbeddableMultilingualString("Test Stop"));
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(10.5, 59.5)));
+
+        boolean changed = tariffZonesLookupService.populateTariffZone(stopPlace);
+
+        assertThat(changed).isFalse();
+        assertThat(stopPlace.getTariffZones()).isEmpty();
     }
 
     @Test

--- a/src/test/java/org/rutebanken/tiamat/versioning/save/FareZoneSaverServiceRetainRatioTest.java
+++ b/src/test/java/org/rutebanken/tiamat/versioning/save/FareZoneSaverServiceRetainRatioTest.java
@@ -1,0 +1,62 @@
+package org.rutebanken.tiamat.versioning.save;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The prune retain floor is safety-critical and its effect is invisible in operation: a value that
+ * cannot express a fraction disables the guard rather than announcing itself. It is therefore
+ * rejected at startup.
+ */
+public class FareZoneSaverServiceRetainRatioTest {
+
+    private FareZoneSaverService withRatio(double ratio) {
+        return new FareZoneSaverService(null, null, null, null, null, null, ratio);
+    }
+
+    @Test
+    public void acceptsFractionsWithinRange() {
+        assertThatCode(() -> withRatio(0.0)).doesNotThrowAnyException();
+        assertThatCode(() -> withRatio(0.5)).doesNotThrowAnyException();
+        assertThatCode(() -> withRatio(1.0)).doesNotThrowAnyException();
+    }
+
+    /**
+     * Every comparison against NaN is false, so the guard would never fire.
+     */
+    @Test
+    public void rejectsNaN() {
+        assertThatThrownBy(() -> withRatio(Double.NaN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("fareZone.prune.minRetainRatio");
+    }
+
+    @Test
+    public void rejectsInfinity() {
+        assertThatThrownBy(() -> withRatio(Double.POSITIVE_INFINITY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("fareZone.prune.minRetainRatio");
+    }
+
+    /**
+     * A negative floor is unreachable from below, so it silently permits any prune.
+     */
+    @Test
+    public void rejectsNegative() {
+        assertThatThrownBy(() -> withRatio(-0.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("fareZone.prune.minRetainRatio");
+    }
+
+    /**
+     * Above 1 no prune can ever satisfy the floor.
+     */
+    @Test
+    public void rejectsAboveOne() {
+        assertThatThrownBy(() -> withRatio(1.5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("fareZone.prune.minRetainRatio");
+    }
+}


### PR DESCRIPTION
Add scheduled FareZone poller and fix external-versioning gaps

Poll the external fare-zone master feed and import it as a replica.

- FareZonePoller: scheduled fetch + SHA-256 change detection, imports via
      the default PublicationDeliveryImporter path. Serialised across replicas
      with a Hazelcast lock; last-imported hash shared in a Hazelcast map so an
      unchanged feed is not re-imported. Disabled by default.
- SystemSecurityContextService + SystemImportContext: run the import as a
      trusted in-process system import. DefaultAuthorizationService grants the
      edit/delete checks while active, so the background job needs no token; a
      minimal principal supplies preferred_username for changedBy.
- FareZoneSaverService: copy keyValues (tzMapping) and multiSurface on
      update; refuse a prune that would drop the stored zone count below a
      configurable safety floor (fareZone.prune.minRetainRatio, default 0.5).
- TariffZonesLookupService: EXPLICIT_STOPS zones attach only to listed
      members, never on polygon coverage; a zone with no members matches
      nothing.
- helm: enable external versioning, ignoreTariffZoneImport and the poller
      in dev/tst; arm the flags in prd with the poller left off pending
      validation.