### PR TITLE
ext/fintraffic - Support tariff-zone-only and FareFrame-only NeTEx imports in import task

### DIFF
--- a/tiamat-core/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/netex/NetexImportTaskTest.java
+++ b/tiamat-core/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/netex/NetexImportTaskTest.java
@@ -9,7 +9,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.rutebanken.netex.model.PublicationDeliveryStructure;
 import org.rutebanken.tiamat.importer.ImportParams;
 import org.rutebanken.tiamat.importer.ImportType;
+import org.rutebanken.tiamat.importer.FareZoneFrameSource;
+import org.rutebanken.tiamat.importer.PublicationDeliveryFareFrameImporter;
 import org.rutebanken.tiamat.importer.PublicationDeliveryImporter;
+import org.rutebanken.tiamat.importer.PublicationDeliveryTariffZoneImporter;
 import org.rutebanken.tiamat.rest.netex.publicationdelivery.PublicationDeliveryUnmarshaller;
 import org.rutebanken.tiamat.service.BlobStoreService;
 import org.springframework.boot.DefaultApplicationArguments;
@@ -36,6 +39,10 @@ class NetexImportTaskTest {
     private PublicationDeliveryUnmarshaller unmarshaller;
     @Mock
     private PublicationDeliveryImporter importer;
+    @Mock
+    private PublicationDeliveryTariffZoneImporter tariffZoneImporter;
+    @Mock
+    private PublicationDeliveryFareFrameImporter fareFrameImporter;
 
     private final DefaultApplicationArguments noArgs = new DefaultApplicationArguments();
 
@@ -44,7 +51,7 @@ class NetexImportTaskTest {
         var result = runWith(null, null);
 
         assertThat(result.exitCodes).containsExactly(1);
-        verifyNoInteractions(blobStoreService, unmarshaller, importer);
+        verifyNoInteractions(blobStoreService, unmarshaller, importer, tariffZoneImporter, fareFrameImporter);
     }
 
     @Test
@@ -52,7 +59,7 @@ class NetexImportTaskTest {
         var result = runWith("   ", null);
 
         assertThat(result.exitCodes).containsExactly(1);
-        verifyNoInteractions(blobStoreService, unmarshaller, importer);
+        verifyNoInteractions(blobStoreService, unmarshaller, importer, tariffZoneImporter, fareFrameImporter);
     }
 
     @Test
@@ -130,7 +137,7 @@ class NetexImportTaskTest {
         var result = runWith("netex/stops.xml", null);
 
         assertThat(result.exitCodes).containsExactly(1);
-        verifyNoInteractions(blobStoreService, unmarshaller, importer);
+        verifyNoInteractions(blobStoreService, unmarshaller, importer, tariffZoneImporter, fareFrameImporter);
     }
 
     @Test
@@ -138,7 +145,7 @@ class NetexImportTaskTest {
         var result = runWith("netex/stops.xml", "INITIAL", null);
 
         assertThat(result.exitCodes).containsExactly(1);
-        verifyNoInteractions(blobStoreService, unmarshaller, importer);
+        verifyNoInteractions(blobStoreService, unmarshaller, importer, tariffZoneImporter, fareFrameImporter);
     }
 
     @Test
@@ -146,7 +153,7 @@ class NetexImportTaskTest {
         var result = runWith("netex/stops.xml", "NOT_A_REAL_TYPE");
 
         assertThat(result.exitCodes).containsExactly(1);
-        verifyNoInteractions(blobStoreService, unmarshaller, importer);
+        verifyNoInteractions(blobStoreService, unmarshaller, importer, tariffZoneImporter, fareFrameImporter);
     }
 
     @Test
@@ -156,7 +163,7 @@ class NetexImportTaskTest {
         var result = runWith("netex/missing.xml", "MERGE");
 
         assertThat(result.exitCodes).containsExactly(1);
-        verifyNoInteractions(unmarshaller, importer);
+        verifyNoInteractions(unmarshaller, importer, tariffZoneImporter, fareFrameImporter);
         verifyStatusWritten(NetexImportTask.STATUS_FAILED);
     }
 
@@ -243,7 +250,7 @@ class NetexImportTaskTest {
         assertThat(result.exitCodes).containsExactly(1);
         verify(blobStoreService, never()).download(any());
         verify(blobStoreService, never()).upload(any(), any());
-        verifyNoInteractions(unmarshaller, importer);
+        verifyNoInteractions(unmarshaller, importer, tariffZoneImporter, fareFrameImporter);
     }
 
     @Test
@@ -261,6 +268,102 @@ class NetexImportTaskTest {
         verify(blobStoreService, never()).download(any());
         verify(blobStoreService, never()).upload(any(), any());
         verify(importer).importPublicationDelivery(eq(delivery), any());
+    }
+
+    @Test
+    void importOnlyTariffZones_routedToTariffZoneImporter() throws Exception {
+        String s3Key = "netex/farezones.xml";
+        InputStream fakeStream = new ByteArrayInputStream(new byte[0]);
+        PublicationDeliveryStructure delivery = new PublicationDeliveryStructure();
+
+        when(blobStoreService.download(s3Key)).thenReturn(fakeStream);
+        when(unmarshaller.unmarshal(fakeStream)).thenReturn(delivery);
+
+        var result = runWith(s3Key, "INITIAL", "false", "true", null);
+
+        ArgumentCaptor<ImportParams> paramsCaptor = ArgumentCaptor.forClass(ImportParams.class);
+        verify(tariffZoneImporter).importPublicationDelivery(eq(delivery), paramsCaptor.capture());
+        assertThat(paramsCaptor.getValue().importOnlyTariffZones).isTrue();
+        assertThat(paramsCaptor.getValue().importType).isEqualTo(ImportType.INITIAL);
+        verifyNoInteractions(importer, fareFrameImporter);
+        assertThat(result.exitCodes).containsExactly(0);
+    }
+
+    @Test
+    void fareFrameSource_routedToFareFrameImporter() throws Exception {
+        String s3Key = "netex/farezones.xml";
+        InputStream fakeStream = new ByteArrayInputStream(new byte[0]);
+        PublicationDeliveryStructure delivery = new PublicationDeliveryStructure();
+
+        when(blobStoreService.download(s3Key)).thenReturn(fakeStream);
+        when(unmarshaller.unmarshal(fakeStream)).thenReturn(delivery);
+
+        var result = runWith(s3Key, "MERGE", "false", null, "FARE_FRAME");
+
+        ArgumentCaptor<ImportParams> paramsCaptor = ArgumentCaptor.forClass(ImportParams.class);
+        verify(fareFrameImporter).importPublicationDelivery(eq(delivery), paramsCaptor.capture());
+        assertThat(paramsCaptor.getValue().fareZoneFrameSource).isEqualTo(FareZoneFrameSource.FARE_FRAME);
+        verifyNoInteractions(importer, tariffZoneImporter);
+        assertThat(result.exitCodes).containsExactly(0);
+    }
+
+    @Test
+    void siteFrameSource_routedToFullImporter() throws Exception {
+        String s3Key = "netex/stops.xml";
+        InputStream fakeStream = new ByteArrayInputStream(new byte[0]);
+        PublicationDeliveryStructure delivery = new PublicationDeliveryStructure();
+
+        when(blobStoreService.download(s3Key)).thenReturn(fakeStream);
+        when(unmarshaller.unmarshal(fakeStream)).thenReturn(delivery);
+
+        var result = runWith(s3Key, "INITIAL", "false", "false", "SITE_FRAME");
+
+        verify(importer).importPublicationDelivery(eq(delivery), any());
+        verifyNoInteractions(tariffZoneImporter, fareFrameImporter);
+        assertThat(result.exitCodes).containsExactly(0);
+    }
+
+    @Test
+    void importOnlyTariffZones_takesPrecedenceOverFareFrameSource() throws Exception {
+        String s3Key = "netex/farezones.xml";
+        InputStream fakeStream = new ByteArrayInputStream(new byte[0]);
+        PublicationDeliveryStructure delivery = new PublicationDeliveryStructure();
+
+        when(blobStoreService.download(s3Key)).thenReturn(fakeStream);
+        when(unmarshaller.unmarshal(fakeStream)).thenReturn(delivery);
+
+        var result = runWith(s3Key, "INITIAL", "false", "true", "FARE_FRAME");
+
+        verify(tariffZoneImporter).importPublicationDelivery(eq(delivery), any());
+        verifyNoInteractions(importer, fareFrameImporter);
+        assertThat(result.exitCodes).containsExactly(0);
+    }
+
+    @Test
+    void routingDefaults_toFullImporterWhenOptionalVarsUnset() throws Exception {
+        String s3Key = "netex/stops.xml";
+        InputStream fakeStream = new ByteArrayInputStream(new byte[0]);
+        PublicationDeliveryStructure delivery = new PublicationDeliveryStructure();
+
+        when(blobStoreService.download(s3Key)).thenReturn(fakeStream);
+        when(unmarshaller.unmarshal(fakeStream)).thenReturn(delivery);
+
+        var result = runWith(s3Key, "INITIAL");
+
+        ArgumentCaptor<ImportParams> paramsCaptor = ArgumentCaptor.forClass(ImportParams.class);
+        verify(importer).importPublicationDelivery(eq(delivery), paramsCaptor.capture());
+        assertThat(paramsCaptor.getValue().importOnlyTariffZones).isFalse();
+        assertThat(paramsCaptor.getValue().fareZoneFrameSource).isEqualTo(FareZoneFrameSource.SITE_FRAME);
+        verifyNoInteractions(tariffZoneImporter, fareFrameImporter);
+        assertThat(result.exitCodes).containsExactly(0);
+    }
+
+    @Test
+    void unknownFareZoneFrameSource_exitsWithCode1() {
+        var result = runWith("netex/stops.xml", "INITIAL", "false", null, "NOT_A_REAL_FRAME");
+
+        assertThat(result.exitCodes).containsExactly(1);
+        verifyNoInteractions(blobStoreService, unmarshaller, importer, tariffZoneImporter, fareFrameImporter);
     }
 
     @Test
@@ -293,14 +396,22 @@ class NetexImportTaskTest {
     }
 
     private RunResult runWith(String s3Key, String importType, String disablePrePostProcessing) {
+        return runWith(s3Key, importType, disablePrePostProcessing, null, null);
+    }
+
+    private RunResult runWith(String s3Key, String importType, String disablePrePostProcessing,
+                              String importOnlyTariffZones, String fareZoneFrameSource) {
         List<Integer> exitCodes = new ArrayList<>();
-        NetexImportTask task = new NetexImportTask(blobStoreService, unmarshaller, importer, exitCodes::add) {
+        NetexImportTask task = new NetexImportTask(blobStoreService, unmarshaller, importer,
+                tariffZoneImporter, fareFrameImporter, exitCodes::add) {
             @Override
             protected String getenv(String name) {
                 return switch (name) {
                     case ENV_S3_KEY -> s3Key;
                     case ENV_IMPORT_TYPE -> importType;
                     case ENV_DISABLE_PRE_POST_PROCESSING -> disablePrePostProcessing;
+                    case ENV_IMPORT_ONLY_TARIFF_ZONES -> importOnlyTariffZones;
+                    case ENV_FARE_ZONE_FRAME_SOURCE -> fareZoneFrameSource;
                     default -> null;
                 };
             }

--- a/tiamat-core/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/netex/NetexImportConfig.java
+++ b/tiamat-core/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/netex/NetexImportConfig.java
@@ -1,6 +1,8 @@
 package org.rutebanken.tiamat.ext.fintraffic.netex;
 
+import org.rutebanken.tiamat.importer.PublicationDeliveryFareFrameImporter;
 import org.rutebanken.tiamat.importer.PublicationDeliveryImporter;
+import org.rutebanken.tiamat.importer.PublicationDeliveryTariffZoneImporter;
 import org.rutebanken.tiamat.rest.netex.publicationdelivery.PublicationDeliveryUnmarshaller;
 import org.rutebanken.tiamat.service.BlobStoreService;
 import org.springframework.context.annotation.Bean;
@@ -32,7 +34,9 @@ public class NetexImportConfig {
     public NetexImportTask netexImportTask(
             BlobStoreService blobStoreService,
             PublicationDeliveryUnmarshaller unmarshaller,
-            PublicationDeliveryImporter importer) {
-        return new NetexImportTask(blobStoreService, unmarshaller, importer);
+            PublicationDeliveryImporter importer,
+            PublicationDeliveryTariffZoneImporter tariffZoneImporter,
+            PublicationDeliveryFareFrameImporter fareFrameImporter) {
+        return new NetexImportTask(blobStoreService, unmarshaller, importer, tariffZoneImporter, fareFrameImporter);
     }
 }

--- a/tiamat-core/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/netex/NetexImportTask.java
+++ b/tiamat-core/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/netex/NetexImportTask.java
@@ -1,9 +1,12 @@
 package org.rutebanken.tiamat.ext.fintraffic.netex;
 
 import org.rutebanken.netex.model.PublicationDeliveryStructure;
+import org.rutebanken.tiamat.importer.FareZoneFrameSource;
 import org.rutebanken.tiamat.importer.ImportParams;
 import org.rutebanken.tiamat.importer.ImportType;
+import org.rutebanken.tiamat.importer.PublicationDeliveryFareFrameImporter;
 import org.rutebanken.tiamat.importer.PublicationDeliveryImporter;
+import org.rutebanken.tiamat.importer.PublicationDeliveryTariffZoneImporter;
 import org.rutebanken.tiamat.rest.netex.publicationdelivery.PublicationDeliveryUnmarshaller;
 import org.rutebanken.tiamat.service.BlobStoreService;
 import org.slf4j.Logger;
@@ -25,12 +28,24 @@ import java.util.function.IntConsumer;
 /**
  * Imports a single NeTEx file into Tiamat and shuts down the application when done.
  * <p>
- * All three environment variables are required:
+ * Three environment variables are required:
  * <ul>
  *   <li>{@code NETEX_S3_KEY} — S3 object key to import, or a local file path
  *       ({@code /abs/path}, {@code ./rel/path}, {@code file://...}) for local testing</li>
  *   <li>{@code NETEX_IMPORT_TYPE} — import mode, e.g. {@code INITIAL} or {@code MERGE}</li>
  *   <li>{@code NETEX_DISABLE_PRE_POST_PROCESSING} — {@code true} or {@code false}</li>
+ * </ul>
+ * Two further variables are optional and select which importer the delivery is routed to,
+ * mirroring the {@code importOnlyTariffZones} and {@code fareZoneFrameSource} query
+ * parameters of the NeTEx import REST endpoint:
+ * <ul>
+ *   <li>{@code NETEX_IMPORT_ONLY_TARIFF_ZONES} — {@code true} imports only tariff zones,
+ *       fare zones and groups of tariff zones from the SiteFrame, ignoring stop places,
+ *       topographic places, parkings and path links. Defaults to {@code false}.</li>
+ *   <li>{@code NETEX_FARE_ZONE_FRAME_SOURCE} — {@code SITE_FRAME} (default) or
+ *       {@code FARE_FRAME}. {@code FARE_FRAME} imports fare zones from an accompanying
+ *       FareFrame only. Ignored when {@code NETEX_IMPORT_ONLY_TARIFF_ZONES} is
+ *       {@code true}.</li>
  * </ul>
  * On completion, writes {@code done} or {@code failed} to {@value #STATUS_S3_KEY} in S3
  * (skipped for local file paths), then calls {@code System.exit}.
@@ -45,6 +60,8 @@ public class NetexImportTask implements ApplicationRunner {
     static final String ENV_S3_KEY = "NETEX_S3_KEY";
     static final String ENV_IMPORT_TYPE = "NETEX_IMPORT_TYPE";
     static final String ENV_DISABLE_PRE_POST_PROCESSING = "NETEX_DISABLE_PRE_POST_PROCESSING";
+    static final String ENV_IMPORT_ONLY_TARIFF_ZONES = "NETEX_IMPORT_ONLY_TARIFF_ZONES";
+    static final String ENV_FARE_ZONE_FRAME_SOURCE = "NETEX_FARE_ZONE_FRAME_SOURCE";
     static final String STATUS_S3_KEY = "netex/processing/status";
     static final String STATUS_DONE = "done";
     static final String STATUS_FAILED = "failed";
@@ -52,14 +69,18 @@ public class NetexImportTask implements ApplicationRunner {
     private final BlobStoreService blobStoreService;
     private final PublicationDeliveryUnmarshaller unmarshaller;
     private final PublicationDeliveryImporter importer;
+    private final PublicationDeliveryTariffZoneImporter tariffZoneImporter;
+    private final PublicationDeliveryFareFrameImporter fareFrameImporter;
     private final IntConsumer exitHandler;
 
     /** Production constructor — uses {@code System::exit}. */
     public NetexImportTask(
             BlobStoreService blobStoreService,
             PublicationDeliveryUnmarshaller unmarshaller,
-            PublicationDeliveryImporter importer) {
-        this(blobStoreService, unmarshaller, importer, System::exit);
+            PublicationDeliveryImporter importer,
+            PublicationDeliveryTariffZoneImporter tariffZoneImporter,
+            PublicationDeliveryFareFrameImporter fareFrameImporter) {
+        this(blobStoreService, unmarshaller, importer, tariffZoneImporter, fareFrameImporter, System::exit);
     }
 
     /** Full constructor — {@code exitHandler} is injectable for testing. */
@@ -67,10 +88,14 @@ public class NetexImportTask implements ApplicationRunner {
             BlobStoreService blobStoreService,
             PublicationDeliveryUnmarshaller unmarshaller,
             PublicationDeliveryImporter importer,
+            PublicationDeliveryTariffZoneImporter tariffZoneImporter,
+            PublicationDeliveryFareFrameImporter fareFrameImporter,
             IntConsumer exitHandler) {
         this.blobStoreService = blobStoreService;
         this.unmarshaller = unmarshaller;
         this.importer = importer;
+        this.tariffZoneImporter = tariffZoneImporter;
+        this.fareFrameImporter = fareFrameImporter;
         this.exitHandler = exitHandler;
     }
 
@@ -84,8 +109,10 @@ public class NetexImportTask implements ApplicationRunner {
             return;
         }
 
-        logger.info("Starting NeTEx import: key={}, importType={}, disablePrePostProcessing={}, source={}",
+        logger.info("Starting NeTEx import: key={}, importType={}, disablePrePostProcessing={}, "
+                        + "importOnlyTariffZones={}, fareZoneFrameSource={}, source={}",
                 config.s3Key(), config.importType(), config.disablePrePostProcessing(),
+                config.importOnlyTariffZones(), config.fareZoneFrameSource(),
                 config.localFile() ? "local file" : "S3");
 
         int exitCode = 1;
@@ -93,7 +120,7 @@ public class NetexImportTask implements ApplicationRunner {
         try {
             InputStream inputStream = openSource(config.s3Key(), config.localFile());
             PublicationDeliveryStructure delivery = unmarshal(inputStream);
-            runImport(delivery, config.importType(), config.disablePrePostProcessing());
+            runImport(delivery, config);
             logSuccess(config.s3Key(), config.importType(), Duration.between(start, Instant.now()));
             writeStatus(STATUS_DONE, config.localFile());
             exitCode = 0;
@@ -110,7 +137,15 @@ public class NetexImportTask implements ApplicationRunner {
         String s3Key = requireEnv(ENV_S3_KEY);
         ImportType importType = requireImportType(requireEnv(ENV_IMPORT_TYPE));
         boolean disablePrePostProcessing = "true".equalsIgnoreCase(requireEnv(ENV_DISABLE_PRE_POST_PROCESSING));
-        return new ImportConfig(s3Key, importType, disablePrePostProcessing, isLocalPath(s3Key));
+        boolean importOnlyTariffZones = "true".equalsIgnoreCase(optionalEnv(ENV_IMPORT_ONLY_TARIFF_ZONES));
+        FareZoneFrameSource fareZoneFrameSource = resolveFareZoneFrameSource(optionalEnv(ENV_FARE_ZONE_FRAME_SOURCE));
+        return new ImportConfig(s3Key, importType, disablePrePostProcessing, importOnlyTariffZones,
+                fareZoneFrameSource, isLocalPath(s3Key));
+    }
+
+    private String optionalEnv(String name) {
+        String value = getenv(name);
+        return value == null || value.isBlank() ? null : value;
     }
 
     private String requireEnv(String name) {
@@ -131,7 +166,22 @@ public class NetexImportTask implements ApplicationRunner {
         return type;
     }
 
-    private record ImportConfig(String s3Key, ImportType importType, boolean disablePrePostProcessing, boolean localFile) {}
+    private static FareZoneFrameSource resolveFareZoneFrameSource(String value) {
+        if (value == null) {
+            return FareZoneFrameSource.SITE_FRAME;
+        }
+        try {
+            return FareZoneFrameSource.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            logger.error("Unknown fare zone frame source '{}'. Valid values: {}. Aborting.",
+                    value, Arrays.toString(FareZoneFrameSource.values()));
+            throw new IllegalStateException("Invalid fare zone frame source: " + value);
+        }
+    }
+
+    private record ImportConfig(String s3Key, ImportType importType, boolean disablePrePostProcessing,
+                                boolean importOnlyTariffZones, FareZoneFrameSource fareZoneFrameSource,
+                                boolean localFile) {}
 
     private InputStream openSource(String s3Key, boolean localFile) throws Exception {
         if (localFile) {
@@ -156,14 +206,28 @@ public class NetexImportTask implements ApplicationRunner {
         return unmarshaller.unmarshal(inputStream);
     }
 
-    private void runImport(PublicationDeliveryStructure delivery, ImportType importType,
-                           boolean disablePrePostProcessing) throws Exception {
+    private void runImport(PublicationDeliveryStructure delivery, ImportConfig config) throws Exception {
         ImportParams params = new ImportParams();
-        params.importType = importType;
-        params.disablePreAndPostProcessing = disablePrePostProcessing;
-        logger.info("Running import (importType={}, disablePrePostProcessing={})...",
-                importType, disablePrePostProcessing);
-        importer.importPublicationDelivery(delivery, params);
+        params.importType = config.importType();
+        params.disablePreAndPostProcessing = config.disablePrePostProcessing();
+        params.importOnlyTariffZones = config.importOnlyTariffZones();
+        params.fareZoneFrameSource = config.fareZoneFrameSource();
+
+        // Routing mirrors ImportResource#importPublicationDelivery so that the task and the
+        // REST endpoint behave identically for the same set of import parameters.
+        if (config.importOnlyTariffZones()) {
+            logger.info("Running import of tariff zones only from SiteFrame (importType={}, disablePrePostProcessing={})...",
+                    config.importType(), config.disablePrePostProcessing());
+            tariffZoneImporter.importPublicationDelivery(delivery, params);
+        } else if (config.fareZoneFrameSource() == FareZoneFrameSource.FARE_FRAME) {
+            logger.info("Running import of fare zones from FareFrame only (importType={}, disablePrePostProcessing={})...",
+                    config.importType(), config.disablePrePostProcessing());
+            fareFrameImporter.importPublicationDelivery(delivery, params);
+        } else {
+            logger.info("Running full import from SiteFrame (importType={}, disablePrePostProcessing={})...",
+                    config.importType(), config.disablePrePostProcessing());
+            importer.importPublicationDelivery(delivery, params);
+        }
     }
 
     private static void logSuccess(String s3Key, ImportType importType, Duration elapsed) {


### PR DESCRIPTION
### Summary

`NetexImportTask` (the Fintraffic ECS batch import runner in `src/ext/`) hardcoded
`PublicationDeliveryImporter`, so it could only perform a full SiteFrame import. The NeTEx import
REST endpoint (`ImportResource`) supports three routes, selected by `importOnlyTariffZones` and
`fareZoneFrameSource`, and the batch task could reach only one of them.

This meant a fare-zone import that is expressible against the REST endpoint as

```
POST /services/stop_places/netex?importType=INITIAL&importOnlyTariffZones=true
```

had no equivalent when run as a batch task, forcing operators back to a curl-based script for that
case.

This PR adds the two missing routes to the task:

- `NETEX_IMPORT_ONLY_TARIFF_ZONES` (optional, default `false`) → `PublicationDeliveryTariffZoneImporter`
- `NETEX_FARE_ZONE_FRAME_SOURCE` (optional, `SITE_FRAME` default / `FARE_FRAME`) → `PublicationDeliveryFareFrameImporter`
- neither set → `PublicationDeliveryImporter`, i.e. exactly the previous behaviour

The routing block is a direct mirror of `ImportResource#importPublicationDelivery`, including the
precedence rule that `importOnlyTariffZones` wins over `fareZoneFrameSource`. Both variables are
optional, so existing deployments that set only the three previously required variables are
unaffected.

An unparseable `NETEX_FARE_ZONE_FRAME_SOURCE` fails fast with exit code 1 and a log line listing the
valid values, consistent with how an unknown `NETEX_IMPORT_TYPE` is already handled — a silent
fallback to the default would risk running a full import when a zones-only import was intended.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Unit tests

`NetexImportTaskTest` (`src/ext-test/`) grew from 18 to 24 tests, all passing. Six were added:

- `importOnlyTariffZones=true` routes to the tariff zone importer, and `ImportParams` carries the flag
- `FARE_FRAME` routes to the fare frame importer, and `ImportParams` carries the frame source
- `SITE_FRAME` routes to the full importer
- `importOnlyTariffZones` takes precedence over `FARE_FRAME`
- both variables unset defaults to the full importer with `importOnlyTariffZones=false` and `SITE_FRAME`
- an unknown frame source exits 1 without touching any importer

Each routing test also asserts `verifyNoInteractions` on the two importers that should *not* be
called, so a regression that fans out to more than one importer fails rather than passing silently.
The importers are injected via constructor and mocked with Mockito; no Spring context is needed.

Verified with:

```
mvn -pl tiamat-core test -Dtest=NetexImportTaskTest
```

### Documentation

The class-level Javadoc on `NetexImportTask` now separates the three required environment variables
from the two optional ones and states the default and precedence for each. The routing block carries
a comment pointing at `ImportResource` as the behaviour that must be kept in sync.
