### PR TITLE
Fix S3 local credentials value annotations + add default values

### DIFF
--- a/tiamat-core/src/main/java/org/rutebanken/tiamat/config/RutebankenBlobStoreConfiguration.java
+++ b/tiamat-core/src/main/java/org/rutebanken/tiamat/config/RutebankenBlobStoreConfiguration.java
@@ -89,8 +89,8 @@ public class RutebankenBlobStoreConfiguration {
     @Profile("local | test")
     @Bean
     public AwsCredentialsProvider localCredentials(
-            @Value("blobstore.s3.access-key-id") String accessKeyId,
-            @Value("blobstore.s3.secret-key") String secretKey
+            @Value("${blobstore.s3.access-key-id:dev-access-key-id}") String accessKeyId,
+            @Value("${blobstore.s3.secret-key:dev-secret-key}") String secretKey
     ) {
         return StaticCredentialsProvider.create(
                 AwsBasicCredentials.create(accessKeyId, secretKey)


### PR DESCRIPTION
### Summary

The `@Value` annotations in `RutebankenBlobStoreConfiguration.localCredentials` are missing
`${...}`, so they inject the property names as literal strings rather than the configured values.
Confusing and redundant as it stands. Defaults are added so the `test` profile, which does not
define these properties, keeps working.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
