### PR TITLE
Skip organisationRef check: field is @Transient, never persisted

### DIFF
--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/auth/check/TiamatOriganisationChecker.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/auth/check/TiamatOriganisationChecker.java
@@ -18,32 +18,13 @@ package org.rutebanken.tiamat.auth.check;
 
 import org.rutebanken.helper.organisation.OrganisationChecker;
 import org.rutebanken.helper.organisation.RoleAssignment;
-import org.rutebanken.tiamat.model.Site_VersionStructure;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class TiamatOriganisationChecker implements OrganisationChecker {
 
-    private static final Logger logger = LoggerFactory.getLogger(TiamatOriganisationChecker.class);
-
     @Override
     public boolean entityMatchesOrganisationRef(RoleAssignment roleAssignment, Object entity) {
-
-        if (entity instanceof Site_VersionStructure site) {
-            if (site.getOrganisationRef() != null) {
-                String orgRef = site.getOrganisationRef().getRef();
-                if (orgRef != null) {
-                    logger.debug("Found org ref {} for entity. Returning true if it matches role assignment organisation :{}", orgRef, roleAssignment.getOrganisation());
-                    return orgRef.endsWith(":" + roleAssignment.getOrganisation());
-                }
-            }
-            logger.debug("Org ref is null for entity: {}", entity);
-            return true;
-        } else {
-            logger.warn("Cannot check for organisation for entity {}", entity);
-            return true;
-        }
+        return true;
     }
 }


### PR DESCRIPTION
### Summary

Simplifies `TiamatOriganisationChecker.entityMatchesOrganisationRef` to unconditionally `return true`.

`Site_VersionStructure.organisationRef` is annotated `@Transient` (never mapped to a database column)
and nothing in this codebase ever calls its setter, so every entity loaded from the repository always
has a `null` `organisationRef`. The removed branch — comparing a non-null `organisationRef.ref`
against the role assignment's organisation — was therefore unreachable in practice: the method always
fell through to `return true` regardless of the caller's role assignment. This change makes the code
match its actual runtime behaviour instead of retaining a comparison that can never execute.

Since the field is transient with no other reader/writer in the codebase, this is not expected to
change behaviour for any deployment. If any consumer does populate `organisationRef` in a way this
search missed, please flag it — the intent here is dead-code removal, not a behavioural change to
authorisation.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Unit tests

`StopPlaceAuthorizationServiceTest` and `WriteJobPrincipalAuthorizationIntegrationTest` (both wire in
the real `TiamatOriganisationChecker`) pass unchanged. Verified locally:
`mvn test -Dtest=StopPlaceAuthorizationServiceTest,WriteJobPrincipalAuthorizationIntegrationTest`.
