### PR TITLE
Mounts the postgres volume at the path the data actually lives in

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,16 @@ services:
     ports:
       - "37432:5432"
     volumes:
-      # Named per major version: postgres refuses to start against a data directory written
-      # by a different major, so a shared name would leave everyone with a container that
-      # will not boot after this change rather than a working empty database.
-      - postgres-data-17:/var/lib/postgresql
+      # Must be the PGDATA path itself. The image declares VOLUME /var/lib/postgresql/data,
+      # and docker honours that independently: mounting the parent leaves the declaration
+      # unsatisfied, so postgres writes to an anonymous volume created for the deeper path
+      # and this named volume holds nothing. The database then does not survive the
+      # container being recreated.
+      #
+      # Named per major version because postgres refuses to start against a data directory
+      # written by a different major, so a shared name would leave everyone with a container
+      # that will not boot rather than a working empty database.
+      - postgres-data-17:/var/lib/postgresql/data
     networks:
       - tiamat-net
 


### PR DESCRIPTION
Raised in review of #443 — and correct. The volume path was wrong, and had been for a long time.

### What is wrong

The image declares `VOLUME /var/lib/postgresql/data` and sets `PGDATA` to the same path. Docker honours that declaration **independently** of our mount, so mounting the parent leaves it unsatisfied: an anonymous volume is created for the deeper path, postgres writes there, and our named volume holds nothing.

```
$ docker inspect <container> --format '{{range .Mounts}}...'
postgres-data-17                 -> /var/lib/postgresql        # ours, effectively empty
d45227a8c2916a4d3ae01ba99a…      -> /var/lib/postgresql/data   # anonymous, the real PGDATA
```

Two consequences: the database does not survive the container being recreated, and every recreate leaves another anonymous volume behind.

### Reproduced both ways

| mount | mounts created | write a row, `docker rm`, recreate |
| --- | --- | --- |
| `…:/var/lib/postgresql` (current) | 2, one anonymous at PGDATA | `ERROR: relation "persistence_check" does not exist` |
| `…:/var/lib/postgresql/data` (this PR) | 1 | row still there |

### This is not new

The same wrong path was there before the move to 17 (`postgres-data:/var/lib/postgresql`), and the 13 image declares the same `VOLUME`. So local databases have been disposable for as long as this file has existed, without anyone intending it. #443 only renamed the volume; it inherited the path.

It also explains `docker-compose/postgres/data`, which is the *other* compose file's mount — that one uses the correct `/var/lib/postgresql/data`, which is why it accumulated a real database while the named volume never did.

### Note for anyone with local data

If you have a database you care about, it is in an anonymous volume rather than `postgres-data-17`. `docker volume ls` will show it; dump it before recreating the container, because after this change the container starts against the named volume and the anonymous one is orphaned.