### PR TITLE
Fix orphaned parkings blocking deletion when parent stop place no longer exists

### DIFF
--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/auth/TiamatEntityResolver.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/auth/TiamatEntityResolver.java
@@ -20,11 +20,15 @@ import org.rutebanken.tiamat.model.Parking;
 import org.rutebanken.tiamat.model.Quay;
 import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.repository.StopPlaceRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class TiamatEntityResolver implements EntityResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(TiamatEntityResolver.class);
 
     @Autowired
     private StopPlaceRepository stopPlaceRepository;
@@ -47,10 +51,14 @@ public class TiamatEntityResolver implements EntityResolver {
                 if (parking.getParentSiteRef() != null && parking.getParentSiteRef().getRef() != null) {
                     StopPlace stopPlace = stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc(parking.getParentSiteRef().getRef());
 
-                    if (stopPlace == null) {
-                        throw new IllegalArgumentException("Cannot resolve stop place from parking: " + entity);
+                    if (stopPlace != null) {
+                        return stopPlace;
                     }
-                    return stopPlace;
+                    // The referenced parent stop place no longer exists. Fall back to
+                    // checking permission on the parking itself instead of throwing -
+                    // same as the case below where the parking has no parent site ref.
+                    logger.warn("Cannot resolve stop place from parking: {}. Parent site ref {} no longer exists, falling back to parking permission check.",
+                            entity, parking.getParentSiteRef().getRef());
                 }
             }
             default -> {

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/service/parking/ParkingDeleter.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/service/parking/ParkingDeleter.java
@@ -34,11 +34,8 @@ package org.rutebanken.tiamat.service.parking;
 import org.rutebanken.tiamat.auth.AuthorizationService;
 import org.rutebanken.tiamat.auth.UsernameFetcher;
 import org.rutebanken.tiamat.changelog.EntityChangedListener;
-import org.rutebanken.tiamat.model.DataManagedObjectStructure;
 import org.rutebanken.tiamat.model.Parking;
-import org.rutebanken.tiamat.model.StopPlace;
 import org.rutebanken.tiamat.repository.ParkingRepository;
-import org.rutebanken.tiamat.repository.reference.ReferenceResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +44,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -65,18 +61,15 @@ public class ParkingDeleter {
 
     private ParkingRepository parkingRepository;
 
-    private ReferenceResolver referenceResolver;
-
     @Autowired
     public ParkingDeleter(ParkingRepository parkingRepository,
                           EntityChangedListener entityChangedListener,
                           AuthorizationService authorizationService,
-                          UsernameFetcher usernameFetcher, ReferenceResolver referenceResolver) {
+                          UsernameFetcher usernameFetcher) {
         this.parkingRepository = parkingRepository;
         this.entityChangedListener = entityChangedListener;
         this.authorizationService = authorizationService;
         this.usernameFetcher = usernameFetcher;
-        this.referenceResolver = referenceResolver;
     }
 
     @Transactional
@@ -91,18 +84,12 @@ public class ParkingDeleter {
             throw new IllegalArgumentException("Cannot find parking to delete from ID: " + parkingId);
         }
 
-        for(Parking parking : parkings) {
-            if(parking.getParentSiteRef() != null) {
-                DataManagedObjectStructure resolved = referenceResolver.resolve(parking.getParentSiteRef());
-                if(resolved instanceof StopPlace) {
-                    authorizationService.verifyCanEditEntities( Arrays.asList(resolved));
-                } else {
-                    throw new IllegalArgumentException("Parking does not have a parent site ref that points to a stop place. " + parking);
-                }
-            } else {
-                throw new IllegalArgumentException("Parking does not have a parent site ref. Cannot check permission. " + parking);
-            }
-        }
+        // Permission is checked directly on the Parking entities, same as
+        // ParkingUpdater does for edits. The auth framework's TiamatEntityResolver
+        // resolves each Parking to its parent StopPlace internally (and falls back
+        // to checking the parking itself if the parent no longer exists), so no
+        // separate resolution is needed here.
+        authorizationService.verifyCanEditEntities(parkings);
 
         parkingRepository.deleteAll(parkings);
         notifyDeleted(parkings);
@@ -111,6 +98,7 @@ public class ParkingDeleter {
 
         return true;
     }
+
     //This is to make sure entity is persisted before sending message
     @Transactional
     public void notifyDeleted(List<Parking> parkings) {

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/auth/TiamatEntityResolverTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/auth/TiamatEntityResolverTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.auth;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.rutebanken.tiamat.model.Parking;
+import org.rutebanken.tiamat.model.SiteRefStructure;
+import org.rutebanken.tiamat.model.StopPlace;
+import org.rutebanken.tiamat.repository.StopPlaceRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TiamatEntityResolverTest {
+
+    private StopPlaceRepository stopPlaceRepository;
+    private TiamatEntityResolver tiamatEntityResolver;
+
+    @Before
+    public void setUp() {
+        stopPlaceRepository = mock(StopPlaceRepository.class);
+        tiamatEntityResolver = new TiamatEntityResolver();
+        ReflectionTestUtils.setField(tiamatEntityResolver, "stopPlaceRepository", stopPlaceRepository);
+    }
+
+    @Test
+    public void resolvesParkingToItsParentStopPlaceWhenParentExists() {
+        StopPlace stopPlace = new StopPlace();
+        Parking parking = new Parking();
+        parking.setParentSiteRef(new SiteRefStructure("NSR:StopPlace:1"));
+
+        when(stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc("NSR:StopPlace:1")).thenReturn(stopPlace);
+
+        Object resolved = tiamatEntityResolver.resolveCorrectEntity(parking);
+
+        assertThat(resolved).isSameAs(stopPlace);
+    }
+
+    /**
+     * A parking's parentSiteRef can point at a stop place that has since
+     * been deleted. Authorization must fall back to checking the parking
+     * itself instead of throwing, so that the parking can still be
+     * edited/deleted.
+     */
+    @Test
+    public void fallsBackToParkingItselfWhenParentStopPlaceNoLongerExists() {
+        Parking parking = new Parking();
+        parking.setParentSiteRef(new SiteRefStructure("NSR:StopPlace:doesNotExist"));
+
+        when(stopPlaceRepository.findFirstByNetexIdOrderByVersionDesc("NSR:StopPlace:doesNotExist")).thenReturn(null);
+
+        Object resolved = tiamatEntityResolver.resolveCorrectEntity(parking);
+
+        assertThat(resolved).isSameAs(parking);
+    }
+
+    @Test
+    public void fallsBackToParkingItselfWhenNoParentSiteRef() {
+        Parking parking = new Parking();
+
+        Object resolved = tiamatEntityResolver.resolveCorrectEntity(parking);
+
+        assertThat(resolved).isSameAs(parking);
+    }
+}

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/service/parking/ParkingDeleterTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/service/parking/ParkingDeleterTest.java
@@ -60,4 +60,48 @@ public class ParkingDeleterTest extends TiamatIntegrationTest {
         assertThat(parkings).isEmpty();
     }
 
+    /**
+     * A parking's parentSiteRef can point at a stop place that has since
+     * been deleted (e.g. the parent was deleted without deleting its child
+     * parking first). Deletion must fall back to checking permission on the
+     * parking itself rather than refusing to delete it outright.
+     */
+    @Test
+    @Transactional
+    public void deleteParkingWithUnresolvableParent() throws Exception {
+
+        Parking v1 = new Parking();
+        v1.setVersion(1L);
+        v1.setParentSiteRef(new SiteRefStructure("NSR:StopPlace:999999999"));
+
+        parkingRepository.save(v1);
+
+        boolean result = parkingDeleter.deleteParking(v1.getNetexId());
+        assertThat(result).isTrue();
+
+        List<Parking> parkings = parkingRepository.findByNetexId(v1.getNetexId());
+        assertThat(parkings).isEmpty();
+    }
+
+    /**
+     * A parking with no parentSiteRef at all (never had a parent) must also
+     * fall back to checking permission on the parking itself, rather than
+     * refusing to delete it.
+     */
+    @Test
+    @Transactional
+    public void deleteParkingWithNoParentSiteRef() throws Exception {
+
+        Parking v1 = new Parking();
+        v1.setVersion(1L);
+
+        parkingRepository.save(v1);
+
+        boolean result = parkingDeleter.deleteParking(v1.getNetexId());
+        assertThat(result).isTrue();
+
+        List<Parking> parkings = parkingRepository.findByNetexId(v1.getNetexId());
+        assertThat(parkings).isEmpty();
+    }
+
 }


### PR DESCRIPTION
### Summary

Fixes an `IllegalArgumentException` that made it impossible to delete a `Parking` whose parent
`StopPlace` had already been deleted (or was otherwise unresolvable), and unifies the permission
check on delete with the one already used for edits.

Two related problems, both in the auth path for deleting a parking:

1. `ParkingDeleter#deleteParking` resolved the parking's parent site ref manually and required it to
   resolve to a `StopPlace`, throwing `IllegalArgumentException` otherwise. If the parent stop place
   had itself been deleted, the reference could no longer resolve, so an orphaned parking became
   permanently undeletable through the normal API.
2. `TiamatEntityResolver` (used for permission checks elsewhere, e.g. `ParkingUpdater`) had the same
   assumption baked in: it threw when a parking's parent site ref didn't resolve to a stop place,
   instead of falling back to checking permission on the parking itself the way it already does when
   a parking has no parent site ref at all.

The fix makes `ParkingDeleter` call `authorizationService.verifyCanEditEntities(parkings)` directly,
the same way edits are authorized, and lets `TiamatEntityResolver` do the resolution (including the
orphaned-parent fallback) internally. `TiamatEntityResolver` now logs and falls back to a
parking-level permission check when the parent site ref no longer resolves, instead of throwing.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Unit tests

Added test cases in `TiamatEntityResolverTest` (parent stop place missing → falls back to parking
permission check) and `ParkingDeleterTest` (delete succeeds via the unified permission check,
including when the parent stop place is gone). Verified locally:
`mvn test -Dtest=TiamatEntityResolverTest,ParkingDeleterTest`.
