### PR TITLE
Refuses a write API update built on a version that has moved on

### DIFF
--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/validation/StaleVersionException.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/validation/StaleVersionException.java
@@ -16,12 +16,12 @@
 package org.rutebanken.tiamat.rest.validation;
 
 /**
- * Thrown when an edit was based on a version that is no longer current.
+ * The writer throws this exception when an edit uses a version that is no longer current.
  * <p>
- * Distinct from the other validation failures because it says something different to the caller.
- * A rejected payload stays rejected however many times it is sent. This one means the payload was
- * fine and somebody else got there first, so reading the stop place again and reapplying the edit
- * is the correct response rather than a retry of the same bytes.
+ * This exception differs from the other validation failures, because it tells the caller
+ * something different. A rejected payload stays rejected, and the same bytes always give the
+ * same result. A stale version means that the payload was correct, and that another client wrote
+ * first. The caller must read the stop place again and reapply the edit.
  */
 public class StaleVersionException extends RuntimeException {
 

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/validation/StaleVersionException.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/validation/StaleVersionException.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.rest.validation;
+
+/**
+ * Thrown when an edit was based on a version that is no longer current.
+ * <p>
+ * Distinct from the other validation failures because it says something different to the caller.
+ * A rejected payload stays rejected however many times it is sent. This one means the payload was
+ * fine and somebody else got there first, so reading the stop place again and reapplying the edit
+ * is the correct response rather than a retry of the same bytes.
+ */
+public class StaleVersionException extends RuntimeException {
+
+    private final long expectedVersion;
+    private final long currentVersion;
+
+    public StaleVersionException(String netexId, long expectedVersion, long currentVersion) {
+        super("Stop place " + netexId + " has moved to version " + currentVersion
+                + " since version " + expectedVersion + " was read.");
+        this.expectedVersion = expectedVersion;
+        this.currentVersion = currentVersion;
+    }
+
+    public long getExpectedVersion() {
+        return expectedVersion;
+    }
+
+    public long getCurrentVersion() {
+        return currentVersion;
+    }
+}

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/validation/StaleVersionException.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/validation/StaleVersionException.java
@@ -25,18 +25,12 @@ package org.rutebanken.tiamat.rest.validation;
  */
 public class StaleVersionException extends RuntimeException {
 
-    private final long expectedVersion;
     private final long currentVersion;
 
     public StaleVersionException(String netexId, long expectedVersion, long currentVersion) {
         super("Stop place " + netexId + " has moved to version " + currentVersion
                 + " since version " + expectedVersion + " was read.");
-        this.expectedVersion = expectedVersion;
         this.currentVersion = currentVersion;
-    }
-
-    public long getExpectedVersion() {
-        return expectedVersion;
     }
 
     public long getCurrentVersion() {

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/validation/StopPlaceMutationValidator.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/validation/StopPlaceMutationValidator.java
@@ -68,6 +68,28 @@ public class StopPlaceMutationValidator {
         return existingStopPlace;
     }
 
+    /**
+     * As above, and refuses the update unless the caller edited the version that is still current.
+     * <p>
+     * Without this an edit built from a stale read silently overwrites whatever happened in
+     * between. The mutate lock does not help: it serialises the writes, but the caller read the
+     * stop place in an earlier request, long before taking the lock.
+     * <p>
+     * Belongs here rather than in the saver service, which has callers throughout the importers
+     * where an expected version is not a concept, and which is a persistence concern rather than a
+     * request one. Callers must resolve the expected version inside the lock, or they reintroduce
+     * the race they are trying to close.
+     *
+     * @throws StaleVersionException if the stop place has moved on since the caller read it.
+     */
+    public StopPlace validateStopPlaceUpdate(String netexId, boolean isParentMutation, long expectedVersion) {
+        StopPlace existingStopPlace = validateStopPlaceUpdate(netexId, isParentMutation);
+        if (existingStopPlace.getVersion() != expectedVersion) {
+            throw new StaleVersionException(netexId, expectedVersion, existingStopPlace.getVersion());
+        }
+        return existingStopPlace;
+    }
+
     public void validateStopPlaceName(StopPlace stopPlace) throws IllegalArgumentException {
         Preconditions.checkArgument(
                 stopPlace.getName() != null && !Strings.isNullOrEmpty(stopPlace.getName().getValue()),

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/validation/StopPlaceMutationValidator.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/validation/StopPlaceMutationValidator.java
@@ -69,18 +69,22 @@ public class StopPlaceMutationValidator {
     }
 
     /**
-     * As above, and refuses the update unless the caller edited the version that is still current.
+     * This method does the same as the two-argument method, and also refuses the update when the
+     * caller edited a version that is no longer current.
      * <p>
-     * Without this an edit built from a stale read silently overwrites whatever happened in
-     * between. The mutate lock does not help: it serialises the writes, but the caller read the
-     * stop place in an earlier request, long before taking the lock.
+     * Without this check, an edit from a stale read overwrites a concurrent edit without a
+     * warning. The mutate lock does not prevent this problem. The lock serializes the writes, but
+     * the caller read the stop place in an earlier request, before anything took the lock.
      * <p>
-     * Belongs here rather than in the saver service, which has callers throughout the importers
-     * where an expected version is not a concept, and which is a persistence concern rather than a
-     * request one. Callers must resolve the expected version inside the lock, or they reintroduce
-     * the race they are trying to close.
+     * This check belongs here and not in the saver service. That service has callers throughout
+     * the importers, where an expected version is not a concept. It is also a persistence concern
+     * and not a request one.
+     * <p>
+     * A caller must resolve the expected version inside the lock. A caller that resolves it
+     * earlier opens the race again.
      *
-     * @throws StaleVersionException if the stop place has moved on since the caller read it.
+     * @throws StaleVersionException if the stop place moved to a later version after the caller
+     *         read it.
      */
     public StopPlace validateStopPlaceUpdate(String netexId, boolean isParentMutation, long expectedVersion) {
         StopPlace existingStopPlace = validateStopPlaceUpdate(netexId, isParentMutation);

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceController.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceController.java
@@ -19,9 +19,11 @@ import org.rutebanken.tiamat.rest.write.dto.StopPlaceJobDto;
     description = """
     Write mono-modal StopPlace entities asynchronously.
 
-    The API ignores the Version and ValidBetween attributes in the NeTEx XML that you submit.
-    The system sets these values. Timestamps in the NeTEx XML that the API returns always use
-    the timezone of the system, without timezone information.
+    The system sets the ValidBetween attribute, and ignores the one in the NeTEx XML that you
+    submit. On an update, the Version attribute states which version you edited, and the API
+    refuses the write if that version is no longer current. On a create, the API ignores the
+    Version attribute. Timestamps in the NeTEx XML that the API returns always use the timezone
+    of the system, without timezone information.
 
     The API does not read a write request before it accepts the request. The API answers a
     syntactically correct request with 202 and a job id. The API then reads and validates the
@@ -108,9 +110,9 @@ interface StopPlaceController {
         that are not in your document. If a quay has an unknown NeTEx ID, the job fails. If a
         quay has no ID, the API adds a new quay.
 
-        CAUTION: Send an update only from a document that you read recently. The API does not
-        know which version you edited. Your document replaces every change that another client
-        made after you read it. Refer to #453.
+        The Version attribute must state the version that you edited. If another client changed
+        the stop place after you read it, the job fails and the reason gives the current
+        version. Read the stop place again, apply your change to it, and submit it again.
 
         The API reports malformed XML and unsupported elements on the job.
         """,

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceController.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceController.java
@@ -20,7 +20,7 @@ import org.rutebanken.tiamat.rest.write.dto.StopPlaceJobDto;
     Write mono-modal StopPlace entities asynchronously.
 
     The system sets the ValidBetween attribute, and ignores the one in the NeTEx XML that you
-    submit. On an update, the Version attribute states which version you edited, and the API
+    submit. On an update, set the Version attribute to the version you read, and the API
     refuses the write if that version is no longer current. On a create, the API ignores the
     Version attribute. Timestamps in the NeTEx XML that the API returns always use the timezone
     of the system, without timezone information.
@@ -110,9 +110,13 @@ interface StopPlaceController {
         that are not in your document. If a quay has an unknown NeTEx ID, the job fails. If a
         quay has no ID, the API adds a new quay.
 
-        The Version attribute must state the version that you edited. If another client changed
-        the stop place after you read it, the job fails and the reason gives the current
-        version. Read the stop place again, apply your change to it, and submit it again.
+        Set the Version attribute to the version you read, not to the version you want to
+        make. The system decides the next version. If the stop place is at version 4, send
+        version="4", and the system writes version 5.
+
+        This is how the API knows that nobody changed the stop place while you were editing
+        it. If somebody did, the job fails, and the reason gives the version that is now
+        current. Read the stop place again, apply your change to it, and submit it again.
 
         The API reports malformed XML and unsupported elements on the job.
         """,
@@ -122,10 +126,10 @@ interface StopPlaceController {
                 mediaType = "application/xml",
                 examples = {
                     @ExampleObject(
-                        name = "Update StopPlace Example",
+                        name = "Update the stop place that is currently at version 1",
                         value = """
                                                 <stopPlaces xmlns="http://www.netex.org.uk/netex">
-                                                  <StopPlace id="MES:StopPlace:1" version="2">
+                                                  <StopPlace id="MES:StopPlace:1" version="1">
                                                     <Name lang="akk">Bīt Mīt Uruk</Name>
                                                     <PrivateCode>1</PrivateCode>
                                                     <Centroid>

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/writer/JobService.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/writer/JobService.java
@@ -214,13 +214,13 @@ public class JobService {
      */
     private String constantReasonFor(Throwable throwable) {
         Throwable cause = throwable;
-        // A stale version is the one failure worth resubmitting, so it says so rather than
-        // arriving as another unexplained rejection. The message carries both versions, because
-        // the caller needs the current one to read the stop place again.
-        // Bounded rather than walked to the end: a cause chain can be cyclic, and no wrapping this
-        // has to see through is anywhere near this deep.
+        // The loop stops at a fixed depth and does not go to the end of the chain. A cause chain
+        // can be cyclic, and no wrapping that this method sees through is anywhere near this deep.
         for (int depth = 0; cause != null && depth < MAX_CAUSE_DEPTH; depth++, cause = cause.getCause()) {
             if (cause instanceof StaleVersionException stale) {
+                // A stale version is the one failure that the caller can resubmit, so the message
+                // says so. It also carries the current version, because the caller needs that
+                // number to read the stop place again.
                 return "The stop place moved to version " + stale.getCurrentVersion()
                         + " while this job was pending. Read it again and reapply the change.";
             }

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/writer/JobService.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/writer/JobService.java
@@ -4,6 +4,7 @@ import org.rutebanken.tiamat.model.job.AsyncStopPlaceJob;
 import org.rutebanken.tiamat.model.job.AsyncStopPlaceJobStatus;
 import org.rutebanken.tiamat.model.job.StopPlaceIdMapping;
 import org.rutebanken.tiamat.repository.AsyncStopPlaceJobRepository;
+import org.rutebanken.tiamat.rest.validation.StaleVersionException;
 import org.rutebanken.tiamat.writer.async.WriteJobNotOwnedException;
 import org.rutebanken.tiamat.writer.async.WriteJobPrincipal;
 import org.slf4j.Logger;
@@ -213,9 +214,16 @@ public class JobService {
      */
     private String constantReasonFor(Throwable throwable) {
         Throwable cause = throwable;
+        // A stale version is the one failure worth resubmitting, so it says so rather than
+        // arriving as another unexplained rejection. The message carries both versions, because
+        // the caller needs the current one to read the stop place again.
         // Bounded rather than walked to the end: a cause chain can be cyclic, and no wrapping this
         // has to see through is anywhere near this deep.
         for (int depth = 0; cause != null && depth < MAX_CAUSE_DEPTH; depth++, cause = cause.getCause()) {
+            if (cause instanceof StaleVersionException stale) {
+                return "The stop place moved to version " + stale.getCurrentVersion()
+                        + " while this job was pending. Read it again and reapply the change.";
+            }
             if (cause instanceof AccessDeniedException) {
                 return "You do not have permission to perform this operation.";
             }

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/writer/StopPlaceWriter.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/writer/StopPlaceWriter.java
@@ -123,12 +123,14 @@ public class StopPlaceWriter {
     }
 
     /**
-     * The version attribute states which version the caller edited, and an update cannot be
-     * checked for staleness without it. Required rather than optional: the alternative leaves
-     * every caller that omits it able to overwrite concurrent edits silently, which is the
-     * problem this exists to close.
+     * The version attribute states which version the caller edited. Without it the writer cannot
+     * find a stale update.
      * <p>
-     * Create ignores the attribute, because there is nothing yet to be stale against.
+     * The attribute is required, not optional. An optional precondition lets every caller that
+     * omits it overwrite a concurrent edit without a warning. That is the problem that this
+     * requirement closes.
+     * <p>
+     * A create ignores the attribute, because a new stop place has no earlier version.
      */
     private static long requireSubmittedVersion(org.rutebanken.netex.model.StopPlace submitted) {
         String version = submitted.getVersion();

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/writer/StopPlaceWriter.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/writer/StopPlaceWriter.java
@@ -93,14 +93,15 @@ public class StopPlaceWriter {
         establishNetexMappingContext();
         long expectedVersion = requireSubmittedVersion(newStopPlace);
         return mutateLock.executeInLock(() -> {
-            // Resolved inside the lock rather than from the request, so the version compared
-            // against is a fresh read rather than one the caller supplied.
+            // The validator reads the current version inside the lock, so the comparison uses a
+            // fresh read and not a version that the caller supplied.
             //
-            // This narrows the window but does not close it. The lock sits inside the
-            // transaction, so the previous writer releases it before committing, and a writer
-            // parked on the lock can still read the superseded version. The unique constraint on
-            // (netex_id, version) catches that, so nothing is lost, but the caller is told a
-            // constraint was violated rather than that the stop place moved on. See #458.
+            // This check narrows the window, but it does not close it. The lock sits inside the
+            // transaction, so the previous writer releases the lock before it commits. A writer
+            // that waits on the lock can still read the superseded version. The unique constraint
+            // on (netex_id, version) then refuses the second row, so the database keeps the first
+            // write. But the caller gets a constraint message instead of the stale-version
+            // reason. See #458.
             var existingStopPlace = stopPlaceMutationValidator.validateStopPlaceUpdate(
                     newStopPlace.getId(),
                     false,

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/writer/StopPlaceWriter.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/writer/StopPlaceWriter.java
@@ -93,8 +93,14 @@ public class StopPlaceWriter {
         establishNetexMappingContext();
         long expectedVersion = requireSubmittedVersion(newStopPlace);
         return mutateLock.executeInLock(() -> {
-            // Resolved inside the lock, so that the version compared against is the one this write
-            // is about to supersede rather than one read before the lock was taken.
+            // Resolved inside the lock rather than from the request, so the version compared
+            // against is a fresh read rather than one the caller supplied.
+            //
+            // This narrows the window but does not close it. The lock sits inside the
+            // transaction, so the previous writer releases it before committing, and a writer
+            // parked on the lock can still read the superseded version. The unique constraint on
+            // (netex_id, version) catches that, so nothing is lost, but the caller is told a
+            // constraint was violated rather than that the stop place moved on. See #458.
             var existingStopPlace = stopPlaceMutationValidator.validateStopPlaceUpdate(
                     newStopPlace.getId(),
                     false,

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/writer/StopPlaceWriter.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/writer/StopPlaceWriter.java
@@ -91,10 +91,14 @@ public class StopPlaceWriter {
     @Transactional
     public StopPlace updateStopPlace(org.rutebanken.netex.model.StopPlace newStopPlace) {
         establishNetexMappingContext();
+        long expectedVersion = requireSubmittedVersion(newStopPlace);
         return mutateLock.executeInLock(() -> {
+            // Resolved inside the lock, so that the version compared against is the one this write
+            // is about to supersede rather than one read before the lock was taken.
             var existingStopPlace = stopPlaceMutationValidator.validateStopPlaceUpdate(
                     newStopPlace.getId(),
-                    false
+                    false,
+                    expectedVersion
             );
             var tiamatStop = netexMapper.mapToTiamatModel(newStopPlace);
 
@@ -109,6 +113,28 @@ public class StopPlaceWriter {
                     Set.of() // currently only mono-modal stops are supported
             );
         });
+    }
+
+    /**
+     * The version attribute states which version the caller edited, and an update cannot be
+     * checked for staleness without it. Required rather than optional: the alternative leaves
+     * every caller that omits it able to overwrite concurrent edits silently, which is the
+     * problem this exists to close.
+     * <p>
+     * Create ignores the attribute, because there is nothing yet to be stale against.
+     */
+    private static long requireSubmittedVersion(org.rutebanken.netex.model.StopPlace submitted) {
+        String version = submitted.getVersion();
+        if (version == null || version.isBlank()) {
+            throw new IllegalArgumentException(
+                    "An update must carry the version attribute of the stop place it edits.");
+        }
+        try {
+            return Long.parseLong(version.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "The version attribute must be a number, but was '" + version + "'.");
+        }
     }
 
     @Transactional

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceControllerAuthorizationTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceControllerAuthorizationTest.java
@@ -73,12 +73,12 @@ public class StopPlaceControllerAuthorizationTest extends TiamatIntegrationTest 
 
         String xml = String.format("""
                 <stopPlaces xmlns="http://www.netex.org.uk/netex">
-                    <StopPlace id="%s">
+                    <StopPlace id="%s" version="%d">
                         <Name>Updated Stop</Name>
                         <StopPlaceType>busStation</StopPlaceType>
                     </StopPlace>
                 </stopPlaces>
-                """, existing.getNetexId());
+                """, existing.getNetexId(), existing.getVersion());
 
         ResponseEntity<StopPlaceJobDto> response = putXml(xml, StopPlaceJobDto.class);
 
@@ -141,12 +141,12 @@ public class StopPlaceControllerAuthorizationTest extends TiamatIntegrationTest 
 
         String xml = String.format("""
                 <stopPlaces xmlns="http://www.netex.org.uk/netex">
-                    <StopPlace id="%s">
+                    <StopPlace id="%s" version="%d">
                         <Name>Updated Bus Stop</Name>
                         <StopPlaceType>busStation</StopPlaceType>
                     </StopPlace>
                 </stopPlaces>
-                """, existing.getNetexId());
+                """, existing.getNetexId(), existing.getVersion());
 
         ResponseEntity<StopPlaceJobDto> response = putXml(xml, StopPlaceJobDto.class);
 

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceControllerIntegrationTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceControllerIntegrationTest.java
@@ -331,7 +331,7 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
                 </stopPlaces>
                 """,
                 saved.getNetexId(), saved.getVersion()
-            );
+        );
 
         ResponseEntity<StopPlaceJobDto> response = putXml(xml, StopPlaceJobDto.class);
 
@@ -701,6 +701,35 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
 
         assertThat(job.status()).isEqualTo(AsyncStopPlaceJobStatus.FAILED);
         assertThat(job.errorMessage()).contains("must carry the version attribute");
+        String unchangedName = written(saved.getNetexId(), sp -> sp.getName().getValue());
+        assertThat(unchangedName).isEqualTo("Original Name");
+    }
+
+    /**
+     * version="any" is legal NeTEx, and is refused deliberately rather than as a side effect of
+     * parsing. "any" is precisely the assertion a precondition cannot accept: it says the caller
+     * does not care which version it edited.
+     */
+    @Test
+    public void updateWithANonNumericVersionFails() throws InterruptedException {
+        StopPlace saved = savedStopPlace("Original Name");
+
+        String xml = """
+            <stopPlaces xmlns="http://www.netex.org.uk/netex">
+                <StopPlace id="%s" version="any">
+                    <Name>Any Version</Name>
+                    <StopPlaceType>busStation</StopPlaceType>
+                </StopPlace>
+            </stopPlaces>
+            """.formatted(saved.getNetexId());
+
+        StopPlaceJobDto job = awaitJobCompletion(putXml(xml, StopPlaceJobDto.class).getBody().jobId());
+
+        assertThat(job.status()).isEqualTo(AsyncStopPlaceJobStatus.FAILED);
+        assertThat(job.errorMessage())
+                .as("the message reaches the caller verbatim, so it is part of the contract")
+                .contains("version attribute must be a number")
+                .contains("'any'");
         String unchangedName = written(saved.getNetexId(), sp -> sp.getName().getValue());
         assertThat(unchangedName).isEqualTo("Original Name");
     }

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceControllerIntegrationTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceControllerIntegrationTest.java
@@ -654,9 +654,10 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
     }
 
     /**
-     * The case from issue #453. Two clients read version 1. The first write moves the stop place to
-     * version 2. The second was built from what the first has already replaced, so applying it
-     * would discard that work without telling anybody.
+     * This test covers the case from issue #453. Two clients read version 1. The first write moves
+     * the stop place to version 2. The second client built its edit from the version that the
+     * first write replaced. Without the precondition, that edit discards the first write without
+     * a warning.
      */
     @Test
     public void updateFromAVersionThatHasMovedOnFails() throws InterruptedException {

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceControllerIntegrationTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceControllerIntegrationTest.java
@@ -706,9 +706,9 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
     }
 
     /**
-     * version="any" is legal NeTEx, and is refused deliberately rather than as a side effect of
-     * parsing. "any" is precisely the assertion a precondition cannot accept: it says the caller
-     * does not care which version it edited.
+     * version="any" is legal NeTEx, and the writer refuses it deliberately, not as a side effect
+     * of the parse. "any" is the one assertion that a precondition cannot accept, because it says
+     * the caller does not care which version it edited.
      */
     @Test
     public void updateWithANonNumericVersionFails() throws InterruptedException {

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceControllerIntegrationTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/write/controllers/StopPlaceControllerIntegrationTest.java
@@ -273,7 +273,7 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
         String xml = String.format(
             """
             <stopPlaces xmlns="http://www.netex.org.uk/netex">
-                <StopPlace id="%s">
+                <StopPlace id="%s" version="%d">
                     <Name>Updated Name</Name>
                     <StopPlaceType>busStation</StopPlaceType>
                     <quays>
@@ -284,7 +284,7 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
                 </StopPlace>
             </stopPlaces>
             """,
-            saved.getNetexId()
+            saved.getNetexId(), saved.getVersion()
         );
 
         ResponseEntity<StopPlaceJobDto> response = putXml(xml, StopPlaceJobDto.class);
@@ -318,7 +318,7 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
         String xml = String.format(
                 """
                 <stopPlaces xmlns="http://www.netex.org.uk/netex">
-                    <StopPlace id="%s">
+                    <StopPlace id="%s" version="%d">
                         <Name>Updated Name</Name>
                         <StopPlaceType>busStation</StopPlaceType>
                         <quays>
@@ -330,8 +330,8 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
                     </StopPlace>
                 </stopPlaces>
                 """,
-                saved.getNetexId()
-        );
+                saved.getNetexId(), saved.getVersion()
+            );
 
         ResponseEntity<StopPlaceJobDto> response = putXml(xml, StopPlaceJobDto.class);
 
@@ -551,7 +551,7 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
         String xml = String.format(
             """
             <stopPlaces xmlns="http://www.netex.org.uk/netex">
-                <StopPlace id="%s" version="0">
+                <StopPlace id="%s" version="%d">
                     <Name>Updated Name</Name>
                     <StopPlaceType>busStation</StopPlaceType>
                     <ValidBetween>
@@ -566,7 +566,7 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
                 </StopPlace>
             </stopPlaces>
             """,
-            saved.getNetexId()
+            saved.getNetexId(), saved.getVersion()
         );
 
         ResponseEntity<StopPlaceJobDto> response = putXml(xml, StopPlaceJobDto.class);
@@ -606,7 +606,7 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
         String xml = String.format(
             """
             <stopPlaces xmlns="http://www.netex.org.uk/netex">
-                <StopPlace id="%s" version="666">
+                <StopPlace id="%s" version="%d">
                     <Name>Updated Name</Name>
                     <StopPlaceType>busStation</StopPlaceType>
                     <AccessibilityAssessment modification="new" version="667" id="NSR:AccessibilityAssessment:1">
@@ -630,7 +630,7 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
                 </StopPlace>
             </stopPlaces>
             """,
-            saved.getNetexId()
+            saved.getNetexId(), saved.getVersion()
         );
 
         ResponseEntity<StopPlaceJobDto> response = putXml(xml, StopPlaceJobDto.class);
@@ -651,6 +651,90 @@ public class StopPlaceControllerIntegrationTest extends TiamatIntegrationTest {
         assertThat(updatedAssessmentVersion).as("the server decides the version, not the client").isEqualTo(2L);
         assertThat(updatedAssessmentId).isEqualTo("NSR:AccessibilityAssessment:1");
         assertThat(updatedLimitationVersion).isEqualTo(1L);
+    }
+
+    /**
+     * The case from issue #453. Two clients read version 1. The first write moves the stop place to
+     * version 2. The second was built from what the first has already replaced, so applying it
+     * would discard that work without telling anybody.
+     */
+    @Test
+    public void updateFromAVersionThatHasMovedOnFails() throws InterruptedException {
+        StopPlace saved = savedStopPlace("Original Name");
+
+        StopPlaceJobDto firstJob = awaitJobCompletion(
+                putXml(updateXml(saved.getNetexId(), 1, "First Edit"), StopPlaceJobDto.class).getBody().jobId());
+        assertThat(firstJob.status()).isEqualTo(AsyncStopPlaceJobStatus.FINISHED);
+
+        ResponseEntity<StopPlaceJobDto> second =
+                putXml(updateXml(saved.getNetexId(), 1, "Second Edit"), StopPlaceJobDto.class);
+
+        assertThat(second.getStatusCode())
+                .as("staleness is found during processing, so the request is still accepted")
+                .isEqualTo(HttpStatus.ACCEPTED);
+
+        StopPlaceJobDto secondJob = awaitJobCompletion(second.getBody().jobId());
+
+        assertThat(secondJob.status()).isEqualTo(AsyncStopPlaceJobStatus.FAILED);
+        assertThat(secondJob.errorMessage())
+                .as("the reason has to say the edit can be reapplied, and give the version to read")
+                .contains("moved to version 2")
+                .contains("Read it again");
+        String survivingName = written(saved.getNetexId(), sp -> sp.getName().getValue());
+        assertThat(survivingName).as("the first edit survives").isEqualTo("First Edit");
+    }
+
+    @Test
+    public void updateWithoutAVersionFails() throws InterruptedException {
+        StopPlace saved = savedStopPlace("Original Name");
+
+        String xml = """
+            <stopPlaces xmlns="http://www.netex.org.uk/netex">
+                <StopPlace id="%s">
+                    <Name>No Version</Name>
+                    <StopPlaceType>busStation</StopPlaceType>
+                </StopPlace>
+            </stopPlaces>
+            """.formatted(saved.getNetexId());
+
+        StopPlaceJobDto job = awaitJobCompletion(putXml(xml, StopPlaceJobDto.class).getBody().jobId());
+
+        assertThat(job.status()).isEqualTo(AsyncStopPlaceJobStatus.FAILED);
+        assertThat(job.errorMessage()).contains("must carry the version attribute");
+        String unchangedName = written(saved.getNetexId(), sp -> sp.getName().getValue());
+        assertThat(unchangedName).isEqualTo("Original Name");
+    }
+
+    @Test
+    public void updateFromTheCurrentVersionSucceeds() throws InterruptedException {
+        StopPlace saved = savedStopPlace("Original Name");
+
+        StopPlaceJobDto job = awaitJobCompletion(
+                putXml(updateXml(saved.getNetexId(), 1, "Edited"), StopPlaceJobDto.class).getBody().jobId());
+
+        assertThat(job.status()).isEqualTo(AsyncStopPlaceJobStatus.FINISHED);
+        String editedName = written(saved.getNetexId(), sp -> sp.getName().getValue());
+        Long newVersion = written(saved.getNetexId(), StopPlace::getVersion);
+        assertThat(editedName).isEqualTo("Edited");
+        assertThat(newVersion).as("the server still decides the next version").isEqualTo(2L);
+    }
+
+    private StopPlace savedStopPlace(String name) {
+        StopPlace stopPlace = new StopPlace(new EmbeddableMultilingualString(name));
+        stopPlace.setVersion(1L);
+        stopPlace.setStopPlaceType(StopTypeEnumeration.BUS_STATION);
+        return stopPlaceRepository.save(stopPlace);
+    }
+
+    private static String updateXml(String netexId, long version, String name) {
+        return """
+            <stopPlaces xmlns="http://www.netex.org.uk/netex">
+                <StopPlace id="%s" version="%d">
+                    <Name>%s</Name>
+                    <StopPlaceType>busStation</StopPlaceType>
+                </StopPlace>
+            </stopPlaces>
+            """.formatted(netexId, version, name);
     }
 
     @Autowired

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/writer/StopPlaceWriterTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/writer/StopPlaceWriterTest.java
@@ -99,7 +99,7 @@ class StopPlaceWriterTest {
         org.rutebanken.netex.model.StopPlace updatedNetexStopPlace = createNetexStopPlace(stopPlaceId, "New Name", 1L);
         StopPlace savedStopPlace = createTiamatStopPlace(stopPlaceId, "New Name", 2L);
 
-        when(validator.validateStopPlaceUpdate(stopPlaceId, false)).thenReturn(existingStopPlace);
+        when(validator.validateStopPlaceUpdate(stopPlaceId, false, 1L)).thenReturn(existingStopPlace);
         when(versionCreator.createCopy(existingStopPlace, StopPlace.class)).thenReturn(updatedTiamatStopPlace);
         when(stopPlaceVersionedSaverService.saveNewVersion(eq(existingStopPlace), eq(updatedTiamatStopPlace), anySet()))
             .thenReturn(savedStopPlace);
@@ -107,7 +107,7 @@ class StopPlaceWriterTest {
         StopPlace result = domainService.updateStopPlace(updatedNetexStopPlace);
 
         assertThat(result).isSameAs(savedStopPlace);
-        verify(validator).validateStopPlaceUpdate(stopPlaceId, false);
+        verify(validator).validateStopPlaceUpdate(stopPlaceId, false, 1L);
         verify(validator).validateStopPlaceMutation(updatedTiamatStopPlace);
         verify(stopPlaceVersionedSaverService).saveNewVersion(eq(existingStopPlace), eq(updatedTiamatStopPlace), anySet());
     }
@@ -149,7 +149,7 @@ class StopPlaceWriterTest {
         String stopPlaceId = "NSR:StopPlace:100";
         org.rutebanken.netex.model.StopPlace updatedStopPlace = createNetexStopPlace(stopPlaceId, "Invalid Stop", 1L);
 
-        when(validator.validateStopPlaceUpdate(stopPlaceId, false)).thenThrow(
+        when(validator.validateStopPlaceUpdate(stopPlaceId, false, 1L)).thenThrow(
             new IllegalArgumentException("Stop place not found")
         );
 
@@ -157,7 +157,7 @@ class StopPlaceWriterTest {
             domainService.updateStopPlace(updatedStopPlace)
         );
 
-        verify(validator).validateStopPlaceUpdate(stopPlaceId, false);
+        verify(validator).validateStopPlaceUpdate(stopPlaceId, false, 1L);
         verify(validator, never()).validateStopPlaceName(any());
         verify(stopPlaceVersionedSaverService, never()).saveNewVersion(any(), any());
     }
@@ -169,7 +169,7 @@ class StopPlaceWriterTest {
         StopPlace updatedTiamatStopPlace = createTiamatStopPlace(stopPlaceId, "", 1L);
         org.rutebanken.netex.model.StopPlace updatedNetexStopPlace = createNetexStopPlace(stopPlaceId, "", 1L);
 
-        when(validator.validateStopPlaceUpdate(stopPlaceId, false)).thenReturn(existingStopPlace);
+        when(validator.validateStopPlaceUpdate(stopPlaceId, false, 1L)).thenReturn(existingStopPlace);
         when(versionCreator.createCopy(existingStopPlace, StopPlace.class)).thenReturn(updatedTiamatStopPlace);
         doThrow(new IllegalArgumentException("Stop place name is required"))
             .when(validator)
@@ -179,7 +179,7 @@ class StopPlaceWriterTest {
             domainService.updateStopPlace(updatedNetexStopPlace)
         );
 
-        verify(validator).validateStopPlaceUpdate(stopPlaceId, false);
+        verify(validator).validateStopPlaceUpdate(stopPlaceId, false, 1L);
         verify(validator).validateStopPlaceMutation(updatedTiamatStopPlace);
         verify(stopPlaceVersionedSaverService, never()).saveNewVersion(any(), any());
     }
@@ -227,7 +227,7 @@ class StopPlaceWriterTest {
         StopPlace savedStopPlace = createTiamatStopPlace(stopPlaceId, "New Name", 2L);
 
         AtomicReference<NetexMappingContext> contextDuringMapping = new AtomicReference<>();
-        when(validator.validateStopPlaceUpdate(stopPlaceId, false)).thenReturn(existingStopPlace);
+        when(validator.validateStopPlaceUpdate(stopPlaceId, false, 1L)).thenReturn(existingStopPlace);
         when(netexMapper.mapToTiamatModel(updatedNetexStopPlace)).thenAnswer(invocation -> {
             contextDuringMapping.set(NetexMappingContextThreadLocal.get());
             return updatedTiamatStopPlace;


### PR DESCRIPTION
Closes half of #453: the write API. GraphQL is left for a follow up, see the end.

### The problem

Two callers read version 1. The first write makes version 2. The second was built from what the first has already replaced, so applying it discarded that work and reported FINISHED.

The mutate lock does not help. It serialises the writes, but each caller read the stop place in an earlier request, long before any lock was taken.

### The change

The `version` attribute now states which version the caller edited, rather than being ignored. If the stop place has moved on, the job fails with a reason that gives the current version.

**Required rather than optional.** An optional precondition leaves every caller that omits it able to overwrite concurrent edits, which is the thing being fixed. This is a change to documented behaviour, but nothing is broken by it today: `tiamat.write-api.enabled` defaults to false and the API has no clients yet. That window closes once it is switched on somewhere.

### Where the check lives

In `StopPlaceMutationValidator`, with the other update validation, which both entry points already call inside the mutate lock.

Not in `StopPlaceVersionedSaverService`, which was the first idea. That has around twenty callers across the importers, where an expected version is not a concept, and it is a persistence concern rather than a request one.

Callers must resolve the expected version inside the lock, or they reintroduce the race. The javadoc says so.

### The job reason

A stale version reads differently to a caller than the other failures. A rejected payload stays rejected however many times it is sent. This one means the payload was fine and somebody else got there first:

> The stop place moved to version 2 while this job was pending. Read it again and reapply the change.

### Not covered

- **GraphQL.** Same gap, but it needs a `version` field on the mutation input, and Abzu has to send it before anything improves. Separate change.
- **Delete.** A delete built on a stale read terminates a stop place someone has just edited. Delete takes only an ID in the URL, so a precondition there needs a header or query parameter, which is a different design decision.

#453 should stay open for those.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Unit tests

Three new integration tests, all through the endpoint: an update from a version that has moved on fails and the first edit survives, an update with no version fails, and an update from the current version still succeeds and still increments.

Mutation checked: disabling the comparison fails `updateFromAVersionThatHasMovedOnFails` and nothing else.

Nine existing tests had to change, which is the breaking change made visible. Their payloads either sent no version or sent a deliberately wrong one, back when it was ignored. They now send the version actually saved, read from the entity rather than hardcoded.

Full suite: 1189 tests, 0 failures.