### PR TITLE
Removes the parking discriminator column the revert left behind

### DIFF
--- a/src/main/resources/db/migration/V62__add_parking_dtype.sql
+++ b/src/main/resources/db/migration/V62__add_parking_dtype.sql
@@ -1,0 +1,5 @@
+-- Add dtype discriminator column for Hibernate SINGLE_TABLE inheritance on Parking.
+-- FintrafficParking extends Parking and is compiled into the same jar, so Hibernate
+-- always requires this column regardless of which Spring profiles are active.
+-- PostgreSQL 11+ handles NOT NULL DEFAULT without a table rewrite.
+ALTER TABLE parking ADD COLUMN IF NOT EXISTS dtype VARCHAR(31) NOT NULL DEFAULT 'Parking';

--- a/src/main/resources/db/migration/V63__drop_parking_dtype.sql
+++ b/src/main/resources/db/migration/V63__drop_parking_dtype.sql
@@ -1,0 +1,11 @@
+-- Removes the discriminator column added by V62, whose feature was reverted.
+--
+-- V62 is restored rather than left deleted on purpose. Flyway validates on migrate, and an
+-- applied version with no local file fails with "Detected applied migration not resolved
+-- locally", so deleting the file breaks startup for any environment that had already run it.
+-- Restoring it byte for byte keeps the recorded checksum valid; this migration then undoes what
+-- it did. Environments that never ran V62 add the column here and drop it immediately, which is
+-- wasted work but correct.
+--
+-- IF EXISTS because both cases have to be safe.
+ALTER TABLE parking DROP COLUMN IF EXISTS dtype;


### PR DESCRIPTION
The revert deleted V62's file but not the column it added.

Restores V62 byte for byte and adds V63 to drop the column. The restore matters because Flyway validates on migrate: an applied version with no local file fails startup with "Detected applied migration not resolved locally", and we have no ignore patterns configured. So any environment that ran V62 is currently blocked, separately from the column.

`IF EXISTS` so it is safe whether or not V62 ran. Tested both paths on PG17.

Worth checking which environments actually ran V62 — if none, the restore is just harmless.

#318 uses V63–V67 and will need renumbering.