### PR TITLE
Extracts the Orika configuration shared by entity copying

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/versioning/EntityCopyMappings.java
+++ b/src/main/java/org/rutebanken/tiamat/versioning/EntityCopyMappings.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.versioning;
+
+import ma.glasnost.orika.CustomConverter;
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.converter.builtin.PassThroughConverter;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+import ma.glasnost.orika.metadata.Type;
+import org.locationtech.jts.geom.Point;
+import org.rutebanken.tiamat.model.AlternativeName;
+import org.rutebanken.tiamat.model.CycleStorageEquipment;
+import org.rutebanken.tiamat.model.EntityInVersionStructure;
+import org.rutebanken.tiamat.model.GeneralSign;
+import org.rutebanken.tiamat.model.PathLink;
+import org.rutebanken.tiamat.model.PathLinkEnd;
+import org.rutebanken.tiamat.model.PlaceEquipment;
+import org.rutebanken.tiamat.model.SanitaryEquipment;
+import org.rutebanken.tiamat.model.ShelterEquipment;
+import org.rutebanken.tiamat.model.TicketingEquipment;
+import org.rutebanken.tiamat.model.TopographicPlace;
+import org.rutebanken.tiamat.model.WaitingRoomEquipment;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * The Orika configuration shared by everything that deep copies a versioned entity.
+ * <p>
+ * Only the mechanical part lives here: the converters, and the entity classes whose copying rules
+ * are the same wherever the copy is made. What differs between callers stays with the caller,
+ * because that part carries meaning rather than boilerplate. A new version of a stop place keeps
+ * its netexId because it is the same stop place; one built from a submitted payload must not,
+ * because it is not. Pulling those decisions in here would hide them.
+ * <p>
+ * These are separate calls rather than one, because callers interleave their own registrations
+ * between them. Note that the sets overlap: {@link PlaceEquipment} is configured both here and by
+ * every caller. Registering a class twice appears to accumulate the exclusions rather than have
+ * the later registration replace the earlier, which is why callers get the union of both. That was
+ * established by reordering these calls and observing that VersionCreatorTest still passed, not
+ * from Orika's documentation, so treat it as observed behaviour rather than a guarantee and keep
+ * the existing call order when changing a caller.
+ */
+public final class EntityCopyMappings {
+
+    public static final String ID_FIELD = "id";
+    public static final String NETEX_ID_FIELD = "netexId";
+    public static final String VERSION_FIELD = "version";
+    public static final String VERSION_COMMENT_FIELD = "versionComment";
+    public static final String CHANGED_BY_FIELD = "changedBy";
+    public static final String VALID_BETWEEN_FIELD = "validBetween";
+    public static final String MODIFICATION_ENUMERATION_FIELD = "modificationEnumeration";
+
+    /**
+     * Id of the converter that carries a topographic place over by reference instead of deep
+     * copying it. Referenced from a field map, so registering it has no effect on its own.
+     */
+    public static final String TOPOGRAPHIC_PLACE_PASS_THROUGH = "stopPlacePassThroughId";
+
+    /**
+     * Entities that are copied the same way wherever they appear: they belong to whatever is being
+     * copied, so they lose the audit trail and the primary key of the entity they came from.
+     */
+    private static final List<Class<? extends EntityInVersionStructure>> COMMON_ENTITIES = List.of(
+            TopographicPlace.class,
+            PathLink.class,
+            PlaceEquipment.class,
+            WaitingRoomEquipment.class,
+            SanitaryEquipment.class,
+            TicketingEquipment.class,
+            ShelterEquipment.class,
+            CycleStorageEquipment.class,
+            GeneralSign.class,
+            AlternativeName.class
+    );
+
+    private EntityCopyMappings() {
+    }
+
+    /**
+     * A factory with the converters every copy needs already registered. Converters have to be in
+     * place before the field maps that reference them, which is why they are not a separate step.
+     */
+    public static MapperFactory newMapperFactory() {
+        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+
+        mapperFactory.getConverterFactory()
+                .registerConverter(TOPOGRAPHIC_PLACE_PASS_THROUGH, new PassThroughConverter(TopographicPlace.class));
+
+        mapperFactory.getConverterFactory()
+                .registerConverter(new PassThroughConverter(Point.class));
+
+        // Geometry and instants are values, not entities: copying them field by field would build
+        // an equal but distinct object where the original reference is what is wanted.
+        mapperFactory.getConverterFactory()
+                .registerConverter(new CustomConverter<Instant, Instant>() {
+                    @Override
+                    public Instant convert(Instant instant, Type<? extends Instant> type, MappingContext mappingContext) {
+                        return Instant.from(instant);
+                    }
+                });
+
+        return mapperFactory;
+    }
+
+    /**
+     * A path link end refers to a place rather than owning it, so only the primary key is dropped.
+     */
+    public static void registerPathLinkEnd(MapperFactory mapperFactory) {
+        mapperFactory.classMap(PathLinkEnd.class, PathLinkEnd.class)
+                .exclude(ID_FIELD)
+                .byDefault()
+                .register();
+    }
+
+    /**
+     * Registers {@link #COMMON_ENTITIES}. Call this last, as the existing callers do: it overlaps
+     * with the entity lists they register themselves.
+     */
+    public static void registerCommonEntities(MapperFactory mapperFactory) {
+        COMMON_ENTITIES.forEach(clazz -> mapperFactory.classMap(clazz, clazz)
+                .exclude(VERSION_COMMENT_FIELD)
+                .exclude(CHANGED_BY_FIELD)
+                .exclude(ID_FIELD)
+                .exclude(VALID_BETWEEN_FIELD)
+                .byDefault()
+                .register());
+    }
+}

--- a/src/main/java/org/rutebanken/tiamat/versioning/VersionCreator.java
+++ b/src/main/java/org/rutebanken/tiamat/versioning/VersionCreator.java
@@ -15,34 +15,17 @@
 
 package org.rutebanken.tiamat.versioning;
 
-import ma.glasnost.orika.CustomConverter;
 import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.MapperFactory;
-import ma.glasnost.orika.MappingContext;
-import ma.glasnost.orika.converter.builtin.PassThroughConverter;
-import ma.glasnost.orika.impl.DefaultMapperFactory;
-import ma.glasnost.orika.metadata.Type;
-import org.locationtech.jts.geom.Point;
-import org.rutebanken.tiamat.model.AlternativeName;
-import org.rutebanken.tiamat.model.CycleStorageEquipment;
 import org.rutebanken.tiamat.model.EntityInVersionStructure;
-import org.rutebanken.tiamat.model.GeneralSign;
 import org.rutebanken.tiamat.model.InstalledEquipment_VersionStructure;
-import org.rutebanken.tiamat.model.PathLink;
-import org.rutebanken.tiamat.model.PathLinkEnd;
 import org.rutebanken.tiamat.model.PlaceEquipment;
-import org.rutebanken.tiamat.model.SanitaryEquipment;
-import org.rutebanken.tiamat.model.ShelterEquipment;
 import org.rutebanken.tiamat.model.StopPlace;
-import org.rutebanken.tiamat.model.TicketingEquipment;
-import org.rutebanken.tiamat.model.TopographicPlace;
-import org.rutebanken.tiamat.model.WaitingRoomEquipment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
@@ -71,46 +54,27 @@ public class VersionCreator {
     public VersionCreator(VersionIncrementor versionIncrementor) {
         this.versionIncrementor = versionIncrementor;
 
-        MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+        MapperFactory mapperFactory = EntityCopyMappings.newMapperFactory();
 
+        EntityCopyMappings.registerPathLinkEnd(mapperFactory);
 
-        final String stopPlacePassThroughId = "stopPlacePassThroughId";
-
-        mapperFactory.getConverterFactory()
-                .registerConverter(stopPlacePassThroughId, new PassThroughConverter(TopographicPlace.class));
-
-        mapperFactory.getConverterFactory()
-                .registerConverter(new PassThroughConverter(Point.class));
-
-        mapperFactory.getConverterFactory()
-                .registerConverter(new CustomConverter<Instant, Instant>() {
-                    @Override
-                    public Instant convert(Instant instant, Type<? extends Instant> type, MappingContext mappingContext) {
-                        return Instant.from(instant);
-                    }
-                });
-
-
-        mapperFactory.classMap(PathLinkEnd.class, PathLinkEnd.class)
-                .exclude(ID_FIELD)
-                .byDefault()
-                .register();
-
-
+        // Equipment belongs to the entity it hangs off rather than existing in its own right, so a
+        // copy gets a fresh identity rather than sharing the original's.
         List<Class<? extends EntityInVersionStructure>> excludeNetexIdAndVersionsForEntities =
                 Arrays.asList(PlaceEquipment.class, InstalledEquipment_VersionStructure.class);
 
         excludeNetexIdAndVersionsForEntities.forEach(clazz -> {
             mapperFactory.classMap(clazz, clazz)
-                    .exclude("netexId")
-                    .exclude("version")
+                    .exclude(EntityCopyMappings.NETEX_ID_FIELD)
+                    .exclude(EntityCopyMappings.VERSION_FIELD)
                     .byDefault()
                     .register();
         });
 
-
+        // A new version is the same stop place, so netexId is deliberately carried over. The
+        // topographic place is referred to rather than copied.
         mapperFactory.classMap(StopPlace.class, StopPlace.class)
-                .fieldMap("topographicPlace").converter(stopPlacePassThroughId).add()
+                .fieldMap("topographicPlace").converter(EntityCopyMappings.TOPOGRAPHIC_PLACE_PASS_THROUGH).add()
                 .exclude(ID_FIELD)
                 .exclude(VERSION_COMMENT_FIELD)
                 .exclude(CHANGED_BY_FIELD)
@@ -119,22 +83,9 @@ public class VersionCreator {
                 .byDefault()
                 .register();
 
-        List<Class<? extends EntityInVersionStructure>> commonClassesToConfigure =
-                Arrays.asList(TopographicPlace.class,
-                        PathLink.class, PlaceEquipment.class,
-                        WaitingRoomEquipment.class, SanitaryEquipment.class,
-                        TicketingEquipment.class, ShelterEquipment.class,
-                        CycleStorageEquipment.class, GeneralSign.class,
-                        AlternativeName.class);
-
-
-        commonClassesToConfigure.forEach(clazz -> mapperFactory.classMap(clazz, clazz)
-                .exclude(VERSION_COMMENT_FIELD)
-                .exclude(CHANGED_BY_FIELD)
-                .exclude(ID_FIELD)
-                .exclude(VALID_BETWEEN)
-                .byDefault()
-                .register());
+        // Registered last, as before: this overlaps with the equipment classes above and the order
+        // decides which rules win.
+        EntityCopyMappings.registerCommonEntities(mapperFactory);
 
         defaultMapperFacade = mapperFactory.getMapperFacade();
     }


### PR DESCRIPTION
Pulls the mechanical part of `VersionCreator`'s Orika setup into a shared `EntityCopyMappings`, so that copying a versioned entity does not mean repeating that configuration everywhere it is needed.

### Why now

This is enabling work, and it is worth being upfront that **it removes no duplication in master today** — there is only one copier here to share from. The duplication it prevents is in #318 (async write API), which adds two more entity copiers, each of which currently repeats this same configuration: the same three converters, the same path link end mapping, the same list of entities that lose their audit trail. That would make three copies of one configuration, where a new NeTEx field gets handled in one and forgotten in the others.

Doing the extraction here rather than inside #318 keeps the risk where it can be reviewed. `VersionCreator` has 14 callers across import, merge and GraphQL, so rewiring it belongs in a small PR of its own rather than folded into a large feature branch that otherwise only touches a flag-gated endpoint.

### What moves, and what deliberately does not

Only the boilerplate moves: the converters, the `PathLinkEnd` mapping, and the entity classes whose copying rules are the same wherever the copy happens.

Which identity fields a copy drops stays with the caller. That part carries meaning rather than boilerplate — a new version is the same stop place and keeps its `netexId`, which is not true of every kind of copy — and hiding it behind a shared helper would make the interesting difference the invisible one.

### No behaviour change intended

The registration sets overlap on `PlaceEquipment`, so the order these calls are made in looked load bearing. Reordering them and observing that `VersionCreatorTest` still passed showed the exclusions accumulate rather than the later registration replacing the earlier. That is recorded on the helper, noting it was established by experiment rather than from Orika's documentation, so the next reader knows how far to trust it. The original call order is kept regardless.

### Verification

Full suite green: **1018 tests, 0 failures, 0 errors**. The suites covering `VersionCreator`'s callers specifically:

| suite | tests |
| --- | --- |
| `VersionCreatorTest` | 10 |
| `QuayMergerTest` | 27 |
| `MergingStopPlaceImporterTest` | 8 |
| `StopPlaceMergerTest` | 6 |
| `TransactionalMergingStopPlacesImporterTest` | 3 |

Worth noting the limit of that evidence: Orika configuration is declarative, so a passing suite shows no *observable* change under existing coverage rather than proving equivalence.