### PR TITLE
Tests and runs locally against the postgres major that production uses

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,11 @@ name: 'tiamat'
 
 services:
   db:
-    container_name: '${COMPOSE_PROJECT_NAME}_postgis13'
-    image: 'postgis/postgis:13-master'
+    container_name: '${COMPOSE_PROJECT_NAME}_postgis17'
+    # Matches the major version running in production, so that a production dump restores
+    # locally and local behaviour is the behaviour that ships. postgis publishes this image
+    # for amd64 only, hence the platform pin below on Apple silicon.
+    image: 'postgis/postgis:17-master'
     hostname: postgres
     platform: linux/amd64
     restart: always
@@ -14,7 +17,10 @@ services:
     ports:
       - "37432:5432"
     volumes:
-      - postgres-data:/var/lib/postgresql
+      # Named per major version: postgres refuses to start against a data directory written
+      # by a different major, so a shared name would leave everyone with a container that
+      # will not boot after this change rather than a working empty database.
+      - postgres-data-17:/var/lib/postgresql
     networks:
       - tiamat-net
 
@@ -41,7 +47,7 @@ services:
       - tiamat-net
 
 volumes:
-  postgres-data:
+  postgres-data-17:
 
 networks:
   tiamat-net:

--- a/docker-compose/compose.yaml
+++ b/docker-compose/compose.yaml
@@ -26,7 +26,7 @@ services:
       - "1888:1888"
 
   db:
-    image: 'postgis/postgis:13-master'
+    image: 'postgis/postgis:17-master'
     container_name: db
     hostname: postgres
     networks:

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -32,7 +32,7 @@ spring.jpa.database=POSTGRESQL
 
 spring.database.driverClassName=org.postgresql.Driver
 
-spring.datasource.url=jdbc:tc:postgis:13-3.3:///tiamat
+spring.datasource.url=jdbc:tc:postgis:17-3.5:///tiamat
 
 spring.jpa.properties.jakarta.persistence.query.timeout=15000
 


### PR DESCRIPTION
Production runs **PostgreSQL 17**. The test suite and both compose files were on **13**.

### The line that matters

```diff
- spring.datasource.url=jdbc:tc:postgis:13-3.3:///tiamat
+ spring.datasource.url=jdbc:tc:postgis:17-3.5:///tiamat
```

Every test resolves its database through that URL, so this is not a local-development convenience: **CI has never exercised the major version we run in production.** The compose changes are secondary.

### How it surfaced

A production dump could not be restored locally at all. A 17 dump carries syntax that 13 rejects outright (`\restrict`, `SET transaction_timeout`), so anyone reaching for real data to reproduce a problem hit a wall before they started. That is a concrete cost rather than a hypothetical one.

### Verification, and its limits

Full suite passes on 17 unchanged: **1018 tests, 0 failures, 0 errors**, in about the same wall-clock as on 13.

Worth being precise about what that shows. It shows nothing in the current suite depended on 13 behaviour. It does **not** certify the upgrade — the value here is closing a blind spot, not proving 17 is problem-free. Anything that behaves differently between the two majors was previously invisible to us either way; now at least the tests are looking at the version that ships.

### Two deliberate choices

**The volume is named per major.** Postgres refuses to start against a data directory written by a different major, so keeping the old name would leave everyone with a container that will not boot after this change, rather than a working empty database. Both are commented in the file.

**The amd64 platform pin stays.** `postgis/postgis:17-master` publishes for amd64 only, so removing the pin breaks Apple silicon. Verified against the manifest rather than assumed. There is no measurable slowdown from the emulation locally, and CI runners are amd64 natively.

### What to expect on merge

First `docker compose up` after this lands gives an **empty database**, because the volume name changes. That is the intended trade against a container that will not start. Anyone with local data they care about should dump it first.