### PR TITLE
Return 400 instead of 500 for IllegalArgumentException

### DIFF
--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/exception/GeneralExceptionMapper.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/rest/exception/GeneralExceptionMapper.java
@@ -42,7 +42,7 @@ public class GeneralExceptionMapper implements ExceptionMapper<Exception> {
     public GeneralExceptionMapper() {
         mapping = new HashMap<>();
         mapping.put(Response.Status.BAD_REQUEST,
-                Sets.newHashSet(ValidationException.class, OptimisticLockException.class, EntityNotFoundException.class, DataIntegrityViolationException.class));
+                Sets.newHashSet(ValidationException.class, OptimisticLockException.class, EntityNotFoundException.class, DataIntegrityViolationException.class, IllegalArgumentException.class));
         mapping.put(Response.Status.CONFLICT, Sets.newHashSet(EntityExistsException.class));
         mapping.put(Response.Status.FORBIDDEN, Sets.newHashSet(AccessDeniedException.class));
         mapping.put(Response.Status.UNAUTHORIZED, Sets.newHashSet(NotAuthorizedException.class, NotAuthenticatedException.class));

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/exception/GeneralExceptionMapperTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/exception/GeneralExceptionMapperTest.java
@@ -49,6 +49,25 @@ public class GeneralExceptionMapperTest {
         Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), rsp.getStatus());
     }
 
+    /**
+     * IllegalArgumentException is the codebase's established convention for a client input
+     * validation error thrown deep in a mapper/importer (e.g. ParkingMapper's timeband
+     * validation) — GraphQLResource#getStatusCodeFromThrowable already treats it as BAD_REQUEST
+     * for the GraphQL path; this mirrors that for the REST/NeTEx import path, which previously
+     * fell through to the INTERNAL_SERVER_ERROR default.
+     */
+    @Test
+    public void rawIllegalArgumentExceptionYieldsBadRequest() {
+        Response rsp = new GeneralExceptionMapper().toResponse(new IllegalArgumentException("bad input"));
+        Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), rsp.getStatus());
+    }
+
+    @Test
+    public void nestedIllegalArgumentExceptionYieldsBadRequest() {
+        Response rsp = new GeneralExceptionMapper().toResponse(new TransactionSystemException("", new IllegalArgumentException("bad input")));
+        Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), rsp.getStatus());
+    }
+
     @Test
     public void nestedUnknownExceptionYieldsInternalServerError() {
         Response rsp = new GeneralExceptionMapper().toResponse(new TransactionSystemException("", new RuntimeException()));


### PR DESCRIPTION
### Summary

Maps `IllegalArgumentException` to HTTP 400 (Bad Request) in `GeneralExceptionMapper`, the mapper
used by Tiamat's plain REST resources, instead of letting it fall through to the default 500
(Internal Server Error).

`IllegalArgumentException` is how several REST-facing services in this codebase already signal a bad
request rather than a server fault — e.g. an unresolvable ID passed by the caller. The GraphQL side
already treats it this way:
`GraphQLResource#getStatusCodeFromThrowable` maps `IllegalArgumentException` to `BAD_REQUEST`. The
plain-REST `GeneralExceptionMapper`, however, only mapped `ValidationException`,
`OptimisticLockException`, `EntityNotFoundException` and `DataIntegrityViolationException` to 400,
so the same class of caller error surfaced as a 500 there — misleading for API consumers and noisy in
server-error monitoring, since a 500 implies a Tiamat-side fault rather than bad input.

This adds `IllegalArgumentException.class` to the existing `BAD_REQUEST` mapping set, bringing plain
REST in line with the GraphQL behaviour that already exists elsewhere in the codebase. No new
`IllegalArgumentException` is thrown by this change; it is a status-code correction for cases that
already throw it today.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Unit tests

Added a `GeneralExceptionMapperTest` case asserting `IllegalArgumentException` maps to 400. Verified
locally: `mvn test -Dtest=GeneralExceptionMapperTest`.
