### PR TITLE
Stops exporting an empty element for a mode we do not store

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/netex/mapping/NetexMapper.java
+++ b/src/main/java/org/rutebanken/tiamat/netex/mapping/NetexMapper.java
@@ -129,6 +129,12 @@ public class NetexMapper {
                 .fieldAToB("topographicPlaceRef.ref", "topographicPlace.netexId")
                 .fieldAToB("topographicPlaceRef.version", "topographicPlace.version")
                 .exclude("roadAddress")
+                // Tiamat does not store other transport modes: the field is @Transient, so a
+                // mapped value goes nowhere. Mapping it anyway would still change the output,
+                // because the netex model's collection getter initialises null to an empty list
+                // and JAXB then marshals <OtherTransportModes></OtherTransportModes> on every
+                // stop place we publish.
+                .exclude("otherTransportModes")
                 .customize(new StopPlaceMapper(publicationDeliveryHelper))
                 .byDefault()
                 .register();
@@ -136,6 +142,8 @@ public class NetexMapper {
         mapperFactoryWithNetexIdClassBuilder(Quay.class, org.rutebanken.tiamat.model.Quay.class)
                 .exclude("postalAddress")
                 .exclude("roadAddress")
+                // Same as on StopPlace: @Transient, and mapping it emits an empty element.
+                .exclude("otherTransportModes")
                 .customize(new QuayMapper())
                 .byDefault()
                 .register();

--- a/src/test/java/org/rutebanken/tiamat/exporter/StreamingPublicationDeliveryIntegrationTest.java
+++ b/src/test/java/org/rutebanken/tiamat/exporter/StreamingPublicationDeliveryIntegrationTest.java
@@ -25,6 +25,8 @@ import org.rutebanken.tiamat.TiamatIntegrationTest;
 import org.rutebanken.tiamat.exporter.params.ExportParams;
 import org.rutebanken.tiamat.exporter.params.StopPlaceSearch;
 import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
+import org.rutebanken.tiamat.model.Quay;
+import org.rutebanken.tiamat.model.VehicleModeEnumeration;
 import org.rutebanken.tiamat.model.GroupOfStopPlaces;
 import org.rutebanken.tiamat.model.PurposeOfGrouping;
 import org.rutebanken.tiamat.model.SiteRefStructure;
@@ -515,6 +517,47 @@ public class StreamingPublicationDeliveryIntegrationTest extends TiamatIntegrati
                 .as("the topographic place referenced only by the parent must also be exported")
                 .extracting(org.rutebanken.netex.model.TopographicPlace::getId)
                 .contains(parentMunicipality.getNetexId(), childMunicipality.getNetexId());
+    }
+
+    /**
+     * Tiamat does not store other transport modes: the field is @Transient. Mapping it to the
+     * NeTEx model anyway changed the output, because that model's collection getter turns null
+     * into an empty list and JAXB then marshals an empty element onto every exported stop place
+     * and quay. It was schema valid but meaningless, it reached every consumer of the export,
+     * and the write API refused it on all 120 production stop places tried, because the field
+     * is not one a client can set.
+     */
+    @Test
+    public void doesNotExportEmptyOtherTransportModes() throws Exception {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString("Stop with a quay"));
+        stopPlace.setTransportMode(VehicleModeEnumeration.BUS);
+        stopPlace.getQuays().add(new Quay(new EmbeddableMultilingualString("Quay")));
+        stopPlaceRepository.save(stopPlace);
+        stopPlaceRepository.flush();
+
+        String xml = exportAll();
+
+        assertThat(xml)
+                .as("the stop place must still carry the transport mode it actually has")
+                .contains("<TransportMode>bus</TransportMode>");
+        assertThat(xml)
+                .as("nothing sets other transport modes, so the element has no business being here")
+                .doesNotContain("OtherTransportModes");
+        validate(xml);
+    }
+
+    private String exportAll() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        streamingPublicationDelivery.stream(
+                ExportParams.newExportParamsBuilder()
+                        .setStopPlaceSearch(StopPlaceSearch.newStopPlaceSearchBuilder()
+                                .setVersionValidity(ExportParams.VersionValidity.CURRENT_FUTURE)
+                                .build())
+                        .setTopographicPlaceExportMode(ExportParams.ExportMode.NONE)
+                        .setTariffZoneExportMode(ExportParams.ExportMode.NONE)
+                        .build(),
+                out);
+        return out.toString();
     }
 
     private void validate(String xml) throws JAXBException, IOException, SAXException {


### PR DESCRIPTION
Every stop place and quay we publish carries `<OtherTransportModes></OtherTransportModes>`.

Nothing sets it. The field is `@Transient`, so a value mapped into it goes nowhere — there is no column. It appears because the NeTEx mapping reads the entity through getters, and the NeTEx model's collection getter turns `null` into an empty list, which JAXB then marshals.

### Why bother, given it is schema valid

It is valid (`VehicleModeListOfEnumerations` is a plain `xsd:list` with no `minLength`), so nothing downstream is broken and this is not urgent. Two reasons it is still worth doing:

**It reaches every consumer of the export.** 306 occurrences per 100 stop places, on data that carries no information.

**It blocks read-then-write.** The write API refuses this path on **120 of 120** production stop places sampled, because it is not a field a client may set. So a client cannot fetch a stop place, change something, and send it back without first stripping an element we emitted ourselves. Of the three refusals that affect essentially every stop, this is the only one that is pure artifact — the other two carry real values.

### Why exclude from the mapping rather than delete the field

Same output either way. Excluding keeps the change inside the mapping layer instead of touching a model class used throughout the codebase, avoids editing a test and a field list that reference it, and is revertible in one line if a consumer turns out to want the element back.

Deleting the field is the tidier end state and remains available. It also belongs with a wider question: there are 159 `@Transient` fields across 40 model classes, all inherited from the JAXB-generated model cleaned up in `NRP-642` back in 2016. Most are inert — a field that is never set is already absent from the export, so removing it changes nothing observable. Only the lazily-initialised **collections** actually emit anything, which is why this one is worth its own change and a blanket sweep is not.

### Verification

Measured against 100 production stop places:

| | before | after |
| --- | --- | --- |
| empty `OtherTransportModes` | 306 | **0** |
| total empty elements | 454 | 148 |
| `<TransportMode>` values | 100 | 100 |

The new test in `StreamingPublicationDeliveryIntegrationTest` asserts both directions and revalidates the export against the NeTEx schema. The positive assertion is load bearing: `doesNotContain("OtherTransportModes")` alone would also pass if the real transport mode stopped being exported.

Confirmed it fails without the fix — removing the two excludes gives:

```
FAILURE - doesNotExportEmptyOtherTransportModes:545
[nothing sets other transport modes, so the element has no business being here]
```

Full suite green: 1019 tests, 0 failures.

### Not covered here

Six further empty elements per 100 stops come from the same cause on other types — `ParkingUserTypes`, `ParkingPaymentProcess`, `SanitaryFacilityList`. Left out deliberately: the parking class map is shared with the Fintraffic extension and deserves its own change rather than being folded in.

The remaining empties (`PrivateCode`, `PublicCode`, `Value`, `ValidBetween`) are real persisted fields that simply have no value. Different cause, not addressed by this.