### PR TITLE
Assign explicitly scoped fare zones by member list, not by outline

### DIFF
--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/netex/mapping/mapper/FareZoneMapper.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/netex/mapping/mapper/FareZoneMapper.java
@@ -15,6 +15,8 @@ import org.rutebanken.netex.model.ScheduledStopPointRefStructure;
 import org.rutebanken.netex.model.ScopingMethodEnumeration;
 import org.rutebanken.tiamat.model.StopPlaceReference;
 import org.rutebanken.tiamat.model.TariffZoneRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.List;
@@ -23,6 +25,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class FareZoneMapper extends CustomMapper<FareZone, org.rutebanken.tiamat.model.FareZone> {
+
+    private static final Logger logger = LoggerFactory.getLogger(FareZoneMapper.class);
 
     final ObjectFactory objectFactory = new ObjectFactory();
 
@@ -41,16 +45,25 @@ public class FareZoneMapper extends CustomMapper<FareZone, org.rutebanken.tiamat
             tiamatFareZone.setNeighbours(tiamatNeighbours);
         }
 
-        if (netexFareZone.getScopingMethod() != null && netexFareZone.getScopingMethod().equals(ScopingMethodEnumeration.EXPLICIT_STOPS)
-                && netexFareZone.getMembers() != null && !netexFareZone.getMembers().getPointRef().isEmpty()) {
+        if (netexFareZone.getScopingMethod() != null && netexFareZone.getScopingMethod().equals(ScopingMethodEnumeration.EXPLICIT_STOPS)) {
+            List<JAXBElement<? extends PointRefStructure>> pointRefs =
+                    netexFareZone.getMembers() == null ? List.of() : netexFareZone.getMembers().getPointRef();
 
-            var fareZoneMembers = netexFareZone.getMembers().getPointRef().stream()
+            Set<StopPlaceReference> fareZoneMembers = pointRefs.stream()
                     .map(jaxbElement -> convertScheduledStopPointRefToStopPlaceRef(jaxbElement.getValue().getRef()))
                     .filter(Objects::nonNull)
                     .map(StopPlaceReference::new)
                     .collect(Collectors.toSet());
 
             tiamatFareZone.setFareZoneMembers(fareZoneMembers);
+
+            if (fareZoneMembers.isEmpty()) {
+                // An explicitly scoped zone with no usable members matches no stops. Refs that no
+                // conversion handles land here too. Surface it so the upstream data can be raised
+                // with the feed owner.
+                logger.warn("FareZone {} is scoped EXPLICIT_STOPS but has no usable members; it will match no stops. "
+                        + "Raise with the feed owner if this is unexpected.", netexFareZone.getId());
+            }
         }
     }
 

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/repository/FareZoneRepositoryCustom.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/repository/FareZoneRepositoryCustom.java
@@ -39,6 +39,8 @@ public interface FareZoneRepositoryCustom extends DataManagedObjectStructureRepo
 
     List<FareZone> findValidFareZones(List<String> netexIds);
 
+    List<FareZone> findValidExplicitStopsFareZones(String stopPlaceNetexId);
+
     int countResult(Set<Long> stopPlaceIds);
 
     public List<FareZone> findAllValidFareZones();

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/repository/FareZoneRepositoryImpl.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/repository/FareZoneRepositoryImpl.java
@@ -101,6 +101,30 @@ public class FareZoneRepositoryImpl implements FareZoneRepositoryCustom {
         return query.getResultList();
     }
 
+    /**
+     * The valid EXPLICIT_STOPS fare zones listing this stop place as a member. The scoping method
+     * declares how a zone's extent is determined, so the zone outline is descriptive only and is not
+     * consulted: a member outside it matches, a non-member inside it does not. Same rule as the
+     * explicit branch of updateStopPlaceTariffZoneRef below, which rebuilds these refs in bulk.
+     */
+    @Override
+    public List<FareZone> findValidExplicitStopsFareZones(String stopPlaceNetexId) {
+        if (stopPlaceNetexId == null) {
+            return Collections.emptyList();
+        }
+
+        String sql = "SELECT fz.* FROM fare_zone fz WHERE fz.scoping_method = 'EXPLICIT_STOPS' " +
+                "AND EXISTS (SELECT 1 FROM fare_zone_members fzm WHERE fzm.fare_zone_id = fz.id AND fzm.ref = :stopPlaceNetexId) " +
+                "AND fz.version = (SELECT MAX(fzv.version) FROM fare_zone fzv WHERE fzv.netex_id = fz.netex_id " +
+                "and (fzv.to_date is null or fzv.to_date > :pointInTime) and (fzv.from_date is null or fzv.from_date < :pointInTime))";
+
+        Query query = entityManager.createNativeQuery(sql, FareZone.class);
+        query.setParameter("stopPlaceNetexId", stopPlaceNetexId);
+        query.setParameter("pointInTime", Instant.now());
+
+        return query.getResultList();
+    }
+
     @Override
     public Optional<FareZone> findValidFareZone(String netexId) {
         Map<String, Object> parameters = new HashMap<>();

--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/service/TariffZonesLookupService.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/service/TariffZonesLookupService.java
@@ -79,53 +79,32 @@ public class TariffZonesLookupService {
                 stopPlace.setTariffZones(new HashSet<>());
             }
 
-            Set<String> refsBefore = mapToIdStrings(stopPlace.getTariffZones());
+            Set<TariffZoneRef> refs = stopPlace.getTariffZones();
+            Set<String> refsBefore = mapToIdStrings(refs);
 
             if(removeExistingReferences) {
-                stopPlace.getTariffZones().clear();
+                refs.clear();
             }
 
-            Set<TariffZoneRef> tariffZoneMatches = findTariffZones(stopPlace.getCentroid())
-                    .stream()
-                    .filter(tariffZone -> stopPlace.getTariffZones().isEmpty() || stopPlace.getTariffZones()
-                            .stream()
-                            .noneMatch(tariffZoneRef -> tariffZone.getNetexId().equals(tariffZoneRef.getRef()) && tariffZoneRef.getVersion().equals(String.valueOf(tariffZone.getVersion()))))
-                    .map(TariffZoneRef::new)
-                    .collect(toSet());
+            findTariffZones(stopPlace.getCentroid()).forEach(tariffZone -> refs.add(new TariffZoneRef(tariffZone)));
+            findImplicitFareZones(stopPlace.getCentroid()).forEach(fareZone -> refs.add(new TariffZoneRef(fareZone)));
+            fareZoneRepository.findValidExplicitStopsFareZones(stopPlace.getNetexId())
+                    .forEach(fareZone -> refs.add(new TariffZoneRef(fareZone)));
 
-            Set<TariffZoneRef> allMatches = new HashSet<>(tariffZoneMatches);
-
-            Set<TariffZoneRef> fareZoneMatches = findFareZones(stopPlace.getCentroid())
-                    .stream()
-                    .filter(fareZone -> stopPlace.getTariffZones().isEmpty() || isNoneMatch(stopPlace, fareZone))
-                    .map(TariffZoneRef::new)
-                    .collect(toSet());
-
-
-            allMatches.addAll(fareZoneMatches);
-
-            stopPlace.getTariffZones().addAll(allMatches);
-
-            Set<String> refsAfter = mapToIdStrings(stopPlace.getTariffZones());
+            Set<String> refsAfter = mapToIdStrings(refs);
 
             return !Sets.symmetricDifference(refsBefore, refsAfter).isEmpty();
         }
         return false;
     }
 
-    private boolean isNoneMatch(StopPlace stopPlace, FareZone fareZone) {
-        if (fareZone.getScopingMethod().equals(ScopingMethodEnumeration.IMPLICIT_SPATIAL_PROJECTION)) {
-            return stopPlace.getTariffZones()
-                    .stream()
-                    .noneMatch(tariffZoneRef -> fareZone.getNetexId().equals(tariffZoneRef.getRef()) && tariffZoneRef.getVersion().equals(String.valueOf(fareZone.getVersion())));
-        }
-        if (fareZone.getScopingMethod().equals(ScopingMethodEnumeration.EXPLICIT_STOPS) && !fareZone.getFareZoneMembers().isEmpty()) {
-            return fareZone.getFareZoneMembers().stream()
-                    .anyMatch(member -> member.getRef().equals(stopPlace.getNetexId()));
-        }
-        return true;
-
+    private List<FareZone> findImplicitFareZones(Point centroid) {
+        return findFareZones(centroid)
+                .stream()
+                .filter(fareZone -> ScopingMethodEnumeration.IMPLICIT_SPATIAL_PROJECTION.equals(fareZone.getScopingMethod()))
+                .collect(toList());
     }
+
     private Set<String> mapToIdStrings(Set<TariffZoneRef> tariffZoneRefs) {
         return tariffZoneRefs.stream().map(tzr -> tzr.getRef()).collect(toSet());
     }

--- a/tiamat-core/src/main/resources/application-local.properties
+++ b/tiamat-core/src/main/resources/application-local.properties
@@ -45,8 +45,6 @@ spring.datasource.hikari.leakDetectionThreshold=30000
 
 tiamat.locals.language.default=eng
 
-tariffZoneLookupService.resetReferences=true
-
 # External versioning for FareZones (Tiamat as replica of master FareZone register)
 # When enabled, Tiamat will update existing FareZones by netexId and cleanup orphaned zones
 fareZone.externalVersioning=false

--- a/tiamat-core/src/main/resources/db/migration/V65__add_fare_zone_members_indexes.sql
+++ b/tiamat-core/src/main/resources/db/migration/V65__add_fare_zone_members_indexes.sql
@@ -1,0 +1,5 @@
+-- Membership lookup per stop place save (findValidExplicitStopsFareZones) and the explicit branch
+-- of updateStopPlaceTariffZoneRef both filter on ref; the EAGER fareZoneMembers collection and the
+-- same batch join load by fare_zone_id. The table carried only a foreign key until now.
+CREATE INDEX idx_fare_zone_members_ref ON fare_zone_members (ref, fare_zone_id);
+CREATE INDEX idx_fare_zone_members_fare_zone_id ON fare_zone_members (fare_zone_id);

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/netex/mapping/mapper/FareZoneMapperTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/netex/mapping/mapper/FareZoneMapperTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+
+package org.rutebanken.tiamat.netex.mapping.mapper;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import ma.glasnost.orika.MappingContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.rutebanken.netex.model.FareZone;
+import org.rutebanken.netex.model.ObjectFactory;
+import org.rutebanken.netex.model.PointRefs_RelStructure;
+import org.rutebanken.netex.model.ScheduledStopPointRefStructure;
+import org.rutebanken.netex.model.ScopingMethodEnumeration;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FareZoneMapperTest {
+
+    private final FareZoneMapper fareZoneMapper = new FareZoneMapper();
+
+    private final Logger mapperLogger = (Logger) LoggerFactory.getLogger(FareZoneMapper.class);
+    private final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+
+    @Before
+    public void attachAppender() {
+        logAppender.start();
+        mapperLogger.addAppender(logAppender);
+    }
+
+    @After
+    public void detachAppender() {
+        mapperLogger.detachAppender(logAppender);
+    }
+
+    @Test
+    public void warnsWhenExplicitStopsHasNoMembers() {
+        FareZone netexFareZone = new FareZone()
+                .withId("RUT:FareZone:15")
+                .withScopingMethod(ScopingMethodEnumeration.EXPLICIT_STOPS);
+
+        org.rutebanken.tiamat.model.FareZone tiamatFareZone = new org.rutebanken.tiamat.model.FareZone();
+        fareZoneMapper.mapAtoB(netexFareZone, tiamatFareZone, new MappingContext(new HashMap<>()));
+
+        assertThat(tiamatFareZone.getFareZoneMembers()).isEmpty();
+        assertThat(logAppender.list)
+                .anySatisfy(event -> {
+                    assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                    assertThat(event.getFormattedMessage()).contains("RUT:FareZone:15", "EXPLICIT_STOPS");
+                });
+    }
+
+    @Test
+    public void warnsWhenNoExplicitStopsMemberCanBeMapped() {
+        ObjectFactory objectFactory = new ObjectFactory();
+        FareZone netexFareZone = new FareZone()
+                .withId("RUT:FareZone:17")
+                .withScopingMethod(ScopingMethodEnumeration.EXPLICIT_STOPS)
+                .withMembers(new PointRefs_RelStructure().withPointRef(
+                        objectFactory.createScheduledStopPointRef(
+                                new ScheduledStopPointRefStructure().withRef("NSR:Quay:4321"))));
+
+        org.rutebanken.tiamat.model.FareZone tiamatFareZone = new org.rutebanken.tiamat.model.FareZone();
+        fareZoneMapper.mapAtoB(netexFareZone, tiamatFareZone, new MappingContext(new HashMap<>()));
+
+        assertThat(tiamatFareZone.getFareZoneMembers()).isEmpty();
+        assertThat(logAppender.list)
+                .anySatisfy(event -> {
+                    assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                    assertThat(event.getFormattedMessage()).contains("RUT:FareZone:17", "EXPLICIT_STOPS");
+                });
+    }
+
+    @Test
+    public void mapsMembersAndDoesNotWarnWhenExplicitStopsHasMembers() {
+        ObjectFactory objectFactory = new ObjectFactory();
+        FareZone netexFareZone = new FareZone()
+                .withId("RUT:FareZone:16")
+                .withScopingMethod(ScopingMethodEnumeration.EXPLICIT_STOPS)
+                .withMembers(new PointRefs_RelStructure().withPointRef(
+                        objectFactory.createScheduledStopPointRef(
+                                new ScheduledStopPointRefStructure().withRef("NSR:ScheduledStopPoint:S54471"))));
+
+        org.rutebanken.tiamat.model.FareZone tiamatFareZone = new org.rutebanken.tiamat.model.FareZone();
+        fareZoneMapper.mapAtoB(netexFareZone, tiamatFareZone, new MappingContext(new HashMap<>()));
+
+        assertThat(tiamatFareZone.getFareZoneMembers())
+                .extracting(org.rutebanken.tiamat.model.StopPlaceReference::getRef)
+                .containsExactly("NSR:StopPlace:54471");
+        assertThat(logAppender.list).noneSatisfy(event ->
+                assertThat(event.getLevel()).isEqualTo(Level.WARN));
+    }
+}

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/netex/publicationdelivery/FareZoneImportTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/netex/publicationdelivery/FareZoneImportTest.java
@@ -39,6 +39,7 @@ import org.rutebanken.tiamat.TiamatIntegrationTest;
 import org.rutebanken.tiamat.importer.ImportParams;
 import org.rutebanken.tiamat.importer.ImportType;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -47,6 +48,11 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// These tests assert importer plumbing, not ref assignment, and their zone fixtures have no geometry to
+// re-derive from. They need a non-production value: the suite default matches production
+// (resetReferences=true), under which populateTariffZone discards import-supplied refs. Whether that
+// discard is intended is an open question, tracked separately.
+@TestPropertySource(properties = "tariffzoneLookupService.resetReferences=false")
 public class FareZoneImportTest extends TiamatIntegrationTest {
 
     private static final ObjectFactory netexObjectFactory = new ObjectFactory();

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/netex/publicationdelivery/TariffZoneImportTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/rest/netex/publicationdelivery/TariffZoneImportTest.java
@@ -38,6 +38,7 @@ import org.rutebanken.tiamat.TiamatIntegrationTest;
 import org.rutebanken.tiamat.importer.ImportParams;
 import org.rutebanken.tiamat.importer.ImportType;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -46,6 +47,11 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// These tests assert importer plumbing, not ref assignment, and their zone fixtures have no geometry to
+// re-derive from. They need a non-production value: the suite default matches production
+// (resetReferences=true), under which populateTariffZone discards import-supplied refs. Whether that
+// discard is intended is an open question, tracked separately.
+@TestPropertySource(properties = "tariffzoneLookupService.resetReferences=false")
 public class TariffZoneImportTest extends TiamatIntegrationTest {
 
     private static final ObjectFactory netexObjectFactory = new ObjectFactory();

--- a/tiamat-core/src/test/java/org/rutebanken/tiamat/service/TariffZonesLookupServiceIntegrationTest.java
+++ b/tiamat-core/src/test/java/org/rutebanken/tiamat/service/TariffZonesLookupServiceIntegrationTest.java
@@ -105,7 +105,7 @@ public class TariffZonesLookupServiceIntegrationTest extends TiamatIntegrationTe
     }
 
     @Test
-    public void shouldNotDuplicateExistingTariffZoneRefs() {
+    public void shouldReportNoChangeWhenTariffZoneRefIsRederived() {
         TariffZone tariffZone = createTariffZoneWithPolygon("NSR:TariffZone:1", "Zone A",
                 new Coordinate(10.0, 59.0),
                 new Coordinate(10.0, 60.0),
@@ -303,16 +303,7 @@ public class TariffZonesLookupServiceIntegrationTest extends TiamatIntegrationTe
     }
 
     @Test
-    public void shouldNotPopulateFareZoneWithExplicitStopsWhenStopNotMemberAndHasExistingRefs() {
-        // Create a tariff zone so the stop place gets an existing ref
-        TariffZone tariffZone = createTariffZoneWithPolygon("NSR:TariffZone:1", "Tariff Zone A",
-                new Coordinate(10.0, 59.0),
-                new Coordinate(10.0, 60.0),
-                new Coordinate(11.0, 60.0),
-                new Coordinate(11.0, 59.0),
-                new Coordinate(10.0, 59.0));
-        tariffZone = tariffZoneRepository.save(tariffZone);
-
+    public void shouldRemoveExplicitStopsFareZoneRefWhenStopIsNotMember() {
         FareZone fareZone = createFareZoneWithPolygon("NSR:FareZone:1", "Fare Zone Explicit",
                 ScopingMethodEnumeration.EXPLICIT_STOPS,
                 new Coordinate(10.0, 59.0),
@@ -321,28 +312,132 @@ public class TariffZonesLookupServiceIntegrationTest extends TiamatIntegrationTe
                 new Coordinate(11.0, 59.0),
                 new Coordinate(10.0, 59.0));
         fareZone.getFareZoneMembers().add(new StopPlaceReference("NSR:StopPlace:999"));
-        fareZoneRepository.save(fareZone);
+        fareZone = fareZoneRepository.save(fareZone);
 
-        tariffZonesLookupService.resetTariffZone();
         tariffZonesLookupService.resetFareZone();
 
-        // Create stop place with existing tariff zone ref - this is required for
-        // EXPLICIT_STOPS logic to be evaluated (when tariffZones is empty, the filter short-circuits)
         StopPlace stopPlace = new StopPlace();
         stopPlace.setNetexId("NSR:StopPlace:1");
-        stopPlace.setName(new EmbeddableMultilingualString("Test Stop"));
+        stopPlace.setName(new EmbeddableMultilingualString("Stop inside the outline but not a member"));
         stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(10.5, 59.5)));
         Set<TariffZoneRef> existingRefs = new HashSet<>();
-        existingRefs.add(new TariffZoneRef(tariffZone));
+        existingRefs.add(new TariffZoneRef(fareZone));
         stopPlace.setTariffZones(existingRefs);
 
         boolean changed = tariffZonesLookupService.populateTariffZone(stopPlace);
 
-        // No change because the tariff zone was already there, and the fare zone with
-        // EXPLICIT_STOPS doesn't include this stop in its members
+        assertThat(changed).isTrue();
+        assertThat(stopPlace.getTariffZones()).isEmpty();
+    }
+
+    @Test
+    public void shouldReportNoChangeWhenExplicitStopsFareZoneRefIsRederived() {
+        FareZone fareZone = createFareZoneWithPolygon("NSR:FareZone:1", "Fare Zone Explicit",
+                ScopingMethodEnumeration.EXPLICIT_STOPS,
+                new Coordinate(10.0, 59.0),
+                new Coordinate(10.0, 60.0),
+                new Coordinate(11.0, 60.0),
+                new Coordinate(11.0, 59.0),
+                new Coordinate(10.0, 59.0));
+        fareZone.getFareZoneMembers().add(new StopPlaceReference("NSR:StopPlace:1"));
+        fareZone = fareZoneRepository.save(fareZone);
+
+        tariffZonesLookupService.resetFareZone();
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:1");
+        stopPlace.setName(new EmbeddableMultilingualString("Member stop"));
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(10.5, 59.5)));
+        Set<TariffZoneRef> existingRefs = new HashSet<>();
+        existingRefs.add(new TariffZoneRef(fareZone));
+        stopPlace.setTariffZones(existingRefs);
+
+        boolean changed = tariffZonesLookupService.populateTariffZone(stopPlace);
+
         assertThat(changed).isFalse();
         assertThat(stopPlace.getTariffZones()).hasSize(1);
-        assertThat(stopPlace.getTariffZones().iterator().next().getRef()).isEqualTo("NSR:TariffZone:1");
+        TariffZoneRef ref = stopPlace.getTariffZones().iterator().next();
+        assertThat(ref.getRef()).isEqualTo("NSR:FareZone:1");
+        assertThat(ref.getVersion()).isEqualTo("1");
+    }
+
+    @Test
+    public void shouldPopulateExplicitStopsFareZoneWhenStopIsMemberButOutsidePolygon() {
+        FareZone fareZone = createFareZoneWithPolygon("NSR:FareZone:1", "Fare Zone Explicit",
+                ScopingMethodEnumeration.EXPLICIT_STOPS,
+                new Coordinate(10.0, 59.0),
+                new Coordinate(10.0, 60.0),
+                new Coordinate(11.0, 60.0),
+                new Coordinate(11.0, 59.0),
+                new Coordinate(10.0, 59.0));
+        fareZone.getFareZoneMembers().add(new StopPlaceReference("NSR:StopPlace:1"));
+        fareZoneRepository.save(fareZone);
+
+        tariffZonesLookupService.resetFareZone();
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:1");
+        stopPlace.setName(new EmbeddableMultilingualString("Member far outside the zone outline"));
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(5.0, 55.0)));
+
+        boolean changed = tariffZonesLookupService.populateTariffZone(stopPlace);
+
+        assertThat(changed).isTrue();
+        assertThat(stopPlace.getTariffZones()).hasSize(1);
+        assertThat(stopPlace.getTariffZones().iterator().next().getRef()).isEqualTo("NSR:FareZone:1");
+    }
+
+    @Test
+    public void shouldNotPopulateExplicitStopsFareZoneWithoutMembers() {
+        // A member list is the definition of an EXPLICIT_STOPS zone, so an empty one matches nothing.
+        // FareZoneRepositoryImpl.updateStopPlaceTariffZoneRef inner joins FARE_ZONE_MEMBERS and so
+        // behaves the same way.
+        FareZone fareZone = createFareZoneWithPolygon("NSR:FareZone:1", "Fare Zone Explicit Without Members",
+                ScopingMethodEnumeration.EXPLICIT_STOPS,
+                new Coordinate(10.0, 59.0),
+                new Coordinate(10.0, 60.0),
+                new Coordinate(11.0, 60.0),
+                new Coordinate(11.0, 59.0),
+                new Coordinate(10.0, 59.0));
+        fareZoneRepository.save(fareZone);
+
+        tariffZonesLookupService.resetFareZone();
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:1");
+        stopPlace.setName(new EmbeddableMultilingualString("Stop inside the outline"));
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(10.5, 59.5)));
+
+        boolean changed = tariffZonesLookupService.populateTariffZone(stopPlace);
+
+        assertThat(changed).isFalse();
+        assertThat(stopPlace.getTariffZones()).isEmpty();
+    }
+
+    @Test
+    public void shouldNotPopulateFareZoneWithoutScopingMethod() {
+        // Neither branch of FareZoneRepositoryImpl.updateStopPlaceTariffZoneRef matches a zone with no
+        // scoping method, so the save path must not assign it either.
+        FareZone fareZone = createFareZoneWithPolygon("NSR:FareZone:1", "Fare Zone Without Scoping Method",
+                null,
+                new Coordinate(10.0, 59.0),
+                new Coordinate(10.0, 60.0),
+                new Coordinate(11.0, 60.0),
+                new Coordinate(11.0, 59.0),
+                new Coordinate(10.0, 59.0));
+        fareZoneRepository.save(fareZone);
+
+        tariffZonesLookupService.resetFareZone();
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:1");
+        stopPlace.setName(new EmbeddableMultilingualString("Stop inside the outline"));
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(10.5, 59.5)));
+
+        boolean changed = tariffZonesLookupService.populateTariffZone(stopPlace);
+
+        assertThat(changed).isFalse();
+        assertThat(stopPlace.getTariffZones()).isEmpty();
     }
 
     @Test
@@ -663,6 +758,70 @@ public class TariffZonesLookupServiceIntegrationTest extends TiamatIntegrationTe
                 geometryFactory.createPoint(new Coordinate(12.5, 59.5)));
         assertThat(resultB).hasSize(1);
         assertThat(resultB.getFirst().getNetexId()).isEqualTo("NSR:TariffZone:1");
+    }
+
+    @Test
+    public void shouldPopulateExplicitStopsFareZoneWithoutGeometry() {
+        FareZone fareZone = new FareZone();
+        fareZone.setNetexId("NSR:FareZone:1");
+        fareZone.setName(new EmbeddableMultilingualString("Fare Zone Without Geometry"));
+        fareZone.setVersion(1L);
+        fareZone.setScopingMethod(ScopingMethodEnumeration.EXPLICIT_STOPS);
+        fareZone.getFareZoneMembers().add(new StopPlaceReference("NSR:StopPlace:1"));
+        fareZoneRepository.save(fareZone);
+
+        tariffZonesLookupService.resetFareZone();
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:1");
+        stopPlace.setName(new EmbeddableMultilingualString("Member of a zone with no outline"));
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(10.5, 59.5)));
+
+        boolean changed = tariffZonesLookupService.populateTariffZone(stopPlace);
+
+        assertThat(changed).isTrue();
+        assertThat(stopPlace.getTariffZones()).hasSize(1);
+        assertThat(stopPlace.getTariffZones().iterator().next().getRef()).isEqualTo("NSR:FareZone:1");
+    }
+
+    @Test
+    public void shouldUseLatestFareZoneVersionMemberList() {
+        Coordinate[] coordinates = new Coordinate[]{
+                new Coordinate(10.0, 59.0),
+                new Coordinate(10.0, 60.0),
+                new Coordinate(11.0, 60.0),
+                new Coordinate(11.0, 59.0),
+                new Coordinate(10.0, 59.0)
+        };
+
+        FareZone v1 = new FareZone();
+        v1.setNetexId("NSR:FareZone:1");
+        v1.setName(new EmbeddableMultilingualString("Fare Zone v1"));
+        v1.setVersion(1L);
+        v1.setScopingMethod(ScopingMethodEnumeration.EXPLICIT_STOPS);
+        v1.setPolygon(geometryFactory.createPolygon(coordinates));
+        v1.getFareZoneMembers().add(new StopPlaceReference("NSR:StopPlace:1"));
+        fareZoneRepository.save(v1);
+
+        FareZone v2 = new FareZone();
+        v2.setNetexId("NSR:FareZone:1");
+        v2.setName(new EmbeddableMultilingualString("Fare Zone v2"));
+        v2.setVersion(2L);
+        v2.setScopingMethod(ScopingMethodEnumeration.EXPLICIT_STOPS);
+        v2.setPolygon(geometryFactory.createPolygon(coordinates));
+        fareZoneRepository.save(v2);
+
+        tariffZonesLookupService.resetFareZone();
+
+        StopPlace stopPlace = new StopPlace();
+        stopPlace.setNetexId("NSR:StopPlace:1");
+        stopPlace.setName(new EmbeddableMultilingualString("Dropped from the member list in v2"));
+        stopPlace.setCentroid(geometryFactory.createPoint(new Coordinate(10.5, 59.5)));
+
+        boolean changed = tariffZonesLookupService.populateTariffZone(stopPlace);
+
+        assertThat(changed).isFalse();
+        assertThat(stopPlace.getTariffZones()).isEmpty();
     }
 
     // ========== Helper Methods ==========

--- a/tiamat-core/src/test/resources/application.properties
+++ b/tiamat-core/src/test/resources/application.properties
@@ -41,7 +41,9 @@ spring.jpa.hibernate.ddl-auto=none
 spring.jpa.open-in-view=false
 spring.jpa.show-sql=false
 
-spring.datasource.hikari.maximumPoolSize=30
+# Every cached Spring context holds its own pool against one shared Testcontainers postgres,
+# whose max_connections is 100. Keep the pool small enough that several contexts coexist.
+spring.datasource.hikari.maximumPoolSize=10
 spring.datasource.username=tiamat
 
 #spring.flyway.enabled=true
@@ -83,6 +85,9 @@ async.export.path=/tmp
 
 #For tariff zone import test
 stopPlaceRefUpdaterService.enableLegacyUpdater=true
+
+# Production value. Set here because this file shadows src/main/resources/application.properties
+tariffzoneLookupService.resetReferences=true
 
 # pubsub
 spring.cloud.gcp.pubsub.project-id=test


### PR DESCRIPTION
## What

`populateTariffZone` never ran its `EXPLICIT_STOPS` membership check. The filter was `getTariffZones().isEmpty() || isNoneMatch(...)`, and `resetReferences=true` clears the refs just above it, so the left operand was always true. Fare zones were assigned on polygon containment alone, in every environment.

Matching now follows the scoping method:

- `EXPLICIT_STOPS`: membership in `fareZoneMembers`, outline ignored
- `IMPLICIT_SPATIAL_PROJECTION`: centroid containment
- anything else, or none: no match

That is the rule `FareZoneRepositoryImpl.updateStopPlaceTariffZoneRef` already implements, and the batch updater runs that SQL every 500 minutes, deleting and rebuilding every ref. The save path now agrees with it instead of being overwritten by it.

`FareZoneMapper` also warns when an `EXPLICIT_STOPS` zone is imported with no members, since membership decides and such a zone matches nothing.

## Impact

Checked against the prd read replica: **0 refs removed, 0 refs added.** The table already holds exactly what membership-only produces, because the batch job has been enforcing it all along. This removes the flapping between a save and the next batch run rather than moving steady-state content, so OTP, mummu and the geocoder need no coordination.

Also empty in prd: zones with no scoping method, `EXPLICIT_PERIPHERY_STOPS`, and `OTHER`. Those branches of the new rule affect nothing today.

`V65` indexes `fare_zone_members` on `ref` and on `fare_zone_id`, which carried only a foreign key. The membership lookup runs per stop place save, and the same table is scanned today by the batch job's explicit join and by every EAGER member collection load. The table is 680 kB, so the migration is a sub-second index build holding a SHARE lock, and Flyway applies it on the first pod to start.

## Unresolved

`FareZoneImportTest` and `TariffZoneImportTest` pin `resetReferences=false`. Import-supplied refs turn out to be discarded in production, which predates this change and needs the import path's owner. Two of the four affected tests are pure tariff zone.

## Known divergence

The save path still skips explicit membership when a stop has no centroid, where the batch updater's explicit join has no centroid predicate. Measured at 0 affected stops: no valid stop place in prd is without a centroid, so this is theoretical. Left as is rather than restructuring `populateTariffZone` around a population that does not exist.

## Follow-ups

- 9 of 73 `EXPLICIT_STOPS` zones have no members and so match no stops. Data quality, for the fare zone owners.
- `mapToIdStrings` compares `ref` only, so swapping a ref for a newer version of the same zone returns `false` and `StopPlaceRefUpdater` then drops the change. Pre-existing and unreachable in production, where `enableLegacyUpdater` is false and the SQL path writes versions directly.
- Nothing detects the two writers disagreeing: the suite sets `enableLegacyUpdater=true` and exercises the Java path while prod runs the SQL one, whose `EXPLICIT_STOPS` branch has no coverage. One parity test would close it.

## Testing

1199 pass, 4 pre-existing skips. Five of the new tests fail against the base commit.
