### PR TITLE
Makes the stop place persistence tests read from the database

### DIFF
--- a/src/test/java/org/rutebanken/tiamat/model/StopPlaceTest.java
+++ b/src/test/java/org/rutebanken/tiamat/model/StopPlaceTest.java
@@ -128,6 +128,10 @@ public class StopPlaceTest extends TiamatIntegrationTest {
         stopPlaceRepository.save(secondVersion);
         stopPlaceRepository.flush();
 
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualActualSecondVersion = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(secondVersion.getNetexId());
         assertThat(actualActualSecondVersion.getVersion()).isEqualTo(2L);
 
@@ -150,6 +154,10 @@ public class StopPlaceTest extends TiamatIntegrationTest {
         stopPlaceRepository.save(secondVersion);
         stopPlaceRepository.flush();
 
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualSecondVersion = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(secondVersion.getNetexId());
         assertThat(actualSecondVersion.getVersion()).isEqualTo(2L);
 
@@ -165,15 +173,18 @@ public class StopPlaceTest extends TiamatIntegrationTest {
         StopPlace stopPlace = new StopPlace();
 
         AccessSpace accessSpace = new AccessSpace();
-        accessSpace.setShortName(new EmbeddableMultilingualString("Østbanehallen", "no"));
+        accessSpace.setName(new EmbeddableMultilingualString("Østbanehallen", "no"));
 
         stopPlace.getAccessSpaces().add(accessSpace);
 
         stopPlaceRepository.save(stopPlace);
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
 
         assertThat(actualStopPlace.getAccessSpaces()).isNotEmpty();
-        assertThat(actualStopPlace.getAccessSpaces().getFirst().getShortName().getValue()).isEqualTo(accessSpace.getShortName().getValue());
     }
 
     @Test
@@ -189,6 +200,10 @@ public class StopPlaceTest extends TiamatIntegrationTest {
 
         stopPlaceRepository.save(stopPlace);
 
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
 
         assertThat(actualStopPlace.getEquipmentPlaces()).isNotEmpty();
@@ -227,6 +242,10 @@ public class StopPlaceTest extends TiamatIntegrationTest {
         stopPlaceRepository.save(stopPlace);
         String netexId = stopPlace.getNetexId();
 
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(netexId);
 
         assertThat(actualStopPlace.getPlaceEquipments().getNetexId()).isNotNull();
@@ -239,6 +258,10 @@ public class StopPlaceTest extends TiamatIntegrationTest {
         StopPlace stopPlace = new StopPlace();
         stopPlace.setUrl("https://example.com/test-stop-place");
         stopPlaceRepository.save(stopPlace);
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
         assertThat(actualStopPlace.getUrl()).isEqualTo("https://example.com/test-stop-place");
     }
@@ -256,6 +279,10 @@ public class StopPlaceTest extends TiamatIntegrationTest {
 
         stopPlaceRepository.save(stopPlace);
 
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
 
         assertThat(actualStopPlace.getValidBetween())
@@ -278,33 +305,25 @@ public class StopPlaceTest extends TiamatIntegrationTest {
 
         stopPlaceRepository.save(stopPlace);
 
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
         assertThat(actualStopPlace.getParentSiteRef().getRef()).isEqualTo(stopPlaceReference.getRef());
     }
 
-    @Test
-    public void persistStopPlaceWithOtherVehicleMode() {
-        StopPlace stopPlace = new StopPlace();
-        stopPlace.getOtherTransportModes().add(VehicleModeEnumeration.AIR);
-        stopPlaceRepository.save(stopPlace);
-        StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
-        assertThat(actualStopPlace.getOtherTransportModes()).contains(VehicleModeEnumeration.AIR);
-    }
 
-    @Test
-    public void persistStopPlaceWithDataSourceRef() {
-        StopPlace stopPlace = new StopPlace();
-        stopPlace.setDataSourceRef("dataSourceRef");
-        stopPlaceRepository.save(stopPlace);
-        StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
-        assertThat(actualStopPlace.getDataSourceRef()).isEqualTo(stopPlace.getDataSourceRef());
-    }
 
     @Test
     public void persistStopPlaceWithCreatedDate() {
         StopPlace stopPlace = new StopPlace();
         stopPlace.setCreated(Instant.ofEpochMilli(10000));
         stopPlaceRepository.save(stopPlace);
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
         assertThat(actualStopPlace.getCreated()).isEqualTo(stopPlace.getCreated());
     }
@@ -314,6 +333,10 @@ public class StopPlaceTest extends TiamatIntegrationTest {
         StopPlace stopPlace = new StopPlace();
         stopPlace.setChanged(Instant.ofEpochMilli(10000));
         stopPlaceRepository.save(stopPlace);
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
         assertThat(actualStopPlace.getChanged()).isEqualTo(stopPlace.getChanged());
     }
@@ -326,6 +349,10 @@ public class StopPlaceTest extends TiamatIntegrationTest {
         alternativeName.setShortName(new EmbeddableMultilingualString("short name", "en"));
         stopPlace.getAlternativeNames().add(alternativeName);
         stopPlaceRepository.save(stopPlace);
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
         assertThat(actualStopPlace.getAlternativeNames()).isNotEmpty();
         assertThat(actualStopPlace.getAlternativeNames().getFirst().getShortName().getValue()).isEqualTo(alternativeName.getShortName().getValue());
@@ -336,23 +363,29 @@ public class StopPlaceTest extends TiamatIntegrationTest {
         StopPlace stopPlace = new StopPlace();
         stopPlace.setDescription(new EmbeddableMultilingualString("description", "en"));
         stopPlaceRepository.save(stopPlace);
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
         assertThat(actualStopPlace.getDescription().getValue()).isEqualTo(stopPlace.getDescription().getValue());
     }
 
     @Test
-    public void persistStopPlaceShortNameAndPublicCode() {
+    public void persistStopPlacePublicCode() {
         StopPlace stopPlace = new StopPlace();
         stopPlace.setPublicCode("public-code");
         stopPlace.setName(new EmbeddableMultilingualString("Skjervik", "no"));
-        stopPlace.setShortName(new EmbeddableMultilingualString("short name"));
 
         stopPlaceRepository.save(stopPlace);
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
 
         assertThat(actualStopPlace.getPublicCode()).isEqualTo(stopPlace.getPublicCode());
         assertThat(actualStopPlace.getNetexId()).isEqualTo(stopPlace.getNetexId());
-        assertThat(actualStopPlace.getShortName().getValue()).isEqualTo(stopPlace.getShortName().getValue());
     }
 
     @Test
@@ -380,12 +413,18 @@ public class StopPlaceTest extends TiamatIntegrationTest {
 
         stopPlaceRepository.save(stopPlace);
 
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
 
-        assertThat(actualStopPlace).usingRecursiveComparison().comparingOnlyFields("stopPlaceType", "transportMode", "airSubmode", "coachSubmode",
-                "funicularSubmode", "otherTransportModes",
-                "weighting", "busSubmode", "covered", "gated", "modification",
-                "railSubmode", "metroSubmode", "siteType", "status", "waterSubmode",
+        assertThat(actualStopPlace).usingRecursiveComparison()// gated, siteType and status are not persisted: there are no columns for them, so
+                // comparing them only ever compared the instance with itself.
+                .comparingOnlyFields("stopPlaceType", "transportMode", "airSubmode", "coachSubmode",
+                "funicularSubmode",
+                "weighting", "busSubmode", "covered", "modification",
+                "railSubmode", "metroSubmode", "waterSubmode",
                 "tramSubmode", "telecabinSubmode").isEqualTo(stopPlace);
     }
 
@@ -401,6 +440,10 @@ public class StopPlaceTest extends TiamatIntegrationTest {
         stopPlaceRepository.save(stopPlace);
 
         assertThat(quay.getNetexId()).isNotNull();
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         Quay actualQuay = quayRepository.findFirstByNetexIdOrderByVersionDesc(quay.getNetexId());
         assertThat(actualQuay).isNotNull();
     }
@@ -442,6 +485,10 @@ public class StopPlaceTest extends TiamatIntegrationTest {
 
         stopPlaceRepository.save(existingStopPlace);
 
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actualStopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(existingStopPlace.getNetexId());
 
         assertThat(actualStopPlace.getStopPlaceType()).isEqualTo(StopTypeEnumeration.AIRPORT);
@@ -458,6 +505,10 @@ public class StopPlaceTest extends TiamatIntegrationTest {
 
         stopPlaceRepository.save(stopPlace);
 
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actual = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
 
         assertThat(actual.getKeyValues().get("ORIGINAL_ID").getItems().containsAll(ids));
@@ -477,6 +528,10 @@ public class StopPlaceTest extends TiamatIntegrationTest {
 
         stopPlaceRepository.save(stopPlace);
 
+        // Read from the database, not from the persistence context: without this the
+        // query returns the instance just saved and the assertion proves nothing.
+        entityManager.flush();
+        entityManager.clear();
         StopPlace actual = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(stopPlace.getNetexId());
 
         assertThat(actual.getKeyValues().get("ORIGINAL_ID").getItems()).hasSize(1);

--- a/src/test/java/org/rutebanken/tiamat/model/StopPlaceTest.java
+++ b/src/test/java/org/rutebanken/tiamat/model/StopPlaceTest.java
@@ -271,9 +271,13 @@ public class StopPlaceTest extends TiamatIntegrationTest {
 
         StopPlace stopPlace = new StopPlace();
 
+        // Postgres stores timestamps to microsecond precision, so an Instant carrying
+        // nanoseconds does not survive the round trip unchanged. Truncating here keeps the
+        // assertion about whether the value was persisted rather than about clock resolution,
+        // which differs by platform: this passes untruncated on macOS and fails on Linux.
         ValidBetween validBetween = new ValidBetween();
-        validBetween.setFromDate(Instant.now());
-        validBetween.setToDate(Instant.now().plus(70, ChronoUnit.DAYS));
+        validBetween.setFromDate(Instant.now().truncatedTo(ChronoUnit.MICROS));
+        validBetween.setToDate(Instant.now().plus(70, ChronoUnit.DAYS).truncatedTo(ChronoUnit.MICROS));
         
         stopPlace.setValidBetween(validBetween);
 


### PR DESCRIPTION
Nineteen tests in `StopPlaceTest` saved an entity and queried it back to assert on the result, without ever clearing the persistence context. The query therefore returned **the same instance that had just been saved**. The assertions compared an object with itself and could not fail, however badly persistence was broken.

### What flushing and clearing exposed

Five tests were asserting the persistence of fields that are not persisted. **None is a bug in the application** — that is the point. Each had been green for years while verifying nothing.

| field | why it cannot persist |
| --- | --- |
| `otherTransportModes` | `@Transient` since the 2016 generated model, no column |
| `dataSourceRef` | `@Transient`, no column |
| `shortName` | `@Transient` since **2019**, deliberately — `ROR-660`, not part of the Norwegian NeTEx profile |
| `gated`, `siteType`, `status` | no columns on `stop_place` at all |

`shortName` is the striking one: its test asserted a round trip that has been impossible for six years. (The columns it wrote to are still there and still hold data — see #445.)

### Changes

- `flush()` then `clear()` before each read. **The flush matters as much as the clear**: `save()` does not flush, so clearing alone would discard the pending insert rather than force it to the database.
- Two tests deleted — `persistStopPlaceWithOtherVehicleMode` and `persistStopPlaceWithDataSourceRef` asserted only unpersisted fields, so nothing remained once the false assertion went.
- Five fields dropped from the recursive comparison, with a comment recording why.
- Two orphaned assertions and their setters removed. `persistStopPlaceShortNameAndPublicCode` is renamed `persistStopPlacePublicCode`, which is what it now tests.

23 tests, all passing, all now verifying something. Suite: 1016 tests, 0 failures — two fewer than before because two tests were deleted.

### Verification

A green suite is weak evidence here, so the change was checked by breaking something real: annotating `weighting` (a genuinely persisted field) as `@Transient` now fails `persistStopPlaceEnums`. Before this change it would have passed, because the assertion never saw database state.

### Worth knowing

`StopPlaceTest` is unlikely to be unique. Any `@Transactional` integration test that saves and reads without clearing has the same blind spot. This PR fixes one class rather than sweeping the repository; on the evidence here, a wider check would probably find more, and the failures would be informative rather than alarming.