### PR TITLE
Fix Parking update crashing with duplicate key on ParkingProperties

### DIFF
--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/versioning/save/ParkingVersionedSaverService.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/versioning/save/ParkingVersionedSaverService.java
@@ -88,6 +88,12 @@ public class ParkingVersionedSaverService {
             newVersion.setVersion(existing.getVersion());
 
             parkingRepository.delete(existing);
+            // Force the delete (including its cascaded ParkingProperties/ParkingCapacity children)
+            // to execute against the database now, before newVersion is saved below. Without this,
+            // Hibernate's action queue executes entity insertions before entity deletions within the
+            // same flush, so re-attached children carrying over the same (netex_id, version) as the
+            // about-to-be-deleted ones would violate parking_properties_netex_id_version_constraint.
+            parkingRepository.flush();
         } else {
             newVersion.setCreated(Instant.now());
         }

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/versioning/save/ParkingVersionedSaverServiceTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/versioning/save/ParkingVersionedSaverServiceTest.java
@@ -22,14 +22,18 @@ import org.locationtech.jts.geom.Point;
 import org.rutebanken.tiamat.TiamatIntegrationTest;
 import org.rutebanken.tiamat.model.EmbeddableMultilingualString;
 import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.ParkingProperties;
+import org.rutebanken.tiamat.model.ParkingUserEnumeration;
 import org.rutebanken.tiamat.model.SiteRefStructure;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.repository.ParkingRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.Instant;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class ParkingVersionedSaverServiceTest extends TiamatIntegrationTest {
 
@@ -82,6 +86,60 @@ public class ParkingVersionedSaverServiceTest extends TiamatIntegrationTest {
         assertThat(actual.getName().getValue()).isEqualTo(newParking.getName().getValue());
         assertThat(actual.getChanged()).as("changed").isNotNull();
         assertThat(actual.getCreated()).as("created").isNotNull();
+    }
+
+    /**
+     * Editing a Parking that already has a {@link ParkingProperties} child a second time (without
+     * changing the child itself, e.g. GraphQL's "copy previous version, apply edits" flow
+     * re-attaching the same logical child with the same netexId/version) used to throw a Postgres
+     * duplicate key violation on {@code parking_properties_netex_id_version_constraint}.
+     * <p>
+     * Root cause: {@link ParkingVersionedSaverService#saveNewVersion(Parking)} deletes the existing
+     * Parking (cascading delete of its ParkingProperties children) and saves the new version in the
+     * same flush, without an explicit flush in between. Hibernate's action queue executes entity
+     * insertions before entity deletions within a single flush, so the INSERT for the new version's
+     * (identically netexId/version-ed) ParkingProperties child raced ahead of the DELETE for the old
+     * one, violating the unique constraint.
+     */
+    @Test
+    public void saveExistingParkingWithParkingPropertiesTwice_doesNotThrowDuplicateKey() {
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlaceRepository.save(stopPlace);
+
+        Point point = geometryFactory.createPoint(new Coordinate(9.84, 59.26));
+
+        ParkingProperties firstProperties = new ParkingProperties();
+        firstProperties.getParkingUserTypes().add(ParkingUserEnumeration.ALL);
+
+        Parking firstVersion = new Parking();
+        firstVersion.setCentroid(point);
+        firstVersion.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        firstVersion.setParkingProperties(List.of(firstProperties));
+
+        Parking saved = parkingVersionedSaverService.saveNewVersion(firstVersion);
+        assertThat(saved.getParkingProperties()).hasSize(1);
+        ParkingProperties savedProperties = saved.getParkingProperties().get(0);
+
+        // Simulate a second, unrelated edit (e.g. only the name changes) where the caller
+        // re-attaches the SAME logical ParkingProperties child, carrying over its already
+        // persisted netexId/version, as GraphQL's copy-and-edit flow does.
+        ParkingProperties reattachedProperties = new ParkingProperties();
+        reattachedProperties.setNetexId(savedProperties.getNetexId());
+        reattachedProperties.setVersion(savedProperties.getVersion());
+        reattachedProperties.getParkingUserTypes().add(ParkingUserEnumeration.ALL);
+
+        Parking secondEdit = new Parking();
+        secondEdit.setNetexId(saved.getNetexId());
+        secondEdit.setName(new EmbeddableMultilingualString("name"));
+        secondEdit.setCentroid(point);
+        secondEdit.setParentSiteRef(new SiteRefStructure(stopPlace.getNetexId()));
+        secondEdit.setParkingProperties(List.of(reattachedProperties));
+
+        assertThatCode(() -> parkingVersionedSaverService.saveNewVersion(secondEdit))
+                .as("saving a second edit that re-attaches an existing ParkingProperties child " +
+                        "must not throw a duplicate key violation on parking_properties_netex_id_version_constraint")
+                .doesNotThrowAnyException();
     }
 
 }


### PR DESCRIPTION
### Summary

Fixes a Postgres duplicate-key violation when saving a second edit to a `Parking` that already has a
`ParkingProperties` child.

`ParkingVersionedSaverService#saveNewVersion` called `versionIncrementor.initiateOrIncrement(newVersion)`,
which only versions the `Parking` root. Its versioned children kept whatever version they arrived with.
Every child table has a unique constraint on `(netex_id, version)`, so when an update re-attaches a child
carrying the same `(netex_id, version)` as the currently persisted one — as the GraphQL "copy previous
version, apply edits" flow does for children it doesn't touch — the row for the new version collides with
the row of the version being replaced, violating `parking_properties_netex_id_version_constraint`.

`Parking` now gets the same treatment `StopPlace` already had: `VersionIncrementor.initiateOrIncrementVersions(Parking)`
walks the entity graph and versions the root together with its children — `parkingProperties` and their
`spaces` (`ParkingCapacity`), and `parkingAreas` including place equipment — mirroring
`initiateOrIncrementVersions(StopPlace)`.

This replaces the earlier revision of this PR, which forced an intermediate `parkingRepository.flush()`
between deleting the existing `Parking` and saving the new version. That made the constraint violation go
away by ordering the DELETE before the INSERT, but it left the children pinned at version 1 forever: the
`Parking` version incremented while its `ParkingProperties` did not. Versioning the children addresses the
cause rather than the symptom, so the flush is no longer needed and has been removed. Thanks to @testower
for suggesting this direction.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Unit tests

`ParkingVersionedSaverServiceTest.saveExistingParkingIncrementsVersionsOfReattachedChildren` saves a
`Parking` with a `ParkingProperties` child and a nested `ParkingCapacity`, then saves a second edit that
re-attaches both children with their already-persisted `netexId` and `version`. It asserts the second save
succeeds and that the parking, its properties and its capacity all reach version 2, while keeping their
`netexId` across versions.

The previous test only asserted that the second save did not throw, which the flush satisfied without ever
incrementing the children. Asserting the versions is what distinguishes the two approaches.

Verified locally with `mvn test -Dtest=ParkingVersionedSaverServiceTest` and across the surrounding parking
and versioning suites.

### Documentation

`initiateOrIncrementVersions(Parking)` carries a Javadoc note explaining why the children must be versioned
along with the root (the `(netex_id, version)` unique constraint on each child table).