### PR TITLE
Fix invalid SiteFrame element order in Fintraffic Read API

### DIFF
--- a/tiamat-core/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryServiceTest.java
+++ b/tiamat-core/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryServiceTest.java
@@ -75,21 +75,26 @@ class ReadApiNetexPublicationDeliveryServiceTest {
     }
 
     @Test
-    void streamPublicationDelivery_fareZoneAppearsBeforeStopPlaces() throws Exception {
-        String fareZoneXml = "<FareZone id=\"TKL:FareZone:A\" version=\"1\"/>";
+    void streamPublicationDelivery_fareZoneAppearsAfterStopPlacesAndParkings() throws Exception {
         String stopPlaceXml = "<StopPlace id=\"FSR:StopPlace:1\" version=\"1\"/>";
-        ReadApiEntityOutRecord fareZoneRecord = new ReadApiEntityOutRecord("FareZone", fareZoneXml);
+        String parkingXml = "<Parking id=\"FSR:Parking:1\" version=\"1\"/>";
+        String fareZoneXml = "<FareZone id=\"TKL:FareZone:A\" version=\"1\"/>";
         ReadApiEntityOutRecord stopPlaceRecord = new ReadApiEntityOutRecord("StopPlace", stopPlaceXml);
+        ReadApiEntityOutRecord parkingRecord = new ReadApiEntityOutRecord("Parking", parkingXml);
+        ReadApiEntityOutRecord fareZoneRecord = new ReadApiEntityOutRecord("FareZone", fareZoneXml);
 
         when(netexRepository.streamStopPlaces(any(ReadApiSearchKey.class)))
-                .thenReturn(Stream.of(fareZoneRecord, stopPlaceRecord));
+                .thenReturn(Stream.of(stopPlaceRecord, parkingRecord, fareZoneRecord));
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         service.streamPublicationDelivery(mock(ReadApiSearchKey.class), out);
         String xml = out.toString();
 
-        assertThat(xml.indexOf("<tariffZones>")).isLessThan(xml.indexOf("<stopPlaces>"));
+        // NeTEx SiteFrameGroup requires TariffZoneInFrameGroup after SiteInFrameGroup
+        assertThat(xml.indexOf("<stopPlaces>")).isLessThan(xml.indexOf("<parkings>"));
+        assertThat(xml.indexOf("<parkings>")).isLessThan(xml.indexOf("<tariffZones>"));
         assertThat(xml).contains("TKL:FareZone:A");
         assertThat(xml).contains("FSR:StopPlace:1");
+        assertThat(xml).contains("FSR:Parking:1");
     }
 }

--- a/tiamat-core/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryServiceTest.java
+++ b/tiamat-core/src/ext-test/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryServiceTest.java
@@ -2,17 +2,21 @@ package org.rutebanken.tiamat.ext.fintraffic.api;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.rutebanken.netex.validation.NeTExValidator;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiEntityOutRecord;
 import org.rutebanken.tiamat.ext.fintraffic.api.model.ReadApiSearchKey;
 import org.rutebanken.tiamat.ext.fintraffic.api.repository.NetexRepository;
 import org.rutebanken.tiamat.netex.id.ValidPrefixList;
 import org.rutebanken.tiamat.time.ExportTimeZone;
 
+import javax.xml.transform.stream.StreamSource;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.time.ZoneId;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -72,6 +76,64 @@ class ReadApiNetexPublicationDeliveryServiceTest {
         assertThat(xml).contains("<tariffZones>");
         assertThat(xml).contains("TKL:FareZone:A");
         assertThat(xml).contains("</tariffZones>");
+    }
+
+    /**
+     * Validates the given bytes against the real NeTEx XSD (bundled in netex-java-model), the same
+     * schema Tiamat's native import/export paths enforce via JAXB. The Read API assembles XML by
+     * hand and bypasses that safeguard, which is how DPO-4978 (invalid SiteFrame element order) went
+     * unnoticed - this assertion closes that gap.
+     */
+    private static void assertValidatesAgainstNetexSchema(byte[] xml) throws Exception {
+        assertThatCode(() -> NeTExValidator.getNeTExValidator(NeTExValidator.NetexVersion.v1_15)
+                .validate(new StreamSource(new ByteArrayInputStream(xml))))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void streamPublicationDelivery_withAllEntityTypes_validatesAgainstNetexSchema() throws Exception {
+        String scheduledStopPointXml = "<ScheduledStopPoint version=\"1\" id=\"FSR:ScheduledStopPoint:1\">"
+                + "<Name>Test stop</Name></ScheduledStopPoint>";
+        String passengerStopAssignmentXml = "<PassengerStopAssignment order=\"0\" version=\"1\" id=\"FSR:PassengerStopAssignment:1\">"
+                + "<ScheduledStopPointRef ref=\"FSR:ScheduledStopPoint:1\" versionRef=\"1\"/>"
+                + "<QuayRef ref=\"FSR:Quay:1\" version=\"1\"/></PassengerStopAssignment>";
+        String topographicPlaceXml = "<TopographicPlace version=\"1\" id=\"FSR:TopographicPlace:1\">"
+                + "<Descriptor><Name lang=\"fi\">Testikunta</Name></Descriptor>"
+                + "<TopographicPlaceType>municipality</TopographicPlaceType></TopographicPlace>";
+        String stopPlaceXml = "<StopPlace version=\"1\" id=\"FSR:StopPlace:1\">"
+                + "<Name lang=\"fi\">Testipysäkki</Name><TransportMode>bus</TransportMode>"
+                + "<quays><Quay version=\"1\" id=\"FSR:Quay:1\"/></quays></StopPlace>";
+        String parkingXml = "<Parking version=\"1\" id=\"FSR:Parking:1\">"
+                + "<Name>Testparkki</Name><ParkingVehicleTypes>car</ParkingVehicleTypes>"
+                + "<ParkingLayout>openSpace</ParkingLayout></Parking>";
+        String fareZoneXml = "<FareZone version=\"1\" id=\"NYS:FareZone:A\"><Name>Zone A</Name></FareZone>";
+
+        when(netexRepository.streamStopPlaces(any(ReadApiSearchKey.class))).thenReturn(Stream.of(
+                new ReadApiEntityOutRecord("ScheduledStopPoint", scheduledStopPointXml),
+                new ReadApiEntityOutRecord("PassengerStopAssignment", passengerStopAssignmentXml),
+                new ReadApiEntityOutRecord("TopographicPlace", topographicPlaceXml),
+                new ReadApiEntityOutRecord("StopPlace", stopPlaceXml),
+                new ReadApiEntityOutRecord("Parking", parkingXml),
+                new ReadApiEntityOutRecord("FareZone", fareZoneXml)
+        ));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        service.streamPublicationDelivery(mock(ReadApiSearchKey.class), out);
+
+        assertValidatesAgainstNetexSchema(out.toByteArray());
+    }
+
+    @Test
+    void streamPublicationDelivery_withOnlyFareZones_validatesAgainstNetexSchema() throws Exception {
+        String fareZoneXml = "<FareZone version=\"1\" id=\"NYS:FareZone:A\"><Name>Zone A</Name></FareZone>";
+
+        when(netexRepository.streamStopPlaces(any(ReadApiSearchKey.class)))
+                .thenReturn(Stream.of(new ReadApiEntityOutRecord("FareZone", fareZoneXml)));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        service.streamPublicationDelivery(mock(ReadApiSearchKey.class), out);
+
+        assertValidatesAgainstNetexSchema(out.toByteArray());
     }
 
     @Test

--- a/tiamat-core/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryService.java
+++ b/tiamat-core/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/ReadApiNetexPublicationDeliveryService.java
@@ -72,9 +72,9 @@ public class ReadApiNetexPublicationDeliveryService {
                             </DefaultLocale>
                         </FrameDefaults>
                         <topographicPlaces/>
-                        <tariffZones/>
                         <stopPlaces/>
                         <parkings/>
+                        <tariffZones/>
                     </SiteFrame>
                 </dataObjects>
             </PublicationDelivery>""";

--- a/tiamat-core/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/repository/FintrafficNetexRepository.java
+++ b/tiamat-core/src/ext/java/org/rutebanken/tiamat/ext/fintraffic/api/repository/FintrafficNetexRepository.java
@@ -76,9 +76,9 @@ public class FintrafficNetexRepository extends AbstractNetexRepository {
                 WHEN 'ScheduledStopPoint' THEN 1
                 WHEN 'PassengerStopAssignment' THEN 2
                 WHEN 'TopographicPlace' THEN 3
-                WHEN 'FareZone' THEN 4
-                WHEN 'StopPlace' THEN 5
-                WHEN 'Parking' THEN 6
+                WHEN 'StopPlace' THEN 4
+                WHEN 'Parking' THEN 5
+                WHEN 'FareZone' THEN 6
                 ELSE 7
             END,
             id


### PR DESCRIPTION
### Summary

Fixes an invalid NeTEx `SiteFrame` element order in the Fintraffic Read API: `tariffZones` was written
before `stopPlaces`/`parkings`, but the schema requires tariff zones last. This broke XSD validation
for the whole document, which in turn broke a downstream GTFS conversion job.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Issue

Internal ticket: DPO-4978 (Fintraffic-only, no public issue - this only affects the `ext` extension).

The Read API hand-assembles NeTEx XML from a template instead of using JAXB, so nothing enforced
element order. Fix: reordered the template to `topographicPlaces, stopPlaces, parkings, tariffZones`
and updated `FintrafficNetexRepository`'s SQL `ORDER BY` to match.

### Unit tests

- Fixed the existing ordering test, which had asserted the buggy order.
- Added two tests that validate the assembled document against the real NeTEx XSD
  (`NeTExValidator`, already bundled in `netex-java-model`).
- Manually verified the new tests fail with the old order and pass with the fix.