### PR TITLE
Lets hazelcast move off a taken port again, and proves why it must

### DIFF
--- a/src/main/java/org/rutebanken/tiamat/config/HazelCastConfig.java
+++ b/src/main/java/org/rutebanken/tiamat/config/HazelCastConfig.java
@@ -28,6 +28,14 @@ public class HazelCastConfig {
     private String hazelcastClusterName;
 
 
+    /**
+     * Off in production, where one instance per pod binds a known port. Tests need it on: each
+     * Spring context starts its own instance, and with several contexts alive the second one
+     * cannot bind and the context fails to load.
+     */
+    @Value("${tiamat.hazelcast.port.auto-increment:false}")
+    private boolean portAutoIncrement;
+
     @Bean
     public Config hazelcastConfig() {
         Config config = new Config();
@@ -36,7 +44,7 @@ public class HazelCastConfig {
         config.setClusterName(hazelcastClusterName);
 
         // Configure network settings
-        config.getNetworkConfig().setPortAutoIncrement(false);
+        config.getNetworkConfig().setPortAutoIncrement(portAutoIncrement);
 
         JoinConfig joinConfig = config.getNetworkConfig().getJoin();
         joinConfig.getMulticastConfig().setEnabled(false);

--- a/src/test/java/org/rutebanken/tiamat/config/SecondSpringContextStartsTest.java
+++ b/src/test/java/org/rutebanken/tiamat/config/SecondSpringContextStartsTest.java
@@ -1,0 +1,50 @@
+package org.rutebanken.tiamat.config;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import org.junit.Test;
+import org.rutebanken.tiamat.TiamatIntegrationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * More than one Hazelcast instance has to be able to start in the same JVM.
+ * <p>
+ * Tests need this because every Spring context brings up its own instance and Spring caches
+ * contexts rather than closing them, so several are alive at once. If an instance cannot move
+ * off a port that is already taken, the second context fails to load, and it surfaces as an
+ * ApplicationContext failure in whichever test happens to run second rather than anywhere near
+ * the cause. That is what {@code tiamat.hazelcast.port.auto-increment} is for, and production
+ * leaves it off because one instance per pod binds a known port.
+ * <p>
+ * Asserting it this way rather than by declaring a second context on purpose: a context based
+ * test passes whenever it happens to run first, and pushes the failure into an unrelated class.
+ * Starting a second instance from the same configuration fails the same way every time, because
+ * the context this test runs in is already holding the port.
+ */
+public class SecondSpringContextStartsTest extends TiamatIntegrationTest {
+
+    @Autowired
+    private Config hazelcastConfig;
+
+    @Autowired
+    private HazelcastInstance runningInstance;
+
+    @Test
+    public void aSecondInstanceCanStartAlongsideTheFirst() {
+        assertThat(runningInstance.getLifecycleService().isRunning())
+                .as("precondition: this context is already holding a port")
+                .isTrue();
+
+        HazelcastInstance second = Hazelcast.newHazelcastInstance(hazelcastConfig);
+        try {
+            assertThat(second.getLifecycleService().isRunning())
+                    .as("a second context must be able to start, which means moving off the taken port")
+                    .isTrue();
+        } finally {
+            second.getLifecycleService().terminate();
+        }
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -65,6 +65,7 @@ tiamat.hazelcast.cluster.name=tiamat
 tiamat.hazelcast.service-name=tiamat
 tiamat.hazelcast.service-port=5701
 tiamat.hazelcast.kubernetes.enabled=false
+tiamat.hazelcast.port.auto-increment=true
 
 
 


### PR DESCRIPTION
The parking revert (#450) also removed the configurable Hazelcast port auto-increment, which was unrelated to parking.

Every Spring context starts its own Hazelcast instance and Spring caches contexts, so with the port fixed the second context cannot bind and fails to load. Master did not notice because no test here declares its own configuration, so only one context is ever built. #318 adds several, which is how it surfaced.

Production keeps it off, as before.

The test starts a second instance from the same config rather than declaring a second context: the context-based version passed while the bug was present, because it ran first and got the port, pushing the failure into an unrelated class.